### PR TITLE
Provision pnpm via Corepack and pin the version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,9 @@ New interactive components are **custom elements**, not inline JS in Python. A c
 
 ### Deployment
 
-Docker-based: multi-stage Dockerfile (uv builder → slim runtime), Caddy as reverse proxy on port 8000, Gunicorn with UvicornWorker (ASGI), Supervisor to manage Caddy + Gunicorn + django-q2. `make dev-prod` mimics production locally. CI/CD via GitHub Actions (`.github/workflows/build-docker.yml`): builds Docker image; Drone CI (`.drone.yml`) also present for deployments via Portainer webhook.
+Docker-based: multi-stage Dockerfile (uv builder → Node assets stage → slim runtime), Caddy as reverse proxy on port 8000, Gunicorn with UvicornWorker (ASGI), Supervisor to manage Caddy + Gunicorn + django-q2. `make dev-prod` mimics production locally. CI/CD via GitHub Actions (`.github/workflows/build-docker.yml`): builds Docker image; Drone CI (`.drone.yml`) also present for deployments via Portainer webhook.
+
+**Package manager (pnpm):** front-end deps use **pnpm**, not npm. The pnpm version is pinned in `package.json`'s `packageManager` field and provisioned via **Corepack** (bundled with Node) — the Docker assets stage runs `corepack enable` rather than `npm install -g pnpm`. To bump pnpm, update the `packageManager` field; local, CI, and Docker all follow it. pnpm disables dependency lifecycle scripts by default (opt in via `pnpm.onlyBuiltDependencies`), so the project is unaffected by npm v12's install-script changes.
 
 ### Database
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ FROM node:22-bookworm-slim AS assets
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
-RUN npm install -g pnpm && pnpm install --frozen-lockfile --ignore-scripts
+# Corepack ships with Node and activates the pnpm version pinned in
+# package.json's "packageManager" field — no npm bootstrap needed.
+RUN corepack enable && pnpm install --frozen-lockfile --ignore-scripts
 COPY . .
 COPY --from=builder /home/timetracker/app/ts/generated ./ts/generated
 RUN pnpm tailwindcss -i ./common/input.css -o ./games/static/base.css \

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "pnpm@10.33.0",
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.13",


### PR DESCRIPTION
## Summary

Removes the only direct `npm` usage in the build and makes the pnpm toolchain reproducible, in response to the [upcoming npm v12 breaking changes](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/).

The project already uses **pnpm** for all front-end dependency work, and pnpm disables dependency lifecycle scripts by default — so the headline npm v12 change (install scripts off by default) doesn't affect us. The one remaining npm touchpoint was the Docker assets stage bootstrapping pnpm with `npm install -g pnpm`. This PR replaces that with Corepack and pins the pnpm version.

## Changes

- **`package.json`** — add `"packageManager": "pnpm@10.33.0"` (matches the currently used pnpm and the `pnpm-lock.yaml` v9.0 lockfile). Single source of truth for the pnpm version across local, CI, and Docker.
- **`Dockerfile`** — replace `npm install -g pnpm` with `corepack enable` in the Node assets stage. Corepack ships with Node and auto-activates the pinned version, so no npm is needed. The `pnpm install --frozen-lockfile --ignore-scripts` step is unchanged.
- **`CLAUDE.md`** — document the Corepack-based pnpm provisioning and version-pinning workflow.

## Verification

- `package.json` validated as JSON.
- `pnpm install --frozen-lockfile --ignore-scripts` (same flags as Docker) succeeds and reports `Done … using pnpm v10.33.0`, confirming the pin agrees with the lockfile.

Note: the Docker image build itself wasn't run in this environment, but Corepack is bundled in `node:22-bookworm-slim`.

https://claude.ai/code/session_01F94J3DuNM4dVjcDConFyHJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01F94J3DuNM4dVjcDConFyHJ)_