### PR TITLE
Provision pnpm via Corepack in CI to honor packageManager pin

### DIFF
--- a/.gitea/workflows/build.yml
+++ b/.gitea/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: "22"
 
       - name: Install pnpm and JS dependencies
-        run: npm install -g pnpm && pnpm install --frozen-lockfile --ignore-scripts
+        run: corepack enable && pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Build TypeScript
         run: make ts

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: "22"
 
       - name: Install pnpm and JS dependencies
-        run: npm install -g pnpm && pnpm install --frozen-lockfile --ignore-scripts
+        run: corepack enable && pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Build TypeScript
         run: make ts


### PR DESCRIPTION
## Summary

Both CI workflows installed pnpm with `npm install -g pnpm`, which pulls the **latest** pnpm release and ignores the `pnpm@10.33.0` pin in `package.json`'s `packageManager` field. This let CI silently drift to a different pnpm major than the Docker image and local dev — the exact drift Corepack is meant to prevent.

The recent parity work brought GitHub and Gitea CI in line with *each other*, but both still diverged from the `Dockerfile` assets stage (`corepack enable`) and from the model documented in `CLAUDE.md`:

> To bump pnpm, update the `packageManager` field; local, CI, and Docker all follow it. … the Docker assets stage runs `corepack enable` rather than `npm install -g pnpm`.

## Change

Switch the pnpm install step in both `.github/workflows/build-docker.yml` and `.gitea/workflows/build.yml` to `corepack enable && pnpm install --frozen-lockfile --ignore-scripts`, matching the Dockerfile. Corepack ships with the Node provided by `actions/setup-node@v4`, so no extra bootstrap is needed.

## Why it's safe

- No CI caching depends on pnpm being on `PATH` before this step (`cache: pnpm` is not used).
- Same command already proven in the Dockerfile build.

https://claude.ai/code/session_01VWXYQxUPWdhoV4otwr6Cyk

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWXYQxUPWdhoV4otwr6Cyk)_