### PR TITLE
Fix staging deployment to use single machine and prevent session loss

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -49,7 +49,13 @@ jobs:
             "APP_URL=https://${HOST}"
 
       - name: Deploy
-        run: flyctl deploy --app "$APP" --config fly.staging.toml --remote-only --yes
+        # --ha=false so Fly provisions a single machine. Staging stores sessions
+        # in machine-local SQLite (no shared volume), so a second machine would
+        # serve requests it has no session for, bouncing logged-in users back to
+        # the login page. scale count 1 fixes apps already created with two.
+        run: |
+          flyctl deploy --app "$APP" --config fly.staging.toml --remote-only --yes --ha=false
+          flyctl scale count 1 --app "$APP" --yes
 
       - name: Summary
         run: echo "Deployed to https://${HOST}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
Updated the staging deployment workflow to provision a single Fly machine and enforce a scale count of 1. This prevents session loss issues caused by multiple machines serving requests without access to shared session data.

## Key Changes
- Added `--ha=false` flag to `flyctl deploy` to prevent Fly from provisioning multiple machines for high availability
- Added explicit `flyctl scale count 1` command to ensure staging apps are scaled to a single machine
- Added explanatory comments documenting why single-machine deployment is necessary for staging (sessions are stored in machine-local SQLite without a shared volume)

## Implementation Details
The staging environment stores sessions in machine-local SQLite rather than a shared volume. With multiple machines, requests could be routed to a machine that has no knowledge of the user's session, causing logged-in users to be bounced back to the login page. The `--ha=false` flag prevents Fly from automatically creating a second machine, and the explicit scale command fixes any staging apps that were previously created with two machines.

https://claude.ai/code/session_01YWAvjVEAibhwbeVgbYmg94