### PR TITLE
fix(search-select): move field id to inner search input (issue #30)

### DIFF
--- a/common/components/search_select.py
+++ b/common/components/search_select.py
@@ -9,15 +9,17 @@ This module imports only from ``common.components`` — it has no Django-forms o
 ``data-*`` attributes wired up by ``ts/search_select.ts`` (compiled to
 ``games/static/js/dist/search_select.js``).
 
-**Disabling**: this is a composite widget — its ``id`` sits on the wrapper
-``<div>``, which has no ``disabled`` state of its own. To disable it, set
-``disabled`` on the inner search ``<input>`` (``[data-search-select-search]``);
-the wrapper then greys itself via the ``has-[:disabled]:`` utilities in
-``_CONTAINER_CLASS``. The inner input is excluded from the global
-disabled-input surface (``common/input.css``) so it stays transparent — the
-widget reads as one faded element, not a nested box. Callers toggle only the
-control's ``disabled`` — never styles. (See ``ts/add_purchase.ts`` gating
-``related_game`` on the type field.)
+**Field id / label association**: when ``SearchSelect`` is used as a Django form
+widget, the field ``id`` (e.g. ``id_related_game``) is placed on the inner
+search ``<input>`` (``[data-search-select-search]``), making it a real labelable
+control. ``<label for="id_X">`` therefore focuses the search box, and
+``document.querySelector('#id_X').disabled`` behaves as for a native input.
+
+**Disabling**: set ``disabled`` directly on the field id (or on the inner
+``[data-search-select-search]`` input). The wrapper greys itself via the
+``has-[:disabled]:`` utilities in ``_CONTAINER_CLASS``. The inner input stays
+transparent — the widget reads as one faded element, not a nested box. Callers
+toggle only the control's ``disabled`` — never styles.
 
 Option sourcing follows two axes. *Population*: options are either rendered
 inline up front (``options=``, no ``search_url``) or fetched from ``search_url``.
@@ -301,6 +303,8 @@ def SearchSelect(
         ("autocomplete", "off"),
         ("class", _SEARCH_CLASS),
     ]
+    if id:
+        search_attrs.append(("id", id))
     if autofocus:
         search_attrs.append(("autofocus", ""))
     if search_value:
@@ -345,7 +349,6 @@ def SearchSelect(
         prefetch=prefetch,
         sync_url="true" if sync_url else "false",
         class_=_CONTAINER_CLASS,
-        id_=id or None,
     )[*children]
 
 

--- a/e2e/test_widgets_e2e.py
+++ b/e2e/test_widgets_e2e.py
@@ -161,7 +161,6 @@ def test_searchselect_border_matches_native_input(
     page = authenticated_page
     page.goto(f"{live_server.url}{reverse('games:add_purchase')}")
     price = page.locator("#id_price")  # always-enabled native input
-    # #id_platform is now on the inner <input>; find the wrapper by name attr.
     wrapper = page.locator("search-select[name='platform']")
     search_input = page.locator("#id_platform")
     border = "el => getComputedStyle(el).borderColor"

--- a/e2e/test_widgets_e2e.py
+++ b/e2e/test_widgets_e2e.py
@@ -161,14 +161,15 @@ def test_searchselect_border_matches_native_input(
     page = authenticated_page
     page.goto(f"{live_server.url}{reverse('games:add_purchase')}")
     price = page.locator("#id_price")  # always-enabled native input
-    wrapper = page.locator("#id_platform")
-    search = page.locator("#id_platform [data-search-select-search]")
+    # #id_platform is now on the inner <input>; find the wrapper by name attr.
+    wrapper = page.locator("search-select[name='platform']")
+    search_input = page.locator("#id_platform")
     border = "el => getComputedStyle(el).borderColor"
 
     rest = price.evaluate(border)
     assert wrapper.evaluate(border) == rest  # same border at rest
 
-    search.focus()
+    search_input.focus()
     focused_wrapper = wrapper.evaluate(border)
     price.focus()
     focused_input = price.evaluate(border)
@@ -189,19 +190,21 @@ def test_add_game_syncs_sort_name_from_name(authenticated_page: Page, live_serve
 def test_add_purchase_type_game_disables_related_game_search(
     authenticated_page: Page, live_server
 ):
-    """When Type is 'game', the related-game SearchSelect is disabled — the
-    real disable target is the inner search input, not the wrapper <div>
-    (a <div> ignores the disabled property)."""
+    """When Type is 'game', the related-game SearchSelect is disabled.
+    #id_related_game is the inner search <input> (the real labelable control),
+    and the <search-select> wrapper fades via has-[:disabled]:opacity-50."""
     page = authenticated_page
     page.goto(f"{live_server.url}{reverse('games:add_purchase')}")
-    wrapper = page.locator("#id_related_game")
-    search = page.locator("#id_related_game [data-search-select-search]")
+    # #id_related_game is now on the inner <input data-search-select-search>
+    search_input = page.locator("#id_related_game")
+    # The wrapper has no id; find it by the stable `name` attribute.
+    wrapper = page.locator("search-select[name='related_game']")
     name = page.locator("#id_name")
     opacity = "el => getComputedStyle(el).opacity"
     bg = "el => getComputedStyle(el).backgroundColor"
 
     page.select_option("#id_type", "game")
-    expect(search).to_be_disabled()
+    expect(search_input).to_be_disabled()
     # A disabled SearchSelect must look identical to a disabled native input:
     # both fade (opacity-50) over the same surface.
     assert wrapper.evaluate(opacity) == "0.5"
@@ -209,14 +212,28 @@ def test_add_purchase_type_game_disables_related_game_search(
     assert wrapper.evaluate(bg) == name.evaluate(bg)
     # The inner input stays transparent (no nested box) with the same not-allowed
     # cursor (no flicker across the widget).
-    assert search.evaluate(bg) == "rgba(0, 0, 0, 0)"
-    assert search.evaluate("el => getComputedStyle(el).cursor") == "not-allowed"
+    assert search_input.evaluate(bg) == "rgba(0, 0, 0, 0)"
+    assert search_input.evaluate("el => getComputedStyle(el).cursor") == "not-allowed"
 
     page.select_option("#id_type", "dlc")
-    expect(search).to_be_enabled()
+    expect(search_input).to_be_enabled()
     # Enabled, both return to full opacity.
     assert wrapper.evaluate(opacity) == "1"
     assert name.evaluate(opacity) == "1"
+
+
+def test_label_click_focuses_search_select(authenticated_page: Page, live_server):
+    """Clicking a <label for="id_X"> on a SearchSelect field must focus the
+    search input — confirmed now that id is on the real <input> control."""
+    page = authenticated_page
+    page.goto(f"{live_server.url}{reverse('games:add_purchase')}")
+    # related_game is disabled when type is "game" (the default); switch so it
+    # is enabled, otherwise clicking the label for a disabled control fails.
+    page.select_option("#id_type", "dlc")
+    label = page.locator("label[for='id_related_game']")
+    search_input = page.locator("#id_related_game")
+    label.click()
+    expect(search_input).to_be_focused()
 
 
 def test_add_game_sync_stops_once_sort_name_edited(

--- a/tests/test_search_select.py
+++ b/tests/test_search_select.py
@@ -154,6 +154,23 @@ class SearchSelectComponentTest(unittest.TestCase):
         html_custom = str(SearchSelect(name="t", prefetch=42))
         self.assertIn('prefetch="42"', html_custom)
 
+    def test_field_id_placed_on_search_input(self):
+        html = str(SearchSelect(name="games", id="id_games"))
+        # id appears exactly once in the whole widget
+        self.assertEqual(html.count('id="id_games"'), 1)
+        # must NOT appear in the <search-select> wrapper's opening tag
+        wrapper_open_end = html.index(">", html.index("<search-select"))
+        self.assertNotIn('id="id_games"', html[:wrapper_open_end])
+        # must appear on the element that carries data-search-select-search
+        search_pos = html.index("data-search-select-search")
+        tag_start = html.rindex("<", 0, search_pos)
+        tag_end = html.index(">", search_pos)
+        self.assertIn('id="id_games"', html[tag_start:tag_end])
+
+    def test_no_id_omits_id_attribute(self):
+        html = str(SearchSelect(name="games"))
+        self.assertNotIn("id=", html)
+
 
 class FilterSelectComponentTest(unittest.TestCase):
     MODIFIERS = [("NOT_NULL", "(Any)"), ("IS_NULL", "(None)")]

--- a/ts/add_purchase.ts
+++ b/ts/add_purchase.ts
@@ -53,12 +53,7 @@ onSwap("#id_separate_prices", (checkbox) => {
 });
 
 function setupElementHandlers(): void {
-  // related_game is a SearchSelect: its #id_related_game wrapper is a <div>
-  // (ignores `disabled`), so target the inner search <input> instead.
-  disableElementsWhenTrue("#id_type", "game", [
-    "#id_name",
-    "#id_related_game [data-search-select-search]",
-  ]);
+  disableElementsWhenTrue("#id_type", "game", ["#id_name", "#id_related_game"]);
 }
 
 onSwap("#id_type", (typeSelect) => {


### PR DESCRIPTION
## Summary

- Moves the Django field `id` (e.g. `id_related_game`) from the `<search-select>` wrapper to the inner `[data-search-select-search]` `<input>`, making it a real labelable, disableable control
- `<label for="id_X">` now focuses the search box (a11y fix)
- `.disabled` / `.focus()` on `#id_X` now work as expected
- `add_purchase.ts` drops the `[data-search-select-search]` descendant-selector workaround and gates `related_game` via `#id_related_game` directly

## Test plan

- [ ] Updated `test_searchselect_border_matches_native_input` — finds wrapper via `search-select[name='platform']`
- [ ] Updated `test_add_purchase_type_game_disables_related_game_search` — `#id_related_game` now IS the inner input; wrapper found via `search-select[name='related_game']`
- [ ] New `test_label_click_focuses_search_select` — clicks label, asserts search input is focused
- [ ] `make check` (515 tests) + `make test-e2e` (49 tests) all pass

Closes #30
Related: #29 (workaround this replaces), #28