### PR TITLE
feat(game): add Submit & Create Session button to add-game form

### DIFF
--- a/e2e/test_widgets_e2e.py
+++ b/e2e/test_widgets_e2e.py
@@ -9,6 +9,8 @@ vendored), so no network access is needed beyond the live server itself.
 Browser binaries must be installed once: ``uv run playwright install chromium``.
 """
 
+import re
+
 import pytest
 from django.urls import reverse
 from playwright.sync_api import Page, expect
@@ -258,3 +260,16 @@ def test_add_game_sync_stops_once_sort_name_edited(
     name.type(" 2")
     expect(name).to_have_value("Halo 2")
     expect(sort).to_have_value("Custom Sort")  # not clobbered
+
+
+def test_add_game_submit_and_create_session_redirects(
+    authenticated_page: Page, live_server
+):
+    """Submit & Create Session saves the game and redirects to add-session with
+    the new game pre-selected in the game SearchSelect."""
+    page = authenticated_page
+    page.goto(f"{live_server.url}{reverse('games:add_game')}")
+    page.fill("#id_name", "E2E Session Game")
+    page.click('button[name="submit_and_create_session"]')
+    page.wait_for_url(f"{live_server.url}/tracker/session/add/for-game/**")
+    expect(page.locator("#id_game")).to_have_value(re.compile(r"^E2E Session Game"))

--- a/games/views/game.py
+++ b/games/views/game.py
@@ -163,6 +163,10 @@ def add_game(request: HttpRequest) -> HttpResponse:
             return HttpResponseRedirect(
                 reverse("games:add_purchase_for_game", kwargs={"game_id": game.id})
             )
+        elif "submit_and_create_session" in request.POST:
+            return HttpResponseRedirect(
+                reverse("games:add_session_for_game", kwargs={"game_id": game.id})
+            )
         else:
             return redirect("games:list_games")
 
@@ -171,12 +175,21 @@ def add_game(request: HttpRequest) -> HttpResponse:
         AddForm(
             form,
             request=request,
-            additional_row=StyledButton(
-                [],
-                "Submit & Create Purchase",
-                color="gray",
-                type="submit",
-                name="submit_and_redirect",
+            additional_row=Fragment(
+                StyledButton(
+                    [],
+                    "Submit & Create Purchase",
+                    color="gray",
+                    type="submit",
+                    name="submit_and_redirect",
+                ),
+                StyledButton(
+                    [],
+                    "Submit & Create Session",
+                    color="gray",
+                    type="submit",
+                    name="submit_and_create_session",
+                ),
             ),
         ),
         title="Add New Game",

--- a/tests/test_rendered_pages.py
+++ b/tests/test_rendered_pages.py
@@ -128,11 +128,28 @@ class RenderedPagesTest(TestCase):
         self.assertIn("dist/add_game.js", html)
         self.assertIn("submit_and_redirect", html)
         self.assertIn("Submit &amp; Create Purchase", html)  # & correctly escaped
+        self.assertIn("submit_and_create_session", html)
+        self.assertIn("Submit &amp; Create Session", html)   # & correctly escaped
         # Fields self-style: label + control carry their own classes (no #add-form
         # / form CSS in input.css).
         self.assertIn("mb-2.5 text-sm font-medium text-heading", html)  # _LABEL_CLASS
         self.assertIn("bg-neutral-secondary-medium", html)  # INPUT_CLASS surface
         self.assertNoEscapedTags(html)
+
+    def test_add_game_submit_and_create_session_redirects(self):
+        response = self.client.post(
+            reverse("games:add_game"),
+            {
+                "name": "New Session Game",
+                "status": "u",
+                "submit_and_create_session": "",
+            },
+        )
+        game = Game.objects.get(name="New Session Game")
+        self.assertRedirects(
+            response,
+            reverse("games:add_session_for_game", kwargs={"game_id": game.id}),
+        )
 
     def test_form_errors_render_with_component_class(self):
         """Invalid submits re-render field errors via FormFields' own class, not


### PR DESCRIPTION
## Summary

- Adds a third submit button ("Submit & Create Session") to the add-game form alongside the existing "Submit" and "Submit & Create Purchase" buttons
- On submit, saves the game and redirects directly to the add-session form pre-filled with the new game
- Uses `Fragment` to group both secondary buttons in `additional_row`

Closes #31

## Test plan

- [x] Visit `/game/add`, fill in a game name, click "Submit & Create Session" — should land on `/session/add/for-game/<id>` with the game pre-selected
- [x] "Submit" and "Submit & Create Purchase" buttons still work as before
- [x] `make test` passes (518 unit tests)
- [x] `make test-e2e` passes (includes new E2E test: `test_add_game_submit_and_create_session_redirects`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)