### PR TITLE
fix(ci): comment staging URL when the PR is opened, not just on deploy

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,18 +3,18 @@ name: Staging deployment
 on:
   push:
     branches-ignore: [main]
+  pull_request:
+    types: [opened, reopened]
   delete:
 
 concurrency:
-  group: staging-${{ github.event.ref }}
+  group: staging-${{ github.event.pull_request.head.ref || github.event.ref }}
   cancel-in-progress: true
 
 jobs:
   deploy:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     env:
       BRANCH: ${{ github.ref_name }}
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
@@ -59,6 +59,28 @@ jobs:
 
       - name: Summary
         run: echo "Deployed to https://${HOST}" >> "$GITHUB_STEP_SUMMARY"
+
+  # Comment the staging URL on the branch's PR. Runs both after a successful
+  # push-deploy (covers PRs that already exist) and when a PR is opened or
+  # reopened (covers the common case of pushing the branch before opening the
+  # PR, where the deploy ran with no PR to comment on). The comment is deduped
+  # by body, so the two paths never double-post.
+  comment:
+    needs: [deploy]
+    if: |
+      always() &&
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'push' && needs.deploy.result == 'success'))
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      BRANCH: ${{ github.head_ref || github.ref_name }}
+    steps:
+      - name: Compute staging host
+        run: |
+          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-//; s/-$//' | cut -c1-30 | sed 's/-*$//')
+          echo "HOST=timetracker-staging-${SLUG}.fly.dev" >> "$GITHUB_ENV"
 
       - name: Comment staging URL on PR
         uses: actions/github-script@v7


### PR DESCRIPTION
## Problem

The staging deployment runs on push to a non-main branch and tries to comment the staging URL on the branch's PR. But you usually push the branch *before* opening the PR, so the deploy runs with no PR to comment on — the comment step logs "No open PR, skipping" and exits. Opening the PR later triggers nothing, so the staging URL comment never appears.

## Fix

- Add a `pull_request: [opened, reopened]` trigger.
- Move the "comment staging URL" logic out of the deploy job into its own `comment` job that runs **both** after a successful push-deploy (covers PRs that already exist) **and** on PR open/reopen (covers the push-before-PR case).
- Branch is `github.head_ref || github.ref_name` (head_ref on PR events, ref_name on push).
- The existing dedupe-by-body check keeps the two paths from double-posting.

The comment script now lives in a single place rather than being duplicated across triggers.

## Notes

On PR-open the deterministic URL is posted without re-verifying the Fly app exists (that would need the Fly token in the comment job). In practice the push-deploy has already run, so this is a non-issue; can add a `flyctl status` guard later if a failed deploy ever leaves a dead link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)