### PR TITLE
fix(filters): label the Days to Finish slider on the PlayEvent filter bar

### DIFF
--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -1495,16 +1495,19 @@ def _playevent_fields(existing: dict) -> list:
                 ),
             ],
         ),
-        RangeSlider(
-            label="Days to Finish",
-            input_name_prefix="filter-days-to-finish",
-            min_value=days_min,
-            max_value=days_max,
-            range_min=0,
-            range_max=365,
-            step="1",
-            min_placeholder="e.g. 1",
-            max_placeholder="e.g. 30",
+        _filter_field(
+            "Days to Finish",
+            RangeSlider(
+                label="Days to Finish",
+                input_name_prefix="filter-days-to-finish",
+                min_value=days_min,
+                max_value=days_max,
+                range_min=0,
+                range_max=365,
+                step="1",
+                min_placeholder="e.g. 1",
+                max_placeholder="e.g. 30",
+            ),
         ),
     ]
     return fields

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -223,6 +223,19 @@ class FilterBarRenderingTest(TestCase):
         )
         self._assert_shell(html, "/presets/playevents/list", "/presets/playevents/save")
 
+    def test_playevent_filter_bar_labels_days_to_finish_slider(self):
+        """The Days to Finish range slider must be wrapped in a labelled field —
+        RangeSlider does not render its own label, so a bare slider shows none."""
+        from common.components import PlayEventFilterBar
+
+        html = str(
+            PlayEventFilterBar(
+                filter_json="", preset_list_url="/l", preset_save_url="/s"
+            )
+        )
+        self.assertIn("Days to Finish", html)
+        self.assertNoEscapedTags(html)
+
     def test_game_filter_bar_has_new_widgets(self):
         """The expanded games FilterBar exposes platform_group, device, playevent_note,
         purchase_type / purchase_ownership_type, plus count and aggregate-playtime


### PR DESCRIPTION
## Problem

The Days to Finish range slider on the PlayEvent list filter bar renders with no label.

## Cause

`RangeSlider` does not render its own `label` — by design the field label is emitted by the `_filter_field` wrapper (see the comment in `RangeSlider`'s label row). Every other slider in `GameFilterBar` / `PurchaseFilterBar` is wrapped in `_filter_field`, but `_playevent_fields` added the Days to Finish slider bare, so no label showed.

## Fix

Wrap the slider in `_filter_field("Days to Finish", RangeSlider(...))`, matching the other filter bars.

## Test

`test_playevent_filter_bar_labels_days_to_finish_slider` — asserts the label text renders. Verified RED before the fix (bare slider emits no label text), GREEN after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)