### PR TITLE
feat(filters): surface started/ended date filters on the PlayEvent filter bar

### DIFF
--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -1479,6 +1479,8 @@ class PlayEventFilterBar(_FilterBarBase):
 def _playevent_fields(existing: dict) -> list:
     game_choice = _filter_get_choice(existing, "game")
     days_min, days_max = _parse_range(existing, "days_to_finish")
+    started_min, started_max = _parse_range(existing, "started")
+    ended_min, ended_max = _parse_range(existing, "ended")
 
     fields = [
         Div(
@@ -1494,6 +1496,24 @@ def _playevent_fields(existing: dict) -> list:
                     ),
                 ),
             ],
+        ),
+        _filter_field(
+            "Started",
+            DateRangePicker(
+                label="Started",
+                input_name_prefix="filter-started",
+                min_value=started_min,
+                max_value=started_max,
+            ),
+        ),
+        _filter_field(
+            "Finished",
+            DateRangePicker(
+                label="Finished",
+                input_name_prefix="filter-ended",
+                min_value=ended_min,
+                max_value=ended_max,
+            ),
         ),
         RangeSlider(
             label="Days to Finish",

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -223,6 +223,59 @@ class FilterBarRenderingTest(TestCase):
         )
         self._assert_shell(html, "/presets/playevents/list", "/presets/playevents/save")
 
+    def test_playevent_filter_bar_renders_date_inputs(self):
+        """PlayEventFilterBar surfaces started and ended as DateRangePicker
+        widgets whose -min/-max hidden inputs (the JS serializer contract)
+        carry the filter-started / filter-ended prefixes, in labelled fields."""
+        from common.components import PlayEventFilterBar
+
+        html = str(
+            PlayEventFilterBar(
+                filter_json="", preset_list_url="/l", preset_save_url="/s"
+            )
+        )
+        for name in (
+            "filter-started-min",
+            "filter-started-max",
+            "filter-ended-min",
+            "filter-ended-max",
+        ):
+            self.assertIn(f'name="{name}"', html)
+            self.assertIn(f'id="{name}"', html)
+        self.assertIn("<date-range-picker", html)
+        self.assertIn("Started", html)
+        self.assertIn("Finished", html)
+        self.assertNoEscapedTags(html)
+
+    def test_playevent_filter_bar_prepopulates_ended_between(self):
+        """A BETWEEN filter on ended populates both date bounds via _parse_range."""
+        from common.components import PlayEventFilterBar
+
+        filter_json = json.dumps(
+            {
+                "ended": {
+                    "value": "2024-01-01",
+                    "value2": "2024-12-31",
+                    "modifier": "BETWEEN",
+                }
+            }
+        )
+        html = str(
+            PlayEventFilterBar(
+                filter_json=filter_json,
+                preset_list_url="/l",
+                preset_save_url="/s",
+            )
+        )
+        self.assertIn(
+            'name="filter-ended-min" id="filter-ended-min" value="2024-01-01"',
+            html,
+        )
+        self.assertIn(
+            'name="filter-ended-max" id="filter-ended-max" value="2024-12-31"',
+            html,
+        )
+
     def test_game_filter_bar_has_new_widgets(self):
         """The expanded games FilterBar exposes platform_group, device, playevent_note,
         purchase_type / purchase_ownership_type, plus count and aggregate-playtime

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -201,6 +201,8 @@ function buildFilterJSON(form: HTMLElement): Record<string, unknown> {
   const dateRangeFields = [
     { prefix: "filter-date-purchased", key: "date_purchased" },
     { prefix: "filter-date-refunded", key: "date_refunded" },
+    { prefix: "filter-started", key: "started" },
+    { prefix: "filter-ended", key: "ended" },
   ];
   dateRangeFields.forEach((dateField) => {
     const valueMin = stringValue(form, dateField.prefix + "-min");


### PR DESCRIPTION
Stacked on #69 (targets `feat/issue-67-playevent-datecriterion`). Rebase onto `main` once #69 merges.

## What

Adds **Started** and **Finished** `DateRangePicker` widgets to the PlayEvent list filter bar, and wires `filter-started` / `filter-ended` into the filter-bar date-range serializer (`ts/elements/filter-bar.ts`). This makes the `started` / `ended` `DateCriterion` fields (introduced in #69 / issue #67) reachable from the UI — e.g. "finished in year Y" as a date range.

## Why it depends on #69

On `main`, `PlayEventFilter.started` / `ended` are `StringCriterion`, which can't express `BETWEEN` / `GREATER_THAN` / `LESS_THAN`. The widgets emit exactly those range criteria, so they only work once #69 lands.

## Notes

- Uses the bare field names (`filter-started`, `filter-ended`), round-tripped through `_parse_range` like the existing Purchase date fields — no `__date` lookup (the columns are `DateField`s).
- The Days to Finish slider label fix is a separate PR (#71); this PR leaves that slider untouched.

## Tests

- `test_playevent_filter_bar_renders_date_inputs` — Started/Finished DateRangePicker widgets render with the `filter-started-*` / `filter-ended-*` hidden-input contract.
- `test_playevent_filter_bar_prepopulates_ended_between` — a BETWEEN filter repopulates both bounds.
- Full unit suite (505) + e2e (55) pass; `make ts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)