### PR TITLE
Make platform and currency optional when adding a purchase

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,7 @@ remove that and `settings.ini` wins; remove that and the code default applies.
 | `APP_URL` | str (or comma-separated URLs) | `http://localhost:8000` | no | Public URL(s) of the site. One full URL or a comma-separated list. Derives `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS` from all listed URLs. |
 | `ALLOWED_HOSTS` | list | derived from `APP_URL` | no | Comma-separated hostnames. Overrides the `APP_URL` derivation (useful for `ALLOWED_HOSTS=*` behind a reverse proxy). |
 | `TZ` | str | `Europe/Prague` (dev) / `UTC` (prod) | no | Time zone. |
+| `DEFAULT_CURRENCY` | str | `CZK` | no | Default currency for new purchases when none is entered, and the FX conversion target for background price conversion. |
 | `DATA_DIR` | path | project root | no | Directory holding the SQLite database. Also read by `entrypoint.sh`. |
 
 `cast` understands `bool` (`true/1/yes/on` → `True`), `list` (comma-separated,

--- a/games/forms.py
+++ b/games/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.contrib.auth.forms import AuthenticationForm
 from django.db import transaction
 
@@ -282,6 +283,7 @@ class PurchaseForm(PrimitiveWidgetsMixin, forms.ModelForm):
     )
     platform = forms.ModelChoiceField(
         queryset=Platform.objects.order_by("name"),
+        required=False,
         widget=SearchSelectWidget(
             search_url="/api/platforms/search", options_resolver=_platform_options
         ),
@@ -295,10 +297,11 @@ class PurchaseForm(PrimitiveWidgetsMixin, forms.ModelForm):
     )
 
     price_currency = forms.CharField(
+        required=False,
         widget=forms.TextInput(
             attrs={
                 "x-mask": "aaa",
-                "placeholder": "CZK",
+                "placeholder": settings.DEFAULT_CURRENCY,
                 "x-data": "",
                 "class": "uppercase",
             }

--- a/games/models.py
+++ b/games/models.py
@@ -2,6 +2,7 @@ import logging
 from datetime import timedelta
 
 import requests
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import F, Q, Sum
@@ -250,6 +251,10 @@ class Purchase(models.Model):
         self.save()
 
     def save(self, *args, **kwargs):
+        if self.platform is None:
+            self.platform = get_sentinel_platform()
+        if not self.price_currency:
+            self.price_currency = settings.DEFAULT_CURRENCY
         if self.type != Purchase.GAME and not self.related_game:
             raise ValidationError(
                 f"{self.get_type_display()} must have a related game."

--- a/games/tasks.py
+++ b/games/tasks.py
@@ -1,14 +1,13 @@
 import logging
 
 import requests
+from django.conf import settings
 from django.db import models
 from games.models import ExchangeRate, Purchase
 
 logger = logging.getLogger("games")
 
-# fixme: save preferred currency in user model
-currency_to = "CZK"
-currency_to = currency_to.upper()
+currency_to = settings.DEFAULT_CURRENCY.upper()
 
 
 def _get_exchange_rate(currency_from, currency_to, year):

--- a/tests/test_purchase_defaults.py
+++ b/tests/test_purchase_defaults.py
@@ -1,0 +1,66 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from games.models import Game, Platform, Purchase, get_sentinel_platform
+
+
+class AddPurchaseDefaultsTest(TestCase):
+    """Adding a purchase without a platform or currency falls back to the
+    "Unspecified" platform sentinel (issue #89) and DEFAULT_CURRENCY (issue
+    #88)."""
+
+    def setUp(self):
+        self.user = User.objects.create_superuser("u", "u@e.com", "pw")
+        self.client.force_login(self.user)
+        self.platform = Platform.objects.create(name="PC", icon="pc", group="PC")
+        self.game_a = Game.objects.create(name="Game A", platform=self.platform)
+        self.game_b = Game.objects.create(name="Game B", platform=self.platform)
+
+    def _base_data(self, **overrides):
+        data = {
+            "games": [self.game_a.id],
+            "platform": "",
+            "date_purchased": "2025-01-01",
+            "price_currency": "",
+            "ownership_type": Purchase.DIGITAL,
+            "type": Purchase.GAME,
+            "name": "",
+        }
+        data.update(overrides)
+        return data
+
+    @override_settings(DEFAULT_CURRENCY="CZK")
+    def test_empty_platform_and_currency_use_defaults(self):
+        data = self._base_data(pricing_mode="combined", price="30")
+        response = self.client.post(reverse("games:add_purchase"), data)
+
+        self.assertEqual(response.status_code, 302)
+        purchase = Purchase.objects.get()
+        self.assertEqual(purchase.platform, get_sentinel_platform())
+        self.assertEqual(purchase.price_currency, "CZK")
+
+    @override_settings(DEFAULT_CURRENCY="CZK")
+    def test_per_game_path_uses_defaults(self):
+        data = self._base_data(
+            games=[self.game_a.id, self.game_b.id],
+            pricing_mode="per_game",
+            **{
+                f"price_for_game_{self.game_a.id}": "10",
+                f"price_for_game_{self.game_b.id}": "20",
+            },
+        )
+        response = self.client.post(reverse("games:add_purchase"), data)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Purchase.objects.count(), 2)
+        for purchase in Purchase.objects.all():
+            self.assertEqual(purchase.platform, get_sentinel_platform())
+            self.assertEqual(purchase.price_currency, "CZK")
+
+    @override_settings(DEFAULT_CURRENCY="EUR")
+    def test_currency_default_follows_setting(self):
+        data = self._base_data(pricing_mode="combined", price="5")
+        self.client.post(reverse("games:add_purchase"), data)
+
+        self.assertEqual(Purchase.objects.get().price_currency, "EUR")

--- a/timetracker/settings.py
+++ b/timetracker/settings.py
@@ -174,6 +174,10 @@ LANGUAGE_CODE = "en-us"
 
 TIME_ZONE = config("TZ", default="Europe/Prague" if DEBUG else "UTC")
 
+# Default currency for new purchases when none is entered, and FX conversion
+# target for background price conversion (issues #88/#89).
+DEFAULT_CURRENCY = config("DEFAULT_CURRENCY", default="CZK")
+
 USE_I18N = True
 
 USE_TZ = True


### PR DESCRIPTION
Fixes #88 and #89.

Adding a purchase no longer requires picking a platform or typing a currency.

## Changes

- **Platform (#89):** an empty platform now resolves to the existing "Unspecified" sentinel in `Purchase.save()`, mirroring `Game.save()`. The `PurchaseForm` platform field is no longer required.
- **Currency (#88):** an empty currency falls back to a new `DEFAULT_CURRENCY` setting (default `CZK`), also applied in `Purchase.save()`. The form field is no longer required and its placeholder is pulled live from the setting. The FX conversion target in `games/tasks.py` now follows the same setting instead of a hardcoded value.

Both defaults live in `Purchase.save()`, so the bundle, per-game ("separate purchases"), and Split creation paths all benefit without duplication. No migration is needed — `Purchase.platform` was already nullable and the currency field default is untouched.

## Files
- `timetracker/settings.py` — new `DEFAULT_CURRENCY` config setting
- `games/models.py` — sentinel + currency fallback in `Purchase.save()`
- `games/forms.py` — `required=False` on both fields, dynamic placeholder
- `games/tasks.py` — conversion target uses the setting
- `docs/configuration.md` — documented the setting
- `tests/test_purchase_defaults.py` — new tests (combined, per-game, and setting-follows-value)

## Verification
- New tests + purchase/price suites pass
- Full unit suite: 590 passed
- `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HPkEna1UKQLcQ8sLqBRrS

---
_Generated by [Claude Code](https://claude.ai/code/session_015HPkEna1UKQLcQ8sLqBRrS)_