### PR TITLE
Enable mypy with django-stubs and gate CI on it

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Run Migrations
         run: uv run python manage.py migrate
 
+      - name: Type check
+        run: uv run mypy .
+
       - name: Run Tests
         run: uv run --with pytest-django pytest
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,12 @@
 {
+    "mypy-type-checker.importStrategy": "fromEnvironment",
+    "mypy-type-checker.reportingScope": "workspace",
     "python.testing.pytestArgs": [
         "tests"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "python.analysis.typeCheckingMode": "strict",
+    "python.analysis.typeCheckingMode": "off",
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.formatOnSave": true,

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,10 @@ format:
 format-check:
 	uv run ruff format --check
 
-check: lint format-check ts-check test
+typecheck:
+	uv run mypy .
+
+check: lint format-check typecheck ts-check test
 
 date:
 	uv run python -c 'import datetime; from zoneinfo import ZoneInfo; print(datetime.datetime.isoformat(datetime.datetime.now(ZoneInfo("Europe/Prague")), timespec="minutes", sep=" "))'

--- a/common/components/core.py
+++ b/common/components/core.py
@@ -16,6 +16,7 @@ Nodes are *lazy*: they hold structure and render to HTML only when asked
 import hashlib
 from collections.abc import Sequence
 from functools import lru_cache
+from typing import Self
 
 from django.utils.html import escape
 from django.utils.safestring import SafeText, mark_safe
@@ -113,7 +114,7 @@ class Node:
         """Total media of this node and its subtree."""
         return self.media
 
-    def with_media(self, media: Media) -> "Node":
+    def with_media(self, media: Media) -> Self:
         """Attach JS dependencies to this node and return it (for fluent use).
 
         Lets a function-built node declare its media without becoming a full

--- a/common/components/custom_elements.py
+++ b/common/components/custom_elements.py
@@ -319,7 +319,7 @@ def _stamp(element: Element, contract: list[tuple[str, str]], id: str) -> Elemen
                 stacklevel=3,
             )
     kept = [(key, value) for key, value in element.attributes if key not in reserved]
-    clone = Element(element.tag_name, kept + contract, element.children)
+    clone = Element(element.tag_name, [*kept, *contract], element.children)
     clone.media = element.media
     return clone
 

--- a/common/components/domain.py
+++ b/common/components/domain.py
@@ -72,10 +72,7 @@ def GameStatus(
         children=["\xa0"],
     )
 
-    return Span(
-        attributes=[("class", outer_class)],
-        children=[dot] + as_children(children),
-    )
+    return Span(class_=outer_class, children=[dot] + as_children(children))
 
 
 def PriceConverted(
@@ -99,8 +96,10 @@ def LinkedPurchase(purchase: Purchase) -> Node:
     game_count = purchase.games.count()
     popover_if_not_truncated = False
     if game_count == 1:
-        link_content += purchase.games.first().name
-        popover_content = link_content
+        first_game = purchase.games.first()
+        if first_game is not None:
+            link_content += first_game.name
+            popover_content = link_content
     if game_count > 1:
         if purchase.name:
             link_content += f"{purchase.name}"
@@ -185,11 +184,12 @@ def _resolve_name_with_icon(
 
     if session is not None:
         game = session.game
-        platform = game.platform
         final_emulated = session.emulated
-        if linkify:
-            create_link = True
-            link = reverse("games:view_game", args=[int(game.pk)])
+        if game is not None:
+            platform = game.platform
+            if linkify:
+                create_link = True
+                link = reverse("games:view_game", args=[int(game.pk)])
     elif game is not None:
         platform = game.platform
         if linkify:

--- a/common/components/primitives.py
+++ b/common/components/primitives.py
@@ -7,6 +7,9 @@ classes or behaviour (``Button``, ``Pill``, ``Checkbox`` …) are written out.
 Everything returns a :class:`Node`; string-built widgets return :class:`Safe`.
 """
 
+from collections.abc import Mapping
+from typing import Any
+
 from django.middleware.csrf import get_token
 from django.templatetags.static import static
 from django.utils.html import conditional_escape
@@ -896,7 +899,7 @@ def TableTd(
     )
 
 
-def TableRow(data: dict | list | None = None) -> Element:
+def TableRow(data: Mapping[str, Any] | list | None = None) -> Element:
     """Generate a <tr> from a row data dict or list.
 
     Dict form: {"row_id": "...", "cell_data": [...], "hx_trigger": ..., ...}
@@ -1103,7 +1106,7 @@ def SimpleTable(
 
 
 def paginated_table_content(
-    data: dict,
+    data: Mapping[str, Any],
     *,
     page_obj=None,
     elided_page_range=None,

--- a/common/components/search_select.py
+++ b/common/components/search_select.py
@@ -31,7 +31,7 @@ first open, ``0`` = none) seeds that window so the panel is populated before the
 user types.
 """
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from typing import TypedDict
 
 
@@ -50,7 +50,7 @@ from common.components.primitives import (
 class SearchSelectOption(TypedDict):
     value: str | int
     label: str
-    data: dict[str, str]  # becomes data-* attrs on the row / pill
+    data: dict[str, str | int]  # becomes data-* attrs on the row / pill
 
 
 # A lightweight (value, label) pair used wherever only those two fields are
@@ -175,7 +175,7 @@ def _normalize_option(option) -> SearchSelectOption:
     return {"value": value, "label": label, "data": {}}
 
 
-def _data_attributes(data: dict[str, str]) -> list[HTMLAttribute]:
+def _data_attributes(data: dict[str, str | int]) -> list[HTMLAttribute]:
     return [(f"data-{key}", str(value)) for key, value in data.items()]
 
 
@@ -447,9 +447,9 @@ def _filter_modifier_row(modifier_value: str, label: str) -> Node:
 def FilterSelect(
     *,
     field_name: str,
-    options: list[LabeledOption | SearchSelectOption] | None = None,
-    included: list[LabeledOption | SearchSelectOption] | None = None,
-    excluded: list[LabeledOption | SearchSelectOption] | None = None,
+    options: Sequence[LabeledOption | SearchSelectOption] | None = None,
+    included: Sequence[LabeledOption | SearchSelectOption] | None = None,
+    excluded: Sequence[LabeledOption | SearchSelectOption] | None = None,
     modifier: str = "",
     modifier_options: list[LabeledOption] | None = None,
     search_url: str = "",
@@ -481,9 +481,9 @@ def FilterSelect(
     types so the +/− buttons (and Enter) commit the typed string itself as an
     include / exclude pill.
     """
-    options = [_normalize_option(option) for option in (options or [])]
-    included = [_normalize_option(option) for option in (included or [])]
-    excluded = [_normalize_option(option) for option in (excluded or [])]
+    normalized_options = [_normalize_option(option) for option in (options or [])]
+    normalized_included = [_normalize_option(option) for option in (included or [])]
+    normalized_excluded = [_normalize_option(option) for option in (excluded or [])]
     modifier_options = modifier_options or []
 
     active_modifier_label = ""
@@ -500,9 +500,9 @@ def FilterSelect(
     pills_children: list[Node] = []
     if active_modifier_label:
         pills_children.append(_filter_modifier_pill(modifier, active_modifier_label))
-    for option in included:
+    for option in normalized_included:
         pills_children.append(_filter_value_pill(option, "include"))
-    for option in excluded:
+    for option in normalized_excluded:
         pills_children.append(_filter_value_pill(option, "exclude"))
 
     pills = Div(
@@ -524,7 +524,10 @@ def FilterSelect(
         _filter_modifier_row(value, label) for value, label in modifier_options
     ]
     value_rows = (
-        [_filter_option_row(option["value"], option["label"]) for option in options]
+        [
+            _filter_option_row(option["value"], option["label"])
+            for option in normalized_options
+        ]
         if not search_url
         else []
     )

--- a/common/http.py
+++ b/common/http.py
@@ -1,0 +1,12 @@
+"""HTTP typing helpers shared across the app."""
+
+from django.http import HttpRequest
+from django_htmx.middleware import HtmxDetails
+
+
+class HtmxHttpRequest(HttpRequest):
+    """An ``HttpRequest`` carrying the ``htmx`` attribute that django-htmx's
+    middleware adds to every request. Use as the request annotation in any view
+    that branches on ``request.htmx``."""
+
+    htmx: HtmxDetails

--- a/common/import_data.py
+++ b/common/import_data.py
@@ -8,12 +8,14 @@ DataList: TypeAlias = list[dict[str, str]] | None
 
 def read_csv(filename: str) -> DataList:
     with open(filename, "r") as csvfile:
-        writer = csv.DictReader(csvfile)
-        return writer
+        reader = csv.DictReader(csvfile)
+        return list(reader)
 
 
 def import_data(data: DataList):
     matching_names = {}
+    if data is None:
+        return
     for line in data:
         name = line["name"]
         if name not in matching_names:

--- a/common/time.py
+++ b/common/time.py
@@ -38,10 +38,10 @@ def date_parts(format_string: str = dateformat_hyphenated) -> list[DatePartSpec]
     return [_DATE_PART_SPECS[directive] for directive in format_string.split("-")]
 
 
-def _safe_timedelta(duration: timedelta | int | None):
+def _safe_timedelta(duration: timedelta | int | float | None):
     if duration is None:
         return timedelta(0)
-    elif isinstance(duration, int):
+    elif isinstance(duration, (int, float)):
         return timedelta(seconds=duration)
     elif isinstance(duration, timedelta):
         return duration
@@ -73,7 +73,8 @@ def format_duration(
     # timestamps where end is before start
     if seconds_total < 0:
         seconds_total = 0
-    days = hours = hours_float = minutes = seconds = 0
+    days = hours_float = minutes = seconds = 0
+    hours: float = 0
     remainder = seconds = seconds_total
     if "%d" in format_string:
         days, remainder = divmod(seconds_total, day_seconds)

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,4 +1,5 @@
 import operator
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date
 from functools import reduce, wraps
@@ -135,7 +136,7 @@ class FilterEntry:
 
 
 def build_dynamic_filter(
-    filters: list[FilterEntry | Q], default_operator: OperatorType = "&"
+    filters: Sequence[FilterEntry | Q], default_operator: OperatorType = "&"
 ):
     """
     Constructs a Django Q filter from a list of filter conditions.

--- a/games/filters.py
+++ b/games/filters.py
@@ -32,6 +32,12 @@ from common.criteria import (
     filter_to_json,
 )
 
+# A queryset of object ids (from ``.values_list("id"/"pk", flat=True)``), reused
+# as the cross-entity ``matching_ids`` local in the ``to_q()`` methods. The model
+# varies per branch (Game / Session / Purchase / …), so only the int row type is
+# pinned.  # e.g. Session.objects.filter(...).values_list("id", flat=True)
+type MatchingIdQuerySet = QuerySet[Any, int]
+
 # ── FindFilter (sort / pagination) ─────────────────────────────────────────
 
 
@@ -138,7 +144,7 @@ class GameFilter(OperatorFilter):
 
             from games.models import Game
 
-            matching_ids: QuerySet[Any, Any] = (
+            matching_ids: MatchingIdQuerySet = (
                 Game.objects.annotate(s_count=Count("sessions", distinct=True))
                 .filter(self.session_count.to_q("s_count"))
                 .values_list("id", flat=True)
@@ -552,7 +558,7 @@ class SessionFilter(OperatorFilter):
             from games.models import Game
 
             game_q = self.game_filter.to_q()
-            matching_ids: QuerySet[Any, Any] = Game.objects.filter(game_q).values_list(
+            matching_ids: MatchingIdQuerySet = Game.objects.filter(game_q).values_list(
                 "id", flat=True
             )
             q &= Q(game_id__in=matching_ids)
@@ -671,7 +677,7 @@ class PurchaseFilter(OperatorFilter):
             from games.models import Game
 
             game_q = self.game_filter.to_q()
-            matching_ids: QuerySet[Any, Any] = Game.objects.filter(game_q).values_list(
+            matching_ids: MatchingIdQuerySet = Game.objects.filter(game_q).values_list(
                 "id", flat=True
             )
             q &= Q(games__id__in=matching_ids)
@@ -869,7 +875,7 @@ class PlatformFilter(OperatorFilter):
             from games.models import Game
 
             game_q = self.game_filter.to_q()
-            matching_ids: QuerySet[Any, Any] = Game.objects.filter(game_q).values_list(
+            matching_ids: MatchingIdQuerySet = Game.objects.filter(game_q).values_list(
                 "platform_id", flat=True
             )
             q &= Q(id__in=matching_ids)
@@ -950,7 +956,7 @@ class PlayEventFilter(OperatorFilter):
             from games.models import Game
 
             game_q = self.game_filter.to_q()
-            matching_ids: QuerySet[Any, Any] = Game.objects.filter(game_q).values_list(
+            matching_ids: MatchingIdQuerySet = Game.objects.filter(game_q).values_list(
                 "id", flat=True
             )
             q &= Q(game_id__in=matching_ids)

--- a/games/filters.py
+++ b/games/filters.py
@@ -12,8 +12,9 @@ with AND/OR/NOT composition and typed criterion fields.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django.urls import reverse
 from django.utils.http import urlencode
 
@@ -137,7 +138,7 @@ class GameFilter(OperatorFilter):
 
             from games.models import Game
 
-            matching_ids = (
+            matching_ids: QuerySet[Any, Any] = (
                 Game.objects.annotate(s_count=Count("sessions", distinct=True))
                 .filter(self.session_count.to_q("s_count"))
                 .values_list("id", flat=True)
@@ -551,7 +552,9 @@ class SessionFilter(OperatorFilter):
             from games.models import Game
 
             game_q = self.game_filter.to_q()
-            matching_ids = Game.objects.filter(game_q).values_list("id", flat=True)
+            matching_ids: QuerySet[Any, Any] = Game.objects.filter(game_q).values_list(
+                "id", flat=True
+            )
             q &= Q(game_id__in=matching_ids)
 
         # Cross-entity filter: sessions for devices matching DeviceFilter
@@ -668,7 +671,9 @@ class PurchaseFilter(OperatorFilter):
             from games.models import Game
 
             game_q = self.game_filter.to_q()
-            matching_ids = Game.objects.filter(game_q).values_list("id", flat=True)
+            matching_ids: QuerySet[Any, Any] = Game.objects.filter(game_q).values_list(
+                "id", flat=True
+            )
             q &= Q(games__id__in=matching_ids)
 
         # Cross-entity platform filter
@@ -713,37 +718,41 @@ class PurchaseFilter(OperatorFilter):
         consistent with every other modifier. All other modifiers delegate
         to the criterion.
         """
+        # Criterion values arrive as strings; the M2M lookups want game PKs.
+        game_ids = [int(game_id) for game_id in criterion.value]
+        exclude_ids = [int(game_id) for game_id in criterion.excludes]
+
         # Empty value means no constraint; still apply excludes if any
-        if not criterion.value:
-            if criterion.excludes:
-                return ~Q(games__in=criterion.excludes)
+        if not game_ids:
+            if exclude_ids:
+                return ~Q(games__in=exclude_ids)
             return Q()
 
         from games.models import Game, Purchase
 
         if criterion.modifier in (Modifier.INCLUDES_ALL, Modifier.INCLUDES_ONLY):
             subquery = Purchase.objects.all()
-            for game_id in criterion.value:
+            for game_id in game_ids:
                 subquery = subquery.filter(games=game_id)
 
             if criterion.modifier == Modifier.INCLUDES_ONLY:
-                extra_ids = Game.objects.exclude(id__in=criterion.value).values_list(
+                extra_ids = Game.objects.exclude(id__in=game_ids).values_list(
                     "id", flat=True
                 )
                 if extra_ids:
                     subquery = subquery.exclude(games__in=extra_ids)
 
             q = Q(pk__in=subquery.values("pk"))
-            if criterion.excludes:
-                q &= ~Q(games__in=criterion.excludes)
+            if exclude_ids:
+                q &= ~Q(games__in=exclude_ids)
             return q
 
         if criterion.modifier == Modifier.INCLUDES:
             # Use subquery to avoid duplicate rows from M2M join
-            subquery = Purchase.objects.filter(games__in=criterion.value)
+            subquery = Purchase.objects.filter(games__in=game_ids)
             q = Q(pk__in=subquery.values("pk"))
-            if criterion.excludes:
-                q &= ~Q(games__in=criterion.excludes)
+            if exclude_ids:
+                q &= ~Q(games__in=exclude_ids)
             return q
 
         return criterion.to_q("games")
@@ -860,7 +869,7 @@ class PlatformFilter(OperatorFilter):
             from games.models import Game
 
             game_q = self.game_filter.to_q()
-            matching_ids = Game.objects.filter(game_q).values_list(
+            matching_ids: QuerySet[Any, Any] = Game.objects.filter(game_q).values_list(
                 "platform_id", flat=True
             )
             q &= Q(id__in=matching_ids)
@@ -941,7 +950,9 @@ class PlayEventFilter(OperatorFilter):
             from games.models import Game
 
             game_q = self.game_filter.to_q()
-            matching_ids = Game.objects.filter(game_q).values_list("id", flat=True)
+            matching_ids: QuerySet[Any, Any] = Game.objects.filter(game_q).values_list(
+                "id", flat=True
+            )
             q &= Q(game_id__in=matching_ids)
 
         sub = self.sub_filter()

--- a/games/models.py
+++ b/games/models.py
@@ -61,9 +61,6 @@ class Game(models.Model):
     status = models.CharField(max_length=1, choices=Status, default=Status.UNPLAYED)
     mastered = models.BooleanField(default=False)
 
-    session_average: float | int | timedelta | None
-    session_count: int | None
-
     def __str__(self):
         return self.name
 
@@ -415,13 +412,13 @@ def get_or_create_rate(currency_from: str, currency_to: str, year: int) -> float
 
             if rate:
                 logger.info(f"[convert_prices]: Got {rate}, saving...")
-                exchange_rate = ExchangeRate.objects.create(
+                created_rate = ExchangeRate.objects.create(
                     currency_from=currency_from,
                     currency_to=currency_to,
                     year=year,
                     rate=floatformat(rate, 2),
                 )
-                exchange_rate = exchange_rate.rate
+                exchange_rate = created_rate.rate
             else:
                 logger.info("[convert_prices]: Could not get an exchange rate.")
         except requests.RequestException as e:

--- a/games/views/game.py
+++ b/games/views/game.py
@@ -820,7 +820,7 @@ def _playevents_section(game: Game) -> Node:
     )
 
 
-def _history_section(game: Game) -> Element:
+def _history_section(game: Game) -> Node:
     statuschanges: QuerySet[GameStatusChange] = game.status_changes.all()
     count = statuschanges.count()
     return Div(

--- a/games/views/game.py
+++ b/games/views/game.py
@@ -3,13 +3,12 @@ from typing import Any
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404, redirect
 from django.template.defaultfilters import date as date_filter
 from django.urls import reverse
-from django.utils.safestring import SafeText
 
 from common.components import (
     H1,
@@ -55,9 +54,9 @@ from games.filters import (
     filter_url,
     parse_game_filter,
 )
-from games.sorting import GAME_DEFAULT_SORT, GAME_SORTS, apply_sort, parse_find_filter
 from games.forms import GameForm
-from games.models import Game
+from games.models import Game, GameStatusChange
+from games.sorting import GAME_DEFAULT_SORT, GAME_SORTS, apply_sort, parse_find_filter
 from games.views.general import use_custom_redirect
 from games.views.playevent import create_playevent_tabledata
 
@@ -217,7 +216,7 @@ def _delete_game_confirmation_modal(
     purchase_count: int,
     playevent_count: int,
     request: HttpRequest,
-) -> SafeText:
+) -> Node:
     data_items = []
     if session_count:
         data_items.append(Li(children=[f"{session_count} session(s)"]))
@@ -323,12 +322,14 @@ def _delete_game_confirmation_modal(
 def delete_game_confirmation(request: HttpRequest, game_id: int) -> HttpResponse:
     game = get_object_or_404(Game, id=game_id)
     return HttpResponse(
-        _delete_game_confirmation_modal(
-            game,
-            game.sessions.count(),
-            game.purchases.count(),
-            game.playevents.count(),
-            request,
+        str(
+            _delete_game_confirmation_modal(
+                game,
+                game.sessions.count(),
+                game.purchases.count(),
+                game.playevents.count(),
+                request,
+            )
         )
     )
 
@@ -410,7 +411,7 @@ def _played_row(game: Game, request: HttpRequest) -> Node:
     ]
 
 
-def _stat_popover(popover_id: str, tooltip: str, svg_key: str, value: str) -> SafeText:
+def _stat_popover(popover_id: str, tooltip: str, svg_key: str, value: str) -> Node:
     return Popover(
         popover_content=tooltip,
         wrapped_classes="flex gap-2 items-center",
@@ -429,7 +430,7 @@ def _meta_row(label: str, value: Node | str, extra: Node | str = "") -> Node:
     return Div([("class", "flex gap-2 items-center")], children)
 
 
-def _game_action_buttons(game: Game) -> SafeText:
+def _game_action_buttons(game: Game) -> Node:
     edit_class = (
         "px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 "
         "rounded-s-lg hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-2 "
@@ -474,7 +475,7 @@ def _game_action_buttons(game: Game) -> SafeText:
     )
 
 
-def _game_history(statuschanges) -> SafeText:
+def _game_history(statuschanges: QuerySet[GameStatusChange]) -> Node:
     items = []
     for change in statuschanges:
         if change.timestamp:
@@ -513,19 +514,16 @@ def _game_history(statuschanges) -> SafeText:
                 ],
             )
         )
-    return Ul(
-        attributes=[("class", "list-disc list-inside")],
-        children=items,
-    )
+    return Ul(class_="list-disc list-inside", children=items)
 
 
 def _game_section(
     title: str,
     count: int,
-    table: SafeText,
+    table: Node,
     empty_message: str,
     view_all_url: str | None = None,
-) -> SafeText:
+) -> Node:
     if view_all_url and count:
         view_all_link = A(
             href=view_all_url,
@@ -541,10 +539,10 @@ def _game_section(
         )
         header = Div(
             [("class", "flex items-center justify-between")],
-            [H1(children=[title], badge=count), view_all_link],
+            [H1(children=[title], badge=str(count)), view_all_link],
         )
     else:
-        header = H1(children=[title], badge=count)
+        header = H1(children=[title], badge=str(count))
     return Div(
         [("class", "mb-6")],
         [
@@ -581,7 +579,7 @@ def _game_overview_metrics(game: Game) -> dict[str, Any]:
     }
 
 
-def _game_header(game: Game, request: HttpRequest, metrics: dict[str, Any]) -> SafeText:
+def _game_header(game: Game, request: HttpRequest, metrics: dict[str, Any]) -> Node:
     grey_value_class = "text-black dark:text-slate-300"
     title_span = Span(
         attributes=[("class", "text-balance max-w-120 text-4xl")],
@@ -670,7 +668,7 @@ def _game_header(game: Game, request: HttpRequest, metrics: dict[str, Any]) -> S
     )
 
 
-def _purchases_section(game: Game) -> SafeText:
+def _purchases_section(game: Game) -> Node:
     purchases = game.purchases.order_by("date_purchased")
     rows = [
         [
@@ -705,7 +703,7 @@ def _purchases_section(game: Game) -> SafeText:
     )
 
 
-def _sessions_section(game: Game, request: HttpRequest) -> SafeText:
+def _sessions_section(game: Game, request: HttpRequest) -> Node:
     sessions_all = game.sessions.order_by("-timestamp_start")
     session_count = sessions_all.count()
     last_session = sessions_all.latest() if sessions_all.exists() else None
@@ -743,7 +741,7 @@ def _sessions_section(game: Game, request: HttpRequest) -> SafeText:
                     ],
                 ),
             )
-            if last_session
+            if last_session and last_session.game
             else "",
         ],
     )
@@ -796,7 +794,7 @@ def _sessions_section(game: Game, request: HttpRequest) -> SafeText:
     )
 
 
-def _playevents_section(game: Game) -> SafeText:
+def _playevents_section(game: Game) -> Node:
     playevents = game.playevents.all()
     data = create_playevent_tabledata(playevents, exclude_columns=["Game"])
     table = SimpleTable(columns=data["columns"], rows=data["rows"])
@@ -822,22 +820,18 @@ def _playevents_section(game: Game) -> SafeText:
     )
 
 
-def _history_section(game: Game) -> SafeText:
-    statuschanges = game.status_changes.all()
+def _history_section(game: Game) -> Element:
+    statuschanges: QuerySet[GameStatusChange] = game.status_changes.all()
     return Div(
-        [
-            ("class", "mb-6"),
-            ("id", "history-container"),
-            ("hx-get", ""),
-            ("hx-trigger", "status-changed from:body"),
-            ("hx-select", "#history-container"),
-            ("hx-swap", "outerHTML"),
-        ],
-        [
-            H1(children=["History"], badge=statuschanges.count()),
-            _game_history(statuschanges),
-        ],
-    )
+        class_="mb-6",
+        id="history-container",
+        hx_trigger="status-changed from:body",
+        hx_select="#history-container",
+        hx_swap="outerHTML",
+    )[
+        H1(children=["History"], badge=str(statuschanges.count())),
+        _game_history(statuschanges),
+    ]
 
 
 _GET_SESSION_COUNT_SCRIPT = Safe(

--- a/games/views/game.py
+++ b/games/views/game.py
@@ -539,10 +539,10 @@ def _game_section(
         )
         header = Div(
             [("class", "flex items-center justify-between")],
-            [H1(children=[title], badge=str(count)), view_all_link],
+            [H1(children=[title], badge=str(count) if count else ""), view_all_link],
         )
     else:
-        header = H1(children=[title], badge=str(count))
+        header = H1(children=[title], badge=str(count) if count else "")
     return Div(
         [("class", "mb-6")],
         [
@@ -822,6 +822,7 @@ def _playevents_section(game: Game) -> Node:
 
 def _history_section(game: Game) -> Element:
     statuschanges: QuerySet[GameStatusChange] = game.status_changes.all()
+    count = statuschanges.count()
     return Div(
         class_="mb-6",
         id="history-container",
@@ -829,7 +830,7 @@ def _history_section(game: Game) -> Element:
         hx_select="#history-container",
         hx_swap="outerHTML",
     )[
-        H1(children=["History"], badge=str(statuschanges.count())),
+        H1(children=["History"], badge=str(count) if count else ""),
         _game_history(statuschanges),
     ]
 

--- a/games/views/playevent.py
+++ b/games/views/playevent.py
@@ -41,6 +41,8 @@ def create_playevent_tabledata(
     exclude_columns: list[str] = [],
     request: HttpRequest | None = None,
 ) -> TableData:
+    if isinstance(playevents, BaseManager):
+        playevents = playevents.all()
     column_list = [
         "Game",
         "Started",
@@ -175,6 +177,7 @@ def add_playevent(request: HttpRequest, game_id: int = 0) -> HttpResponse:
             try:
                 latest_playevent = game.playevents.latest("ended")
                 # Start date for the new PlayEvent form
+                assert latest_playevent.ended is not None
                 new_playevent_form_start_date = latest_playevent.ended + timedelta(
                     days=1
                 )

--- a/games/views/playevent.py
+++ b/games/views/playevent.py
@@ -176,20 +176,21 @@ def add_playevent(request: HttpRequest, game_id: int = 0) -> HttpResponse:
             # This will be either the day after the last playevent ended, or the earliest session.
             try:
                 latest_playevent = game.playevents.latest("ended")
-                # Start date for the new PlayEvent form
-                assert latest_playevent.ended is not None
+            except PlayEvent.DoesNotExist:
+                latest_playevent = None
+
+            if latest_playevent is not None and latest_playevent.ended is not None:
+                # Start the day after the last playevent ended.
                 new_playevent_form_start_date = latest_playevent.ended + timedelta(
                     days=1
                 )
                 initial["started"] = new_playevent_form_start_date
-
-                # Start timestamp for playtime calculation
                 playtime_calc_start_ts = datetime.combine(
                     new_playevent_form_start_date, datetime.min.time()
                 )
-
-            except PlayEvent.DoesNotExist:
-                # No previous playevents, so the new playevent starts from the earliest session.
+            else:
+                # No previous playevent (or none with an end date), so the new
+                # playevent starts from the earliest session.
                 earliest_session_ts = game.sessions.earliest(
                     "timestamp_start"
                 ).timestamp_start

--- a/games/views/purchase.py
+++ b/games/views/purchase.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import (
@@ -128,7 +126,7 @@ def _render_purchase_row(purchase):
 
 @login_required
 def list_purchases(request: HttpRequest) -> HttpResponse:
-    purchases: QuerySet[Any, Any] = Purchase.objects.select_related(
+    purchases: QuerySet[Purchase] = Purchase.objects.select_related(
         "platform"
     ).prefetch_related("games", "games__platform")
 

--- a/games/views/purchase.py
+++ b/games/views/purchase.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import (
@@ -6,6 +8,7 @@ from django.http import (
     HttpResponseRedirect,
 )
 from django.db import transaction
+from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404, redirect
 from django.template.defaultfilters import date as date_filter
 from django.template.defaultfilters import floatformat
@@ -125,9 +128,9 @@ def _render_purchase_row(purchase):
 
 @login_required
 def list_purchases(request: HttpRequest) -> HttpResponse:
-    purchases = Purchase.objects.select_related("platform").prefetch_related(
-        "games", "games__platform"
-    )
+    purchases: QuerySet[Any, Any] = Purchase.objects.select_related(
+        "platform"
+    ).prefetch_related("games", "games__platform")
 
     filter_json = request.GET.get("filter", "")
     if filter_json:

--- a/games/views/session.py
+++ b/games/views/session.py
@@ -127,7 +127,7 @@ def session_row(session: Session, device_list, csrf_token: str) -> Node:
 
 @login_required
 def list_sessions(request: HttpRequest, search_string: str = "") -> HttpResponse:
-    sessions: QuerySet[Any, Any] = Session.objects.select_related(
+    sessions: QuerySet[Session] = Session.objects.select_related(
         "game", "game__platform", "device"
     )
     device_list = Device.objects.order_by("name")

--- a/games/views/session.py
+++ b/games/views/session.py
@@ -2,7 +2,7 @@ from typing import Any, TypedDict
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404, redirect
@@ -37,6 +37,8 @@ from common.time import (
     timeformat,
 )
 from common.utils import paginate, truncate
+from django_htmx.middleware import HtmxDetails
+
 from games.forms import SessionForm
 from games.models import Device, Game, Session
 from games.sorting import (
@@ -45,6 +47,12 @@ from games.sorting import (
     apply_sort,
     parse_find_filter,
 )
+
+
+class HtmxHttpRequest(HttpRequest):
+    """HttpRequest with the ``htmx`` attribute django-htmx's middleware adds."""
+
+    htmx: HtmxDetails
 
 
 class SessionRowData(TypedDict):
@@ -126,7 +134,9 @@ def session_row(session: Session, device_list, csrf_token: str) -> Node:
 
 @login_required
 def list_sessions(request: HttpRequest, search_string: str = "") -> HttpResponse:
-    sessions = Session.objects.select_related("game", "game__platform", "device")
+    sessions: QuerySet[Any, Any] = Session.objects.select_related(
+        "game", "game__platform", "device"
+    )
     device_list = Device.objects.order_by("name")
 
     # ── Structured filter (JSON) ──
@@ -195,7 +205,7 @@ def list_sessions(request: HttpRequest, search_string: str = "") -> HttpResponse
                                 ],
                             ),
                         )
-                        if last_session
+                        if last_session and last_session.game
                         else "",
                     ]
                 ),
@@ -345,7 +355,7 @@ def clone_session_by_id(session_id: int) -> Session:
 
 @login_required
 def new_session_from_existing_session(
-    request: HttpRequest, session_id: int
+    request: HtmxHttpRequest, session_id: int
 ) -> HttpResponse:
     clone_session_by_id(session_id)
     if request.htmx:
@@ -358,7 +368,7 @@ def new_session_from_existing_session(
 
 
 @login_required
-def end_session(request: HttpRequest, session_id: int) -> HttpResponse:
+def end_session(request: HtmxHttpRequest, session_id: int) -> HttpResponse:
     session = get_object_or_404(Session, id=session_id)
     session.timestamp_end = timezone.now()
     session.save()
@@ -368,7 +378,7 @@ def end_session(request: HttpRequest, session_id: int) -> HttpResponse:
 
 
 @login_required
-def reset_session_start(request: HttpRequest, session_id: int) -> HttpResponse:
+def reset_session_start(request: HtmxHttpRequest, session_id: int) -> HttpResponse:
     session = get_object_or_404(Session, id=session_id)
     session.timestamp_start = timezone.now()
     session.save()

--- a/games/views/session.py
+++ b/games/views/session.py
@@ -37,8 +37,7 @@ from common.time import (
     timeformat,
 )
 from common.utils import paginate, truncate
-from django_htmx.middleware import HtmxDetails
-
+from common.http import HtmxHttpRequest
 from games.forms import SessionForm
 from games.models import Device, Game, Session
 from games.sorting import (
@@ -47,12 +46,6 @@ from games.sorting import (
     apply_sort,
     parse_find_filter,
 )
-
-
-class HtmxHttpRequest(HttpRequest):
-    """HttpRequest with the ``htmx`` attribute django-htmx's middleware adds."""
-
-    htmx: HtmxDetails
 
 
 class SessionRowData(TypedDict):

--- a/games/views/stats_content.py
+++ b/games/views/stats_content.py
@@ -27,6 +27,7 @@ from common.components import (
 from common.time import durationformat, format_duration
 from games.filters import filter_url
 from games.views import stats_links
+from games.views.stats_data import StatsData
 
 _CELL = "px-2 sm:px-4 md:px-6 md:py-2"
 _CELL_MONO = f"{_CELL} font-mono"
@@ -359,8 +360,8 @@ def _priced_table(purchases, currency, view_all_url=None, total=None) -> Node:
     return _table(rows, thead)
 
 
-def stats_content(ctx: dict) -> Node:
-    year = ctx.get("year")
+def stats_content(ctx: StatsData) -> Node:
+    year = ctx["year"]
     currency = ctx.get("total_spent_currency")
     # Build a navigation URL with an `__year__` placeholder the picker's JS
     # substitutes. Reverse a sentinel year, then swap it for the placeholder

--- a/games/views/stats_data.py
+++ b/games/views/stats_data.py
@@ -169,7 +169,7 @@ def compute_stats(year: int | None = None) -> StatsData:
                 first_session.timestamp_start.date(),
                 last_session.timestamp_start.date(),
             )
-            if first_session
+            if first_session and last_session
             else 0
         )
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "ruff",
     "pytest-django>=4.12.0",
     "pytest-playwright>=0.8.0",
+    "django-stubs[compatible-mypy]>=6.0.5",
 ]
 
 [tool.uv]
@@ -63,6 +64,16 @@ extend-exclude = [
     # it's excluded for now rather than contorted to satisfy the linter.
     "streak_bruteforce.py",
 ]
+
+[tool.mypy]
+plugins = ["mypy_django_plugin.main"]
+
+[tool.django-stubs]
+django_settings_module = "timetracker.settings"
+
+[[tool.mypy.overrides]]
+module = ["django_q.*", "django_htmx.*"]
+ignore_missing_imports = true
 
 [tool.isort]
  profile = "black"

--- a/timetracker/config.py
+++ b/timetracker/config.py
@@ -124,7 +124,9 @@ def derive_hosts_and_origins(
     Returns ``(allowed_hosts, csrf_trusted_origins)``.
     """
     parsed_urls = [urlparse(raw_url.strip()) for raw_url in app_url.split(",")]
-    allowed_hosts = [parsed_url.hostname for parsed_url in parsed_urls]
+    allowed_hosts = [
+        parsed_url.hostname for parsed_url in parsed_urls if parsed_url.hostname
+    ]
     csrf_trusted_origins = [
         f"{parsed_url.scheme}://{parsed_url.netloc}" for parsed_url in parsed_urls
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -251,6 +251,39 @@ wheels = [
 ]
 
 [[package]]
+name = "django-stubs"
+version = "6.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "django-stubs-ext" },
+    { name = "types-pyyaml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8a/8946216758eb66c5700a235e230af538d4ea474244c79452159b580425ba/django_stubs-6.0.5.tar.gz", hash = "sha256:7742b8e60afc68a8545158e2bdb103376d5a092f7902c17f370920a9c08eb957", size = 280490, upload-time = "2026-05-25T08:47:02.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/09/64ff51a4cf4e8bdf8423d249b32eca0676e69233009ce9cd5478ba2c9635/django_stubs-6.0.5-py3-none-any.whl", hash = "sha256:9fb9eede9b2fc47b36c3dc4a93652eb959dff45466ec4a580e4a22782192d746", size = 544132, upload-time = "2026-05-25T08:47:00.332Z" },
+]
+
+[package.optional-dependencies]
+compatible-mypy = [
+    { name = "mypy" },
+]
+
+[[package]]
+name = "django-stubs-ext"
+version = "6.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/01/419bc3cd882f3ec645d5a4511085202dd6bd3ef8d385871dcd2d32cc15b3/django_stubs_ext-6.0.5.tar.gz", hash = "sha256:1cc325e991303849bce70e19748981b225ef08b37256f263e113caf97cd3bcc0", size = 6666, upload-time = "2026-05-25T08:46:36.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/bf/7ee71071d84ad4e0efcd77e2681afed254a5f65c27524441a9caf8c60467/django_stubs_ext-6.0.5-py3-none-any.whl", hash = "sha256:a9932c8233d6dd4e34ae0b192026379c1a9be8f0b7c27aa1fa09ae215169773e", size = 10362, upload-time = "2026-05-25T08:46:34.467Z" },
+]
+
+[[package]]
 name = "django-template-partials"
 version = "24.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1044,6 +1077,7 @@ dependencies = [
 dev = [
     { name = "django-debug-toolbar" },
     { name = "django-extensions" },
+    { name = "django-stubs", extra = ["compatible-mypy"] },
     { name = "djhtml" },
     { name = "djlint" },
     { name = "isort" },
@@ -1075,6 +1109,7 @@ requires-dist = [
 dev = [
     { name = "django-debug-toolbar", specifier = ">=4.4.2,<5" },
     { name = "django-extensions", specifier = ">=3.2.3,<4" },
+    { name = "django-stubs", extras = ["compatible-mypy"], specifier = ">=6.0.5" },
     { name = "djhtml", specifier = ">=3.0.6,<4" },
     { name = "djlint", specifier = ">=1.34.1,<2" },
     { name = "isort", specifier = ">=5.13.2,<6" },
@@ -1097,6 +1132,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/05/0d5260f1f1ca784f4a4a0def9cbe6affe587f5b4025328d446c3d67765f4/tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add", size = 171923, upload-time = "2026-06-09T13:26:42.539Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/75/1a0392bcc21c44dcdf87b3cf2d137e7829be2c083a1e38d44efca3d57a16/tqdm-4.68.2-py3-none-any.whl", hash = "sha256:d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede", size = 78578, upload-time = "2026-06-09T13:26:40.731Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds `django-stubs` + the `mypy_django_plugin` so mypy actually type-checks Django code, fixes the **75 pre-existing errors** that surfaced once the plugin could see `django.*`, and makes mypy a **blocking CI gate**.

Before this, mypy skipped every `django.*` import as untyped and caught almost nothing.

## How

**Config**
- `pyproject.toml`: mypy plugin + `django_settings_module`, plus `ignore_missing_imports` for `django_q.*` / `django_htmx.*`.
- `Makefile`: `typecheck` target, folded into `make check`.
- `.github/workflows/build-docker.yml`: blocking `mypy .` step before tests.
- `.vscode/settings.json`: mypy extension as the editor checker, Pyright type-checking off (it can't run the plugin, so it can't see reverse relations).

**Code (75 errors, by cluster)**
- Component builders annotated `-> Node` (not `SafeText`); `str()` at the `HttpResponse` boundary; `Node.with_media` returns `Self`.
- Genuine None-safety guards on nullable `session.game` and `.first()`/`.latest()` results.
- `filters.py`: broadly-typed `matching_ids` locals; `int()`-cast game-id M2M lookups.
- SearchSelect/FilterSelect: typed normalized option lists; `list`→`Sequence` params; `SearchSelectOption.data` widened to `str | int` (it really holds ints).
- TypedDict args accepted as `Mapping`/`StatsData` instead of bare `dict`.
- `HtmxHttpRequest` type for `request.htmx`; misc single-site corrections.

## Verification

- `uv run mypy .` → `Success: no issues found in 127 source files`
- 602 unit tests pass; ruff lint + format clean.

## Follow-up

Found a separate component-system footgun while refactoring (htpy-style `[]` subscript silently escapes a bare list) — filed as #101, fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
