### PR TITLE
Render element children with no separator instead of "\n"

### DIFF
--- a/common/components/core.py
+++ b/common/components/core.py
@@ -200,8 +200,15 @@ def _render_element(
 
     ``attrs_key`` is (name, stringified value) pairs (values always escaped);
     ``children_key`` is (text, is_safe) pairs (safe passes through, else escaped).
+
+    Children are concatenated with no separator: in HTML, inter-element
+    whitespace is significant for inline content (a newline between two inline
+    spans renders as a space) and literal inside ``<pre>``/``<textarea>``. A
+    separator-less join matches the string-concatenation semantics the app used
+    before the node tree, and matches ``Fragment``'s default ``separator=""``.
+    For deliberate spacing, put it in an explicit child.
     """
-    children_blob = "\n".join(
+    children_blob = "".join(
         child if is_safe else escape(child) for child, is_safe in children_key
     )
     if attrs_key:

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -322,9 +322,11 @@ class ComponentEdgeCasesTest(unittest.TestCase):
         result = str(components.Element(tag_name="span", children="hello"))
         self.assertIn("hello", result)
 
-    def test_multiple_children_joined_with_newlines(self):
+    def test_multiple_children_concatenated_without_separator(self):
         result = str(components.Element(tag_name="div", children=["hello", "world"]))
-        self.assertIn("hello\nworld", result)
+        # Children join with no separator (inline whitespace is significant);
+        # explicit spacing must be its own child.
+        self.assertIn("helloworld", result)
         self.assertIn("<div>", result)
         self.assertIn("</div>", result)
 

--- a/tests/test_node_tree.py
+++ b/tests/test_node_tree.py
@@ -177,7 +177,18 @@ class HtpyStyleSugarTest(unittest.TestCase):
     def test_getitem_multiple_children(self):
         from common.components import Div
 
-        self.assertEqual(render(Div()["a", "b"]), "<div>a\nb</div>")
+        self.assertEqual(render(Div()["a", "b"]), "<div>ab</div>")
+
+    def test_children_join_without_separator(self):
+        """Children concatenate with no separator. A newline join would render
+        as a space between inline elements (e.g. "1 — 10" instead of "1—10")
+        and become literal content inside <pre>/<textarea>."""
+        from common.components import Element, Span
+
+        result = render(
+            Element("p", children=[Span()["1"], "—", Span()["10"]])
+        )
+        self.assertEqual(result, "<p><span>1</span>—<span>10</span></p>")
 
     def test_kwargs_class_underscore_becomes_class(self):
         from common.components import Div


### PR DESCRIPTION
## What
`_render_element` joined an element's children with `"\n"`. This changes the join to `""`.

## Why
The newline join was a cosmetic holdover, not a correctness requirement, and was actively wrong:
- **Inline content:** a newline between two inline elements renders as a space, so `<span>1</span>—<span>10</span>` showed `1 — 10` instead of `1—10` (surfaced in #109's pagination summary).
- **Whitespace-significant tags:** a newline between children of `<pre>` / `<textarea>` becomes literal content.

Joining with `""` matches the string-concatenation semantics the app used before the node tree, and matches `Fragment`'s default `separator=""` — the two sibling-join mechanisms now agree. Deliberate spacing must be an explicit child.

## Test
- `make test` → 699 passed (incl. e2e).
- `ruff` / `ruff format` / `mypy` clean.
- Updates the two tests that pinned the newline output; adds one asserting adjacent inline children concatenate without a phantom space.

## Relation to #109
This is the base of #109 (which is stacked on this branch). **Merge this first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)