### PR TITLE
Fix #101: flatten bare-list child in Element.__getitem__, fail loud on stray iterables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | Format Python | `make format` (or `uv run ruff format`) |
 | Lint Python | `make lint` (or `uv run ruff check`) |
 | Auto-fix lint | `make lint-fix` (`ruff check --fix`) |
-| Lint + format check + tests | `make check` (CI-style aggregate) |
+| Type check (mypy) | `make typecheck` (or `uv run mypy .`) |
+| Lint + format check + mypy + ts-check + tests | `make check` (CI-style aggregate) |
 | Sync uv.lock | `uv sync` (after editing pyproject.toml) |
 | Load platform fixtures | `make loadplatforms` |
 | Load sample data | `make loadsample` |
@@ -66,7 +67,8 @@ docs/           — Additional documentation
 - **`primitives.py`** — Generic HTML. Plain leaf builders (`A`, `Button`, `Div`, `Span`, `P`, `Ul`, `Li`, `Strong`, `Label`, `Template`, `Td`, `Tr`, `Th`, `Table`, `Thead`, `Tbody`, `Caption`, `Nav`) are **generated from a whitelist** via the `_html_element(tag)` factory over `Element` — not hand-written per tag. Builders that add classes/behaviour are written out: `StyledButton()`, `ButtonGroup()`, `Input()`, `Checkbox()`, `Radio()`, `Pill()`, `Icon()`, `Popover()`, `PopoverTruncated()`, `SearchField()`, `H1()`, `Modal()`, `StyledTable()`, `TableRow()`, `TableTd()`, `TableHeader()`, `paginated_table_content()`, `AddForm()`, `YearPicker()` (declares datepicker media), `CsrfInput()`/`ModuleScript()`/`StaticScript()` (script-tag string helpers used by `Page()`).
 - **`domain.py`** — Domain-specific: `GameLink()`, `GameStatus()` (colored dot + label), `GameStatusSelector()` (Alpine.js PATCH dropdown), `SessionDeviceSelector()` (Alpine.js PATCH dropdown), `LinkedPurchase()`, `NameWithIcon()`, `PriceConverted()`, `PurchasePrice()`
 - **`filters.py`** — Filter UI: `FilterBar()`, `SessionFilterBar()`, `PurchaseFilterBar()` (built from `FilterSelect` widgets)
-- **`search_select.py`** — `SearchSelect()` (form combobox) + `FilterSelect()` (include/exclude filter combobox with pinned Any/None modifiers) + `SearchSelectOption`, all built on a shared `_combobox_shell`; wired by `games/static/js/search_select.js`
+- **`search_select.py`** — `SearchSelect()` (form combobox) + `FilterSelect()` (include/exclude filter combobox with pinned Any/None modifiers) + `SearchSelectOption`, all built on a shared `_combobox_shell`; wired by `ts/elements/search-select.ts` (compiled to `dist/search_select.js`)
+- **`date_range_picker.py`** — `DateRangePicker()`/`DateRangeField()`/`DateRangeCalendar()` custom-element date-range widget (wired by `ts/elements/date-range-picker.ts`); used by filter bars
 
 **Filter system** (`games/filters.py` + `common/criteria.py`): Stash-inspired structured filtering.
 
@@ -82,6 +84,7 @@ docs/           — Additional documentation
 - `general.py` — `stats()`, `stats_alltime()`, `index()`, `model_counts` context processor, `global_current_year` context processor, `use_custom_redirect` decorator (redirects to `request.session["return_path"]` if set)
 - `stats_data.py` — `compute_stats(year)` returns a `StatsData` TypedDict; pure computation, no HTTP
 - `stats_content.py` — renders stats page content from a `StatsData` dict
+- `stats_links.py` — pure filter-link builders for stats rows/counts (issue #65); parity-tested so each builder's queryset count equals the stat it links from
 - `filter_presets.py` — `list_presets`, `save_preset`, `delete_preset`, `load_preset`
 - `auth.py` — custom `LoginView` subclassing Django's auth view, renders login page via `render_page()`
 
@@ -118,11 +121,11 @@ Only a small number of HTML templates remain (platform icon snippets and partial
 - **Flowbite** (vendored: `flowbite.min.js`; `datepicker.umd.js` for the stats YearPicker) — navbar collapse, dropdown toggles
 - **Tailwind CSS** — utility classes, compiled from `common/input.css` → `games/static/base.css`
 - All third-party JS is served locally from `games/static/js/` (no CDNs), so pages and browser tests work offline
-- **Custom JS** in `games/static/js/`:
-  - `toast.js` — Alpine.js toast store (listens for `show-toast` HTMX event); also defines `window.fetchWithHtmxTriggers`
-  - `search_select.js` — SearchSelect/FilterSelect widgets (search-as-you-type, pills, include/exclude filter mode)
-  - `utils.js` — shared ES-module helpers (`onSwap`, `toISOUTCString`, …)
-- **Widget initialization**: widget JS registers with `onSwap(selector, initializeElement)` from `utils.js` — a port of FastHTML's `proc_htmx` built on `htmx.onLoad`. It runs the initializer once per matching element, on initial page load and inside every htmx-swapped fragment. Never hand-roll `DOMContentLoaded`/`htmx:afterSwap` listeners with per-element guard flags.
+- **Custom JS** authored in TypeScript under `ts/`, compiled to `games/static/js/dist/` (gitignored, build-only):
+  - `ts/toast.ts` — Alpine.js toast store (listens for `show-toast` HTMX event); also defines `window.fetchWithHtmxTriggers`
+  - `ts/elements/search-select.ts` — SearchSelect/FilterSelect widgets (search-as-you-type, pills, include/exclude filter mode)
+  - `ts/utils.ts` — shared ES-module helpers (`onSwap`, `toISOUTCString`, …)
+- **Widget initialization**: widget JS registers with `onSwap(selector, initializeElement)` from `ts/utils.ts` — a port of FastHTML's `proc_htmx` built on `htmx.onLoad`. It runs the initializer once per matching element, on initial page load and inside every htmx-swapped fragment. Never hand-roll `DOMContentLoaded`/`htmx:afterSwap` listeners with per-element guard flags.
 
 ### Interactive components: custom elements + TypeScript
 

--- a/common/components/core.py
+++ b/common/components/core.py
@@ -14,7 +14,7 @@ Nodes are *lazy*: they hold structure and render to HTML only when asked
 """
 
 import hashlib
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from functools import lru_cache
 from typing import Self
 
@@ -187,6 +187,11 @@ def _child_key(child: object) -> tuple[str, bool]:
         return (child._render(), True)
     if isinstance(child, str):
         return (child, False)
+    if isinstance(child, Iterable):
+        raise TypeError(
+            f"Iterable child {child!r} of type {type(child).__name__} cannot be a "
+            f"child; unpack it with [*items] or wrap in Fragment(*items)."
+        )
     return (str(child), False)
 
 
@@ -247,9 +252,13 @@ class Element(Node):
         """htpy-style children: ``Div(class_="x")[child1, child2]``.
 
         Returns an Element with the same tag/attributes/media and these
-        children, so the tree stays walkable (Media still bubbles)."""
-        items = children if isinstance(children, tuple) else (children,)
-        clone = Element(self.tag_name, self.attributes, list(items))
+        children, so the tree stays walkable (Media still bubbles).
+
+        A subscripted tuple (``[a, b]``) and a single bare list (``[items]``)
+        both flatten to their elements via :func:`as_children`; a single
+        node/string becomes one child. Nested lists are *not* flattened — they
+        survive as children and fail loud in :func:`_child_key`."""
+        clone = Element(self.tag_name, self.attributes, as_children(children))
         clone.media = self.media
         return clone
 

--- a/tests/test_node_tree.py
+++ b/tests/test_node_tree.py
@@ -185,9 +185,7 @@ class HtpyStyleSugarTest(unittest.TestCase):
         and become literal content inside <pre>/<textarea>."""
         from common.components import Element, Span
 
-        result = render(
-            Element("p", children=[Span()["1"], "—", Span()["10"]])
-        )
+        result = render(Element("p", children=[Span()["1"], "—", Span()["10"]]))
         self.assertEqual(result, "<p><span>1</span>—<span>10</span></p>")
 
     def test_kwargs_class_underscore_becomes_class(self):
@@ -217,6 +215,38 @@ class HtpyStyleSugarTest(unittest.TestCase):
 
         node = Div(class_="x").with_media(Media(js=("a.js",)))["child"]
         self.assertEqual(collect_media(node).js, ("a.js",))
+
+    def test_getitem_flattens_bare_list(self):
+        """A bare list passed to ``[]`` flattens to its children (issue #101),
+        matching the unpacked ``[*items]`` and ``children=items`` forms instead
+        of stringifying the list's repr."""
+        from common.components import Li, Ul
+
+        items = [Li()["a"], Li()["b"]]
+        self.assertEqual(
+            render(Ul(class_="x")[items]),
+            '<ul class="x"><li>a</li><li>b</li></ul>',
+        )
+
+    def test_nested_list_child_raises(self):
+        """Nested lists are not flattened; a stray iterable child fails loud
+        rather than escaping to repr — on both render paths (subscript via
+        Element and the Fragment / children= kwarg path)."""
+        from common.components import Fragment, Span, Ul
+
+        with self.assertRaises(TypeError):
+            render(Ul()[[Span()["a"]], [Span()["b"]]])
+        with self.assertRaises(TypeError):
+            render(Fragment([Span()["a"]]))
+        with self.assertRaises(TypeError):
+            render(Element("span", children=[["a"]]))
+
+    def test_scalar_child_still_renders(self):
+        """A bare scalar child keeps the str() fallback (decision A): only
+        iterables raise, so int/Decimal/timedelta children render as before."""
+        from common.components import Span
+
+        self.assertEqual(render(Span(children=[42])), "<span>42</span>")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #101.

## Problem
`Element.__getitem__` only special-cased `tuple`, so a list passed via the subscript form became a single child and rendered the list's escaped `repr` — silent, no error. Easy to hit when refactoring `children=[...]` → `[...]`.

```python
items = [Li()["a"], Li()["b"]]
Ul(class_="x")[items]   # was: <ul class="x">[&lt;...Element object...&gt;, ...]</ul>
```

## Fix
- **`__getitem__`** normalizes children through the existing `as_children()` helper, flattening a bare list/tuple to its elements (matching `[*items]` and `children=items`). Reusing the typed helper keeps the tree walkable and passes mypy.
- **`_child_key`** raises an actionable `TypeError` on any stray **iterable** child (list/tuple/set/dict/generator) before the scalar `str()` fallback — so remaining misuse (e.g. nested lists) fails loud on both the `Element` and `Fragment` render paths. Bare scalars still render via `str()` (decision: guard targets the silent-escape class only, not all non-Node/str).

Nested lists (`Ul()[[a,b],[c,d]]`) are intentionally **not** recursively flattened — they now raise loudly instead of escaping silently.

## Tests (`tests/test_node_tree.py`)
- bare-list flattens to children (the repro)
- stray iterable raises on both render paths (subscript + `Fragment`/`children=`)
- scalar child (`42`) still renders

## Verification
`make check` — ruff, mypy, ts-check, 705 tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)