### PR TITLE
feat(layout): add SVG favicon

### DIFF
--- a/common/layout.py
+++ b/common/layout.py
@@ -541,6 +541,11 @@ def TimetrackerDocument(
                             name="viewport",
                             content="width=device-width, initial-scale=1.0",
                         ),
+                        Link(
+                            rel="icon",
+                            type="image/svg+xml",
+                            href=static("icons/tesserae-favicon.svg"),
+                        ),
                         Script(src=static("js/htmx.min.js")),
                         Script(src=static("js/flowbite.min.js")),
                         Script(src=static("js/dist/htmx-redirect-toast.js")),

--- a/games/static/icons/tesserae-favicon.svg
+++ b/games/static/icons/tesserae-favicon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Tesserae">
+  <title>Tesserae</title>
+  <rect x="0" y="0" width="64" height="64" rx="14" fill="#1A0B2E"/>
+  <g fill="#FF2A6D">
+    <rect x="20.5" y="12" width="6" height="6" rx="1"/>
+    <rect x="20.5" y="20.5" width="6" height="6" rx="1"/>
+    <rect x="20.5" y="29" width="6" height="6" rx="1"/>
+    <rect x="20.5" y="37.5" width="6" height="6" rx="1"/>
+    <rect x="20.5" y="46" width="6" height="6" rx="1"/>
+    <rect x="29" y="20.5" width="6" height="6" rx="1"/>
+    <rect x="29" y="29" width="6" height="6" rx="1"/>
+    <rect x="29" y="37.5" width="6" height="6" rx="1"/>
+    <rect x="37.5" y="29" width="6" height="6" rx="1"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Add the tesserae favicon (`games/static/icons/tesserae-favicon.svg`)
- Link it in the document head via `Link(rel="icon", type="image/svg+xml", ...)` in `common/layout.py`

SVG favicon served locally (no CDN), consistent with the project's offline-asset convention.

## Test plan
- `make test` / `pytest tests/test_rendered_pages.py` — 30 passed
- Verified `Link` renders `<link rel="icon" type="image/svg+xml" href="/static/icons/tesserae-favicon.svg">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)