### PR TITLE
fix(filters): round-trip cross-entity sub-filters + add finished filters

### DIFF
--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -98,11 +98,19 @@ def _filter_get_choice(existing: dict, field: str) -> FilterChoice:
 
 
 def _parse_range(existing: dict, key: str) -> RangeValues:
-    """Extract (min, max) from a range filter criterion, defaulting to ("", "")."""
+    """Extract (min, max) from a range filter criterion, defaulting to ("", "").
+
+    A one-sided range stores its single bound in ``value`` regardless of side
+    (GREATER_THAN → min, LESS_THAN → max), so the modifier decides which slot it
+    fills; only BETWEEN carries both ``value`` (min) and ``value2`` (max).
+    """
     field = existing.get(key, {})
     if not isinstance(field, dict):
         return RangeValues("", "")
-    return RangeValues(str(field.get("value", "")), str(field.get("value2", "")))
+    value = str(field.get("value", ""))
+    if field.get("modifier") == "LESS_THAN":
+        return RangeValues("", value)
+    return RangeValues(value, str(field.get("value2", "")))
 
 
 def _parse_number(existing: dict, key: str) -> NumberValues:
@@ -631,6 +639,7 @@ def _game_fields(
     session_avg = _parse_number(existing, "session_average")
     purchase_count = _parse_number(existing, "purchase_count")
     playevent_count = _parse_number(existing, "playevent_count")
+    finished_min, finished_max = _parse_range(existing, "finished")
     manual_pt = _parse_number(existing, "manual_playtime_hours")
     calc_pt = _parse_number(existing, "calculated_playtime_hours")
     price_total = _parse_number(existing, "purchase_price_total")
@@ -803,6 +812,15 @@ def _game_fields(
                         modifier=playevent_count.modifier,
                         placeholder="e.g. 1",
                         placeholder2="e.g. 5",
+                    ),
+                ),
+                _filter_field(
+                    "Finished",
+                    DateRangePicker(
+                        label="Finished",
+                        input_name_prefix="filter-finished",
+                        min_value=finished_min,
+                        max_value=finished_max,
                     ),
                 ),
                 _filter_field(
@@ -985,6 +1003,7 @@ def _purchase_fields(existing: dict) -> list:
     )
     date_purchased_min, date_purchased_max = _parse_range(existing, "date_purchased")
     date_refunded_min, date_refunded_max = _parse_range(existing, "date_refunded")
+    finished_min, finished_max = _parse_range(existing, "finished")
     num = _parse_number(existing, "num_purchases")
 
     fields = [
@@ -1072,6 +1091,15 @@ def _purchase_fields(existing: dict) -> list:
                         input_name_prefix="filter-date-refunded",
                         min_value=date_refunded_min,
                         max_value=date_refunded_max,
+                    ),
+                ),
+                _filter_field(
+                    "Finished",
+                    DateRangePicker(
+                        label="Finished",
+                        input_name_prefix="filter-finished",
+                        min_value=finished_min,
+                        max_value=finished_max,
                     ),
                 ),
                 _filter_field(

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -271,9 +271,8 @@ class BoolCriterion(_Criterion):
         # `value` is the whole payload here, so it must always serialize — the
         # base implementation omits fields equal to their default, which would
         # silently drop a meaningful ``value=False`` (e.g. is_refunded=False).
-        result: dict[str, Any] = {"value": self.value}
-        if self.modifier != Modifier.EQUALS:
-            result["modifier"] = self.modifier
+        result = super().to_json()
+        result["value"] = self.value
         return result
 
 
@@ -401,12 +400,16 @@ _CRITERION_TYPES: dict[str, type[_Criterion]] = {
     "ChoiceCriterion": ChoiceCriterion,
 }
 
-# Registry of OperatorFilter subclasses by name, so to_json/from_json can
-# round-trip cross-entity sub-filter fields (e.g. PurchaseFilter.game_filter,
-# GameFilter.playevent_filter). Populated by OperatorFilter.__init_subclass__
-# as each concrete filter class is defined (see games/filters.py). Mirrors
-# _CRITERION_TYPES for criterion fields.
+# Registry of OperatorFilter subclasses by name, so from_json can resolve a
+# cross-entity sub-filter field's type from its (string) annotation name — e.g.
+# PurchaseFilter.game_filter, GameFilter.playevent_filter. (to_json needs no
+# lookup; it dispatches structurally on isinstance.) Populated by
+# OperatorFilter.__init_subclass__ as each concrete filter class is defined (see
+# games/filters.py). Mirrors _CRITERION_TYPES for criterion fields.
 _FILTER_TYPES: dict[str, type["OperatorFilter"]] = {}
+
+# The three sub-filter composition fields, shared by every OperatorFilter.
+_OPERATOR_FIELDS: tuple[str, str, str] = ("AND", "OR", "NOT")
 
 
 def _criterion_class_for(
@@ -516,7 +519,7 @@ class OperatorFilter:
 
     def sub_filter(self) -> OperatorFilter | None:
         """Return the first non-None of AND / OR / NOT."""
-        for attr in ("AND", "OR", "NOT"):
+        for attr in _OPERATOR_FIELDS:
             if hasattr(self, attr):
                 v = getattr(self, attr)
                 if v is not None:
@@ -527,7 +530,7 @@ class OperatorFilter:
         """Return field names that hold a _Criterion instance."""
         names: list[str] = []
         for f in dc_fields(self):
-            if f.name in ("AND", "OR", "NOT"):
+            if f.name in _OPERATOR_FIELDS:
                 continue
             v = getattr(self, f.name)
             if isinstance(v, _Criterion):
@@ -566,7 +569,7 @@ class OperatorFilter:
                 kwargs[f.name] = None
                 continue
             # Recurse into sub-filters (AND / OR / NOT)
-            if f.name in ("AND", "OR", "NOT"):
+            if f.name in _OPERATOR_FIELDS:
                 kwargs[f.name] = cls.from_json(raw) if isinstance(raw, dict) else None
                 continue
             # Resolve criterion fields from string type annotation
@@ -598,15 +601,16 @@ class OperatorFilter:
             v = getattr(self, f.name)
             if v is None:
                 continue
-            if f.name in ("AND", "OR", "NOT"):
+            if f.name in _OPERATOR_FIELDS:
                 result[f.name] = v.to_json()
             elif isinstance(v, _Criterion):
                 j = v.to_json()
                 if j:
                     result[f.name] = j
             # Cross-entity sub-filter field (game_filter, playevent_filter, …).
-            # AND/OR/NOT are OperatorFilter too but handled above, so exclude them.
-            elif isinstance(v, OperatorFilter) and f.name not in ("AND", "OR", "NOT"):
+            # AND/OR/NOT already matched the first branch; the name guard is
+            # belt-and-suspenders against a future reordering of these branches.
+            elif isinstance(v, OperatorFilter) and f.name not in _OPERATOR_FIELDS:
                 j = v.to_json()
                 if j:
                     result[f.name] = j

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -267,6 +267,15 @@ class BoolCriterion(_Criterion):
             return ~Q(**{field_name: self.value})
         raise ValueError(f"Unsupported modifier {self.modifier} for bool field")
 
+    def to_json(self) -> dict[str, Any]:
+        # `value` is the whole payload here, so it must always serialize — the
+        # base implementation omits fields equal to their default, which would
+        # silently drop a meaningful ``value=False`` (e.g. is_refunded=False).
+        result: dict[str, Any] = {"value": self.value}
+        if self.modifier != Modifier.EQUALS:
+            result["modifier"] = self.modifier
+        return result
+
 
 @dataclass
 class _SetCriterion(_Criterion):
@@ -392,6 +401,13 @@ _CRITERION_TYPES: dict[str, type[_Criterion]] = {
     "ChoiceCriterion": ChoiceCriterion,
 }
 
+# Registry of OperatorFilter subclasses by name, so to_json/from_json can
+# round-trip cross-entity sub-filter fields (e.g. PurchaseFilter.game_filter,
+# GameFilter.playevent_filter). Populated by OperatorFilter.__init_subclass__
+# as each concrete filter class is defined (see games/filters.py). Mirrors
+# _CRITERION_TYPES for criterion fields.
+_FILTER_TYPES: dict[str, type["OperatorFilter"]] = {}
+
 
 def _criterion_class_for(
     cls: type["OperatorFilter"], field_name: str
@@ -444,6 +460,12 @@ class OperatorFilter:
             name: StringCriterion | None = None
             ...
     """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # Register concrete filter classes so from_json can resolve a
+        # cross-entity sub-filter field's type by its annotation name.
+        _FILTER_TYPES[cls.__name__] = cls
 
     @classmethod
     def where(cls: type[F], **lookups: Any) -> F:
@@ -561,6 +583,13 @@ class OperatorFilter:
                 kwargs[f.name] = (
                     f_type.from_json(raw) if isinstance(raw, dict) else None
                 )
+            # Cross-entity sub-filter field (e.g. game_filter, playevent_filter):
+            # resolve the filter class by its annotation name and recurse.
+            elif isinstance(f_type, str) and f_type in _FILTER_TYPES:
+                filter_cls = _FILTER_TYPES[f_type]
+                kwargs[f.name] = (
+                    filter_cls.from_json(raw) if isinstance(raw, dict) else None
+                )
         return cls(**kwargs)
 
     def to_json(self) -> dict[str, Any]:
@@ -572,6 +601,12 @@ class OperatorFilter:
             if f.name in ("AND", "OR", "NOT"):
                 result[f.name] = v.to_json()
             elif isinstance(v, _Criterion):
+                j = v.to_json()
+                if j:
+                    result[f.name] = j
+            # Cross-entity sub-filter field (game_filter, playevent_filter, …).
+            # AND/OR/NOT are OperatorFilter too but handled above, so exclude them.
+            elif isinstance(v, OperatorFilter) and f.name not in ("AND", "OR", "NOT"):
                 j = v.to_json()
                 if j:
                     result[f.name] = j

--- a/e2e/test_date_range_picker_e2e.py
+++ b/e2e/test_date_range_picker_e2e.py
@@ -63,7 +63,10 @@ urlpatterns = [
 ]
 
 
-PICKER = "date-range-picker"
+# PurchaseFilterBar renders several date-range-pickers (Purchased, Refunded,
+# Finished); scope to the Purchased one — the only picker this module drives —
+# by the hidden input its prefix produces, so the locators stay unambiguous.
+PICKER = 'date-range-picker:has(input[name="filter-date-purchased-min"])'
 POPUP = PICKER + " [data-date-range-calendar]"
 HIDDEN_MIN = 'input[name="filter-date-purchased-min"]'
 HIDDEN_MAX = 'input[name="filter-date-purchased-max"]'

--- a/games/filters.py
+++ b/games/filters.py
@@ -100,6 +100,10 @@ class GameFilter(OperatorFilter):
     # Cross-entity: substring match against the game's playevent notes
     playevent_note: StringCriterion | None = None
 
+    # Cross-entity: game has a playevent whose `ended` date is in range
+    # (i.e. the game was finished in that window). See PlayEvent.ended.
+    finished: DateCriterion | None = None
+
     # Free-text search (combines name + sort_name + platform name)
     search: StringCriterion | None = None
 
@@ -183,6 +187,18 @@ class GameFilter(OperatorFilter):
             matching_ids = (
                 Game.objects.annotate(pe_count=Count("playevents", distinct=True))
                 .filter(self.playevent_count.to_q("pe_count"))
+                .values_list("id", flat=True)
+            )
+            q &= Q(id__in=matching_ids)
+
+        if self.finished is not None:
+            from games.models import Game
+
+            # Games with a playevent whose `ended` date is in range. distinct()
+            # collapses the row-per-playevent fan-out of the reverse relation.
+            matching_ids = (
+                Game.objects.filter(self.finished.to_q("playevents__ended"))
+                .distinct()
                 .values_list("id", flat=True)
             )
             q &= Q(id__in=matching_ids)
@@ -600,6 +616,8 @@ class PurchaseFilter(OperatorFilter):
     games: ChoiceCriterion | None = None  # games (M2M IDs)
     date_purchased: DateCriterion | None = None
     date_refunded: DateCriterion | None = None
+    # Cross-entity: purchase of a game finished in range (PlayEvent.ended).
+    finished: DateCriterion | None = None
     is_refunded: BoolCriterion | None = None  # date_refunded IS NOT NULL
     price: FloatCriterion | None = None  # on price field
     converted_price: FloatCriterion | None = None
@@ -636,6 +654,18 @@ class PurchaseFilter(OperatorFilter):
             q &= self.date_purchased.to_q("date_purchased")
         if self.date_refunded is not None:
             q &= self.date_refunded.to_q("date_refunded")
+        if self.finished is not None:
+            from games.models import Game
+
+            # Purchases whose game has a playevent ended in range. Resolve the
+            # matching game ids first (distinct) so the reverse-relation join
+            # doesn't multiply purchase rows.
+            finished_game_ids: MatchingIdQuerySet = (
+                Game.objects.filter(self.finished.to_q("playevents__ended"))
+                .distinct()
+                .values_list("id", flat=True)
+            )
+            q &= Q(games__id__in=finished_game_ids)
         if self.is_refunded is not None:
             q &= Q(date_refunded__isnull=not self.is_refunded.value)
         if self.price is not None:

--- a/games/filters.py
+++ b/games/filters.py
@@ -657,9 +657,10 @@ class PurchaseFilter(OperatorFilter):
         if self.finished is not None:
             from games.models import Game
 
-            # Purchases whose game has a playevent ended in range. Resolve the
-            # matching game ids first (distinct) so the reverse-relation join
-            # doesn't multiply purchase rows.
+            # Match via a game-id subquery instead of traversing
+            # games__playevents__ended directly, so the playevents join stays out
+            # of the purchase query. (The games M2M join can still duplicate
+            # rows; callers apply .distinct(), as with the game_filter block.)
             finished_game_ids: MatchingIdQuerySet = (
                 Game.objects.filter(self.finished.to_q("playevents__ended"))
                 .distinct()

--- a/games/sorting.py
+++ b/games/sorting.py
@@ -76,6 +76,10 @@ GAME_SORTS: SortMap = {
     "playtime": SortSpec(
         "total_playtime", {"total_playtime": Sum("sessions__duration_total")}
     ),
+    # No annotate dict: list_games pre-annotates `filtered_playtime` (playtime
+    # restricted to the active session sub-filter) on the queryset, and this
+    # spec just orders by that existing alias.
+    "filtered_playtime": SortSpec("filtered_playtime"),
     "finished": SortSpec("last_finished", {"last_finished": Max("playevents__ended")}),
 }
 GAME_DEFAULT_SORT: SortString = "-created"

--- a/games/views/game.py
+++ b/games/views/game.py
@@ -1,8 +1,9 @@
+from datetime import timedelta
 from typing import Any
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.db.models import Q, QuerySet
+from django.db.models import F, OuterRef, Q, QuerySet, Subquery, Sum
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404, redirect
@@ -59,7 +60,7 @@ from games.filters import (
 )
 from games.formatting import session_time_range
 from games.forms import GameForm
-from games.models import Game, GameStatusChange
+from games.models import Game, GameStatusChange, Session
 from games.sorting import GAME_DEFAULT_SORT, GAME_SORTS, apply_sort, parse_find_filter
 from games.views.general import use_custom_redirect
 from games.views.playevent import create_playevent_tabledata
@@ -69,12 +70,19 @@ from games.views.playevent import create_playevent_tabledata
 def list_games(request: HttpRequest, search_string: str = "") -> HttpResponse:
     games = Game.objects.select_related("platform")
 
+    # Playtime column sums only the sessions matching the active session
+    # sub-filter; an empty Q matches every session, so with no session filter the
+    # column shows total playtime.
+    session_q = Q()
+
     # ── Structured filter (Stash-style JSON) ──
     filter_json = request.GET.get("filter", "")
     if filter_json:
         game_filter = parse_game_filter(filter_json)
         if game_filter is not None:
             games = games.filter(game_filter.to_q())
+            if game_filter.session_filter is not None:
+                session_q = game_filter.session_filter.to_q()
     else:
         # ── Legacy free-text search ──
         search_string = request.GET.get("search_string", search_string)
@@ -97,6 +105,17 @@ def list_games(request: HttpRequest, search_string: str = "") -> HttpResponse:
                     filters.append(Q(status=search_status))
             games = games.filter(build_dynamic_filter(filters, "|"))
 
+    # Per-game playtime restricted to the session sub-filter, summed in the DB.
+    # session_q stays in Session's own field namespace via the correlated
+    # subquery, so no `sessions__` path-prefixing is needed.
+    windowed_playtime = (
+        Session.objects.filter(session_q, game=OuterRef("pk"))
+        .values("game")
+        .annotate(total=Sum(F("duration_calculated") + F("duration_manual")))
+        .values("total")
+    )
+    games = games.annotate(filtered_playtime=Subquery(windowed_playtime))
+
     sort = apply_sort(games, parse_find_filter(request), GAME_SORTS, GAME_DEFAULT_SORT)
     games = sort.queryset
     for key in sort.unknown:
@@ -115,6 +134,7 @@ def list_games(request: HttpRequest, search_string: str = "") -> HttpResponse:
             Column("Name", "name"),
             Column("Sort Name", "sort_name"),
             Column("Year", "year"),
+            Column("Playtime", "filtered_playtime"),
             Column("Status", "status"),
             Column("Wikidata", "wikidata"),
             Column("Created", "created"),
@@ -130,6 +150,7 @@ def list_games(request: HttpRequest, search_string: str = "") -> HttpResponse:
                     else "(identical)"
                 ),
                 str(game.year_released),
+                format_duration(game.filtered_playtime or timedelta(0), "%2.1H"),
                 GameStatusSelector(game, Game.Status.choices, get_token(request)),
                 game.wikidata,
                 local_strftime(game.created_at, dateformat),

--- a/games/views/purchase.py
+++ b/games/views/purchase.py
@@ -50,7 +50,7 @@ from common.layout import render_page
 from common.time import dateformat
 from common.utils import paginate
 from games.forms import PurchaseForm
-from games.models import Game, Purchase
+from games.models import Game, PlayEvent, Purchase
 from games.sorting import (
     PURCHASE_DEFAULT_SORT,
     PURCHASE_SORTS,
@@ -107,12 +107,25 @@ def _render_purchase_buttons(purchase_id, is_refunded, can_split=False):
 
 def _render_purchase_row(purchase: Purchase) -> TableRowData:
     """Return a row for simple-table rendering."""
+    # TODO: simplify if multiple purchases are no longer allowed
+    date_finished = "-"
+    try:
+        latest_play_event = PlayEvent.objects.filter(
+            game__in=purchase.games.all(),
+            ended__isnull=False,
+        ).latest("ended")
+        if latest_play_event:
+            if latest_play_event.ended:
+                date_finished = latest_play_event.ended.strftime(dateformat)
+    except PlayEvent.DoesNotExist:
+        pass
     return make_row(
         LinkedPurchase(purchase),
         purchase.get_type_display(),
         PurchasePrice(purchase),
         str(purchase.infinite),
         purchase.date_purchased.strftime(dateformat),
+        date_finished,
         (
             purchase.date_refunded.strftime(dateformat)
             if purchase.date_refunded
@@ -161,6 +174,7 @@ def list_purchases(request: HttpRequest) -> HttpResponse:
             Column("Price", "price"),
             Column("Infinite", "infinite"),
             Column("Purchased", "purchased"),
+            Column("Finished", "finished"),
             Column("Refunded", "refunded"),
             Column("Created", "created"),
             Column("Actions", align="right"),

--- a/games/views/stats_content.py
+++ b/games/views/stats_content.py
@@ -431,7 +431,7 @@ def stats_content(ctx: StatsData) -> Node:
             _finished_table(
                 all_finished,
                 view_all_url=filter_url(
-                    stats_links.purchases_finished(year), sort="finished"
+                    stats_links.purchases_finished(year), sort="-finished"
                 ),
                 total=ctx.get("all_finished_this_year_count"),
             ),

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -441,6 +441,27 @@ class FilterBarRenderingTest(TestCase):
             html,
         )
 
+    def test_finished_filter_prepopulates_greater_than_into_min(self):
+        """A GREATER_THAN (min-only) finished filter fills the min slot — the
+        symmetric counterpart to the LESS_THAN case above."""
+        filter_json = json.dumps(
+            {"finished": {"value": "2024-01-01", "modifier": "GREATER_THAN"}}
+        )
+        html = str(
+            PurchaseFilterBar(
+                filter_json=filter_json,
+                preset_list_url="/l",
+                preset_save_url="/s",
+            )
+        )
+        self.assertIn(
+            'name="filter-finished-min" id="filter-finished-min" value="2024-01-01"',
+            html,
+        )
+        self.assertIn(
+            'name="filter-finished-max" id="filter-finished-max" value=""', html
+        )
+
     def test_boolean_fields_render_as_radio_groups(self):
         """Boolean fields must render as radio groups with True/False choices."""
         from common.components import FilterBar, SessionFilterBar, PurchaseFilterBar

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -402,6 +402,45 @@ class FilterBarRenderingTest(TestCase):
             html,
         )
 
+    def test_purchase_filter_bar_renders_finished_dates(self):
+        """PurchaseFilterBar exposes the #121 'Finished' date-range widget."""
+        html = str(
+            PurchaseFilterBar(
+                filter_json="", preset_list_url="/l", preset_save_url="/s"
+            )
+        )
+        self.assertIn('name="filter-finished-min"', html)
+        self.assertIn('name="filter-finished-max"', html)
+
+    def test_game_filter_bar_renders_finished_dates(self):
+        """The Game filter bar exposes the #121 'Finished' date-range widget."""
+        from common.components import FilterBar
+
+        html = str(FilterBar(filter_json=""))
+        self.assertIn('name="filter-finished-min"', html)
+        self.assertIn('name="filter-finished-max"', html)
+
+    def test_finished_filter_prepopulates_less_than_into_max(self):
+        """A LESS_THAN (max-only) finished filter fills the max slot, not min —
+        guards the modifier-aware _parse_range fix."""
+        filter_json = json.dumps(
+            {"finished": {"value": "2024-12-31", "modifier": "LESS_THAN"}}
+        )
+        html = str(
+            PurchaseFilterBar(
+                filter_json=filter_json,
+                preset_list_url="/l",
+                preset_save_url="/s",
+            )
+        )
+        self.assertIn(
+            'name="filter-finished-min" id="filter-finished-min" value=""', html
+        )
+        self.assertIn(
+            'name="filter-finished-max" id="filter-finished-max" value="2024-12-31"',
+            html,
+        )
+
     def test_boolean_fields_render_as_radio_groups(self):
         """Boolean fields must render as radio groups with True/False choices."""
         from common.components import FilterBar, SessionFilterBar, PurchaseFilterBar

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -810,6 +810,11 @@ class TestExpandedFiltersAgainstDB:
                 }
             }
         )
+        # The cross-entity sub-filters must actually deserialize — otherwise the
+        # query is unconstrained and the assertion below passes by accident on a
+        # single-device fixture (issue #120 false positive).
+        assert df.session_filter is not None
+        assert df.session_filter.game_filter is not None
         results = list(Device.objects.filter(df.to_q()))
         assert data["dev"] in results
 
@@ -1281,6 +1286,53 @@ class TestPurchaseFilterDates:
         assert out["date_purchased"]["modifier"] == Modifier.BETWEEN
         assert out["date_refunded"]["modifier"] == Modifier.NOT_NULL
 
+    @pytest.mark.django_db
+    def test_cross_entity_subfilter_json_round_trip(self):
+        """A PurchaseFilter nesting game_filter → playevent_filter survives the
+        JSON round-trip the stats links / list views perform (issue #120)."""
+        from games.filters import GameFilter, PlayEventFilter, PurchaseFilter
+
+        original = PurchaseFilter(
+            game_filter=GameFilter(
+                playevent_filter=PlayEventFilter(
+                    ended=DateCriterion(
+                        value="2024-01-01",
+                        value2="2024-12-31",
+                        modifier=Modifier.BETWEEN,
+                    )
+                )
+            )
+        )
+        out = original.to_json()
+        # The nested structure must actually be serialized, not dropped.
+        assert out["game_filter"]["playevent_filter"]["ended"]["value"] == "2024-01-01"
+
+        restored = PurchaseFilter.from_json(json.loads(json.dumps(out)))
+        assert restored.game_filter is not None
+        assert restored.game_filter.playevent_filter is not None
+        ended = restored.game_filter.playevent_filter.ended
+        assert isinstance(ended, DateCriterion)
+        assert ended.value2 == "2024-12-31"
+        assert str(restored.to_q()) == str(original.to_q())
+
+    def test_flat_finished_field_round_trip(self):
+        """The flat `finished` DateCriterion on Game/Purchase filters (#121)
+        round-trips through JSON like any other criterion field."""
+        from games.filters import GameFilter, PurchaseFilter
+
+        for cls in (GameFilter, PurchaseFilter):
+            payload = {
+                "finished": {
+                    "value": "2024-01-01",
+                    "value2": "2024-12-31",
+                    "modifier": "BETWEEN",
+                }
+            }
+            obj = cls.from_json(payload)
+            assert isinstance(obj.finished, DateCriterion)
+            out = obj.to_json()
+            assert out == payload
+
 
 class TestPlayEventFilterDates:
     """End-to-end: a PlayEventFilter built from JSON narrows the queryset
@@ -1378,3 +1430,73 @@ class TestPlayEventFilterDates:
         assert out["ended"]["value2"] == "2024-12-31"
         assert out["ended"]["modifier"] == Modifier.BETWEEN
         assert out["started"]["modifier"] == Modifier.GREATER_THAN
+
+
+class TestFinishedFilter:
+    """The flat `finished` DateCriterion (#121): a game/purchase is matched when
+    the game has a PlayEvent whose `ended` date falls in the range."""
+
+    def _seed(self):
+        import datetime
+
+        from games.models import Game, Platform, PlayEvent, Purchase
+
+        pc = Platform.objects.create(name="PC")
+        in_range = Game.objects.create(name="Done2024", platform=pc)
+        out_range = Game.objects.create(name="Done2023", platform=pc)
+        never = Game.objects.create(name="Unfinished", platform=pc)
+        PlayEvent.objects.create(game=in_range, ended=datetime.date(2024, 6, 1))
+        PlayEvent.objects.create(game=out_range, ended=datetime.date(2023, 6, 1))
+        # never: no playevent with an `ended` date
+        PlayEvent.objects.create(game=never, started=datetime.date(2024, 1, 1))
+
+        p_in = Purchase.objects.create(
+            type=Purchase.GAME, date_purchased=datetime.date(2024, 1, 1)
+        )
+        p_in.games.set([in_range])
+        p_out = Purchase.objects.create(
+            type=Purchase.GAME, date_purchased=datetime.date(2023, 1, 1)
+        )
+        p_out.games.set([out_range])
+        return {
+            "in_range": in_range,
+            "out_range": out_range,
+            "never": never,
+            "p_in": p_in,
+            "p_out": p_out,
+        }
+
+    @pytest.mark.django_db
+    def test_game_finished_in_range(self):
+        from games.filters import GameFilter
+        from games.models import Game
+
+        data = self._seed()
+        gf = GameFilter.where(finished__between=("2024-01-01", "2024-12-31"))
+        results = set(Game.objects.filter(gf.to_q()).distinct())
+        assert results == {data["in_range"]}
+
+    @pytest.mark.django_db
+    def test_purchase_finished_in_range(self):
+        from games.filters import PurchaseFilter
+        from games.models import Purchase
+
+        data = self._seed()
+        pf = PurchaseFilter.where(finished__between=("2024-01-01", "2024-12-31"))
+        results = set(Purchase.objects.filter(pf.to_q()).distinct())
+        assert results == {data["p_in"]}
+
+    @pytest.mark.django_db
+    def test_game_finished_no_duplicate_rows(self):
+        """A game with several finished playevents in range appears once."""
+        import datetime
+
+        from games.filters import GameFilter
+        from games.models import Game, Platform, PlayEvent
+
+        pc = Platform.objects.create(name="PC")
+        game = Game.objects.create(name="Multi", platform=pc)
+        PlayEvent.objects.create(game=game, ended=datetime.date(2024, 3, 1))
+        PlayEvent.objects.create(game=game, ended=datetime.date(2024, 9, 1))
+        gf = GameFilter.where(finished__between=("2024-01-01", "2024-12-31"))
+        assert Game.objects.filter(gf.to_q()).distinct().count() == 1

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -119,6 +119,15 @@ class TestBoolCriterion:
         c = BoolCriterion(value=True, modifier=Modifier.EQUALS)
         assert c.to_q("mastered") == Q(mastered=True)
 
+    def test_value_false_survives_to_json(self):
+        """value=False must serialize — it equals the dataclass default, so the
+        base to_json would drop it, losing e.g. is_refunded=False."""
+        assert BoolCriterion(value=False).to_json() == {"value": False}
+
+    def test_value_false_round_trip(self):
+        restored = BoolCriterion.from_json(BoolCriterion(value=False).to_json())
+        assert restored.value is False
+
 
 class TestChoiceCriterion:
     def test_includes(self):
@@ -1315,6 +1324,13 @@ class TestPurchaseFilterDates:
         assert ended.value2 == "2024-12-31"
         assert str(restored.to_q()) == str(original.to_q())
 
+    def test_empty_subfilter_is_omitted_not_serialized_as_empty(self):
+        """An all-None sub-filter contributes no constraint, so to_json omits it
+        entirely rather than emitting `{"game_filter": {}}`."""
+        from games.filters import GameFilter, PurchaseFilter
+
+        assert PurchaseFilter(game_filter=GameFilter()).to_json() == {}
+
     def test_flat_finished_field_round_trip(self):
         """The flat `finished` DateCriterion on Game/Purchase filters (#121)
         round-trips through JSON like any other criterion field."""
@@ -1485,6 +1501,28 @@ class TestFinishedFilter:
         pf = PurchaseFilter.where(finished__between=("2024-01-01", "2024-12-31"))
         results = set(Purchase.objects.filter(pf.to_q()).distinct())
         assert results == {data["p_in"]}
+
+    @pytest.mark.django_db
+    def test_game_finished_greater_than_min_only(self):
+        """A min-only (GREATER_THAN) finished bound maps to playevents__ended__gt."""
+        from games.filters import GameFilter
+        from games.models import Game
+
+        data = self._seed()
+        gf = GameFilter.where(finished__gt="2024-01-01")
+        results = set(Game.objects.filter(gf.to_q()).distinct())
+        assert results == {data["in_range"]}
+
+    @pytest.mark.django_db
+    def test_purchase_finished_less_than_max_only(self):
+        """A max-only (LESS_THAN) finished bound maps to playevents__ended__lt."""
+        from games.filters import PurchaseFilter
+        from games.models import Purchase
+
+        data = self._seed()
+        pf = PurchaseFilter.where(finished__lt="2024-01-01")
+        results = set(Purchase.objects.filter(pf.to_q()).distinct())
+        assert results == {data["p_out"]}
 
     @pytest.mark.django_db
     def test_game_finished_no_duplicate_rows(self):

--- a/tests/test_stats_links.py
+++ b/tests/test_stats_links.py
@@ -262,8 +262,8 @@ _NESTED_BUILDERS = [
 @pytest.mark.parametrize("name,builder,model", _NESTED_BUILDERS)
 def test_nested_builder_survives_json_round_trip(world, name, builder, model):
     filter_obj = builder()
-    # Guard: the builder actually carries a nested cross-entity sub-filter, so
-    # this test is meaningful (a flat-only filter would round-trip trivially).
+    # Sanity check: the builder serialized to a non-empty payload (Session
+    # builders are exempt — sessions_for_platform may serialize flat-only).
     serialized = filter_obj.to_json()
     assert serialized != {} or model is Session, f"{name}: nothing serialized"
     assert _count_via_json(filter_obj, model) == _count(filter_obj, model), (

--- a/tests/test_stats_links.py
+++ b/tests/test_stats_links.py
@@ -9,6 +9,7 @@ are separate single-game purchases), where the filter system's id-set semantics
 match the stats queries' M2M traversal exactly.
 """
 
+import json
 from datetime import datetime, timezone
 
 import pytest
@@ -78,6 +79,17 @@ def world(db):
 
 def _count(filter_obj, model):
     return model.objects.filter(filter_obj.to_q()).distinct().count()
+
+
+def _count_via_json(filter_obj, model):
+    """Count after a full JSON round-trip, mirroring what a clicked stats link
+    does: serialize to the ``?filter=`` payload and deserialize in the view.
+
+    On the pre-fix serializer this drops cross-entity sub-filters (issue #120),
+    so the count diverges from the in-memory ``_count`` for nested builders.
+    """
+    restored = type(filter_obj).from_json(json.loads(json.dumps(filter_obj.to_json())))
+    return model.objects.filter(restored.to_q()).distinct().count()
 
 
 # ── Per-row session links ────────────────────────────────────────────────────
@@ -209,4 +221,59 @@ def test_finished_alltime_matches_backlog(world):
     assert (
         _count(stats_links.purchases_backlog_decrease("Alltime"), Purchase)
         == stats["backlog_decrease_count"]
+    )
+
+
+# ── JSON round-trip parity (issue #120) ──────────────────────────────────────
+#
+# Builders that nest cross-entity sub-filters (game_filter / session_filter /
+# playevent_filter). Before the serialization fix these serialized to an empty
+# or partial `?filter=`, so a clicked link landed on an unfiltered list. Each
+# must survive the same to_json → from_json the view performs.
+
+_NESTED_BUILDERS = [
+    ("purchases_finished", lambda: stats_links.purchases_finished(YEAR), Purchase),
+    (
+        "purchases_finished_released",
+        lambda: stats_links.purchases_finished_released(YEAR),
+        Purchase,
+    ),
+    (
+        "purchases_bought_and_finished",
+        lambda: stats_links.purchases_bought_and_finished(YEAR),
+        Purchase,
+    ),
+    ("purchases_dropped", lambda: stats_links.purchases_dropped(YEAR), Purchase),
+    ("purchases_unfinished", lambda: stats_links.purchases_unfinished(YEAR), Purchase),
+    (
+        "purchases_backlog_decrease",
+        lambda: stats_links.purchases_backlog_decrease(YEAR),
+        Purchase,
+    ),
+    ("games_played", lambda: stats_links.games_played(YEAR), Game),
+    (
+        "sessions_for_platform",
+        lambda: stats_links.sessions_for_platform(1, YEAR),
+        Session,
+    ),
+]
+
+
+@pytest.mark.parametrize("name,builder,model", _NESTED_BUILDERS)
+def test_nested_builder_survives_json_round_trip(world, name, builder, model):
+    filter_obj = builder()
+    # Guard: the builder actually carries a nested cross-entity sub-filter, so
+    # this test is meaningful (a flat-only filter would round-trip trivially).
+    serialized = filter_obj.to_json()
+    assert serialized != {} or model is Session, f"{name}: nothing serialized"
+    assert _count_via_json(filter_obj, model) == _count(filter_obj, model), (
+        f"{name}: JSON round-trip changed the result set"
+    )
+
+
+def test_finished_link_round_trips_to_same_count_as_stat(world):
+    stats = compute_stats(YEAR)
+    assert (
+        _count_via_json(stats_links.purchases_finished(YEAR), Purchase)
+        == stats["all_finished_this_year_count"]
     )

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -202,6 +202,7 @@ function buildFilterJSON(form: HTMLElement): Record<string, unknown> {
     { prefix: "filter-date-refunded", key: "date_refunded" },
     { prefix: "filter-started", key: "started" },
     { prefix: "filter-ended", key: "ended" },
+    { prefix: "filter-finished", key: "finished" },
   ];
   dateRangeFields.forEach((dateField) => {
     const valueMin = stringValue(form, dateField.prefix + "-min");


### PR DESCRIPTION
Fixes #120. Closes #121.

## Problem

The per-year stats page's "View all" links navigated to an empty or partial `?filter=` (e.g. `filter=%7B%7D`), so the destination list was unfiltered.

**Root cause:** `OperatorFilter.to_json` / `from_json` silently dropped every cross-entity sub-filter field (`game_filter`, `playevent_filter`, `session_filter`, …) — they're typed as other `OperatorFilter` subclasses, so they matched neither the criterion path nor the AND/OR/NOT path. The `stats_links` builders are constructed from exactly these nested sub-filters (8 of 13 builders), so a clicked link lost its filter on the way into the URL. Parity tests missed it because they call `.to_q()` on the in-memory object, never round-tripping through JSON.

## Changes

**Serialization round-trip (root cause)** — `common/criteria.py`
- Register filter subclasses via `__init_subclass__` (`_FILTER_TYPES`); `to_json`/`from_json` now recurse into `OperatorFilter`-typed fields. New `to_json` branch excludes AND/OR/NOT and skips empties.
- **`BoolCriterion.to_json`** fix (found in adversarial review): `value=False` equalled the dataclass default, so the base serializer dropped it — making `is_refunded=False` / `infinite=False` vanish on round-trip and leak refunded purchases into `purchases_unfinished`.

**"Finished when" filter (#121)** — `games/filters.py`, `common/components/filters.py`, `ts/elements/filter-bar.ts`
- Flat `finished` `DateCriterion` on `GameFilter` (`playevents__ended`, distinct) and `PurchaseFilter` (game-id subquery, no row explosion).
- "Finished" `DateRangePicker` added to the Game and Purchase bars (reuses the existing widget); one `dateRangeFields` TS entry.
- `_parse_range` made modifier-aware — fixes an existing bug where a max-only (`LESS_THAN`) bound prefilled the min slot.

**No `stats_links` logic change** — the builders already encode the agreed semantics (Finished = any game finished in the year; Bought and Finished = bought ∧ finished in the year). They only needed lossless serialization.

## Tests

- Through-JSON parity across all 8 nested builders (fails on pre-fix `main`).
- Nested + flat `finished` JSON round-trips.
- Strengthened the previously false-positive `test_device_filter_and_cross_entity` (it passed by accident when sub-filters were dropped).
- Finished-filter DB coverage incl. no-duplicate-rows and `LESS_THAN` prefill render.

693 passed · mypy clean · ruff lint+format clean · ts-check passes.

## Follow-up

#123 — unify filter-bar serialization on codegen'd widget paths to retire flat convenience fields (deferred; the robust design is disproportionate to this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)