### PR TITLE
Relation algebra: match-mode + aggregate criterion (#123 Phase 1)

### DIFF
--- a/common/criteria.py
+++ b/common/criteria.py
@@ -382,6 +382,26 @@ class ChoiceCriterion(_SetCriterion):
     excludes: list[str] = field(default_factory=list)
 
 
+@dataclass
+class AggregateCriterion(_Criterion):
+    """Filter a parent entity by a reducer (count / sum / avg) over one of its
+    relations, compared numerically — e.g. "games with > 5 sessions" or "sum of
+    a game's purchase prices between X and Y".
+
+    The reducer, relation accessor, source field, and unit are *static config*
+    supplied by the filter at query time (see ``aggregate_to_q``); the instance
+    carries only the user's comparison value(s)/modifier and an optional
+    ``scope`` sub-filter restricting which related rows are aggregated.
+    """
+
+    value: int | float = 0
+    value2: int | float | None = None
+    modifier: Modifier = Modifier.EQUALS
+    # OperatorFilter | None — restricts which related rows are aggregated. Always
+    # None today; widget + JSON round-trip wiring lands with the path serializer.
+    scope: Any = None
+
+
 # ── OperatorFilter base ────────────────────────────────────────────────────
 
 F = TypeVar("F", bound="OperatorFilter")
@@ -398,6 +418,7 @@ _CRITERION_TYPES: dict[str, type[_Criterion]] = {
     "BoolCriterion": BoolCriterion,
     "MultiCriterion": MultiCriterion,
     "ChoiceCriterion": ChoiceCriterion,
+    "AggregateCriterion": AggregateCriterion,
 }
 
 # Registry of OperatorFilter subclasses by name, so from_json can resolve a
@@ -462,7 +483,14 @@ class OperatorFilter:
             NOT: "GameFilter | None" = None
             name: StringCriterion | None = None
             ...
+
+    ``match`` is the relation quantifier, meaningful only when this filter is
+    nested as a cross-entity sub-filter (e.g. ``GameFilter.session_filter``):
+    ANY=INCLUDES (default), NONE=EXCLUDES, ALL=INCLUDES_ALL. ``relation_to_q``
+    reads it. At the top level it is ignored.
     """
+
+    match: Modifier = Modifier.INCLUDES
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -565,6 +593,10 @@ class OperatorFilter:
             if f.name not in data:
                 continue
             raw = data[f.name]
+            # Relation quantifier (meaningful only on a nested sub-filter).
+            if f.name == "match":
+                kwargs["match"] = Modifier(raw) if isinstance(raw, str) else raw
+                continue
             if raw is None:
                 kwargs[f.name] = None
                 continue
@@ -597,9 +629,16 @@ class OperatorFilter:
 
     def to_json(self) -> dict[str, Any]:
         result: dict[str, Any] = {}
+        # Relation quantifier: only emit when set to a non-default (a nested
+        # sub-filter asking for NONE/ALL); the default ANY stays implicit so
+        # existing top-level and ANY-matched filters serialize unchanged.
+        if self.match != Modifier.INCLUDES:
+            result["match"] = self.match
         for f in dc_fields(self):
             v = getattr(self, f.name)
             if v is None:
+                continue
+            if f.name == "match":
                 continue
             if f.name in _OPERATOR_FIELDS:
                 result[f.name] = v.to_json()
@@ -639,3 +678,159 @@ def filter_from_json(cls: type[F], json_str: str) -> F | None:
 def filter_to_json(f: OperatorFilter) -> str:
     """Serialize a filter to a JSON string for URL params or storage."""
     return json.dumps(f.to_json())
+
+
+# ── Relation & aggregate query helpers ──────────────────────────────────────
+# Self-contained Q builders for the two cross-entity node kinds. Filters pass the
+# related/parent model and the relation wiring (lookups, accessor, reducer); the
+# algebra lives here so every entity composes the same logic instead of repeating
+# bespoke subqueries in each to_q().
+
+Number = int | float
+
+
+def _numeric_to_q(
+    value: Number, value2: Number | None, modifier: Modifier, field_name: str
+) -> Q:
+    """Numeric comparison Q against a plain column/annotation (int or float)."""
+    if modifier == Modifier.EQUALS:
+        return Q(**{field_name: value})
+    if modifier == Modifier.NOT_EQUALS:
+        return ~Q(**{field_name: value})
+    if modifier == Modifier.GREATER_THAN:
+        return Q(**{f"{field_name}__gt": value})
+    if modifier == Modifier.LESS_THAN:
+        return Q(**{f"{field_name}__lt": value})
+    if modifier == Modifier.BETWEEN:
+        if value2 is None:
+            raise ValueError("BETWEEN requires value2")
+        return Q(
+            **{
+                f"{field_name}__gte": min(value, value2),
+                f"{field_name}__lte": max(value, value2),
+            }
+        )
+    if modifier == Modifier.NOT_BETWEEN:
+        if value2 is None:
+            raise ValueError("NOT_BETWEEN requires value2")
+        lo, hi = min(value, value2), max(value, value2)
+        return Q(**{f"{field_name}__lt": lo}) | Q(**{f"{field_name}__gt": hi})
+    if modifier == Modifier.IS_NULL:
+        return Q(**{f"{field_name}__isnull": True})
+    if modifier == Modifier.NOT_NULL:
+        return Q(**{f"{field_name}__isnull": False})
+    raise ValueError(f"Unsupported modifier {modifier} for numeric comparison")
+
+
+def duration_hours_to_q(
+    value: Number, value2: Number | None, modifier: Modifier, field_name: str
+) -> Q:
+    """Compare an hours value against a DurationField (or a duration aggregate).
+
+    Django stores DurationField as microseconds, so hours convert to
+    ``timedelta``. EQUALS matches the whole hour bucket ``[h, h+1)``;
+    IS_NULL/NOT_NULL test against a zero duration. This is the single home for
+    the hours<->timedelta logic shared by the direct duration fields (playtime,
+    session durations) and the duration-unit aggregates.
+    """
+    from datetime import timedelta
+
+    td = timedelta(hours=value)
+    if modifier == Modifier.EQUALS:
+        return Q(
+            **{
+                f"{field_name}__gte": td,
+                f"{field_name}__lt": timedelta(hours=value + 1),
+            }
+        )
+    if modifier == Modifier.NOT_EQUALS:
+        return ~Q(
+            **{
+                f"{field_name}__gte": td,
+                f"{field_name}__lt": timedelta(hours=value + 1),
+            }
+        )
+    if modifier == Modifier.GREATER_THAN:
+        return Q(**{f"{field_name}__gt": td})
+    if modifier == Modifier.LESS_THAN:
+        return Q(**{f"{field_name}__lt": td})
+    if modifier == Modifier.BETWEEN and value2 is not None:
+        lo = timedelta(hours=min(value, value2))
+        hi = timedelta(hours=max(value, value2))
+        return Q(**{f"{field_name}__gte": lo, f"{field_name}__lte": hi})
+    if modifier == Modifier.NOT_BETWEEN and value2 is not None:
+        lo = timedelta(hours=min(value, value2))
+        hi = timedelta(hours=max(value, value2))
+        return Q(**{f"{field_name}__lt": lo}) | Q(**{f"{field_name}__gt": hi})
+    if modifier == Modifier.IS_NULL:
+        return Q(**{field_name: timedelta(0)})
+    if modifier == Modifier.NOT_NULL:
+        return ~Q(**{field_name: timedelta(0)})
+    return Q()
+
+
+def relation_to_q(
+    sub: OperatorFilter,
+    *,
+    related_model: Any,
+    related_lookup: str,
+    parent_field: str = "id",
+) -> Q:
+    """EXISTS / NOT-EXISTS subquery for a nested cross-entity sub-filter.
+
+    Builds ``parent_field IN (<related rows matching sub>.related_lookup)``; the
+    sub-filter's ``match`` quantifier selects ANY (INCLUDES, default) vs NONE
+    (EXCLUDES, the negation). ALL (INCLUDES_ALL) is reserved but unimplemented.
+    """
+    ids = related_model.objects.filter(sub.to_q()).values_list(
+        related_lookup, flat=True
+    )
+    base = Q(**{f"{parent_field}__in": ids})
+    if sub.match == Modifier.EXCLUDES:
+        return ~base
+    if sub.match == Modifier.INCLUDES_ALL:
+        raise NotImplementedError(
+            "ALL relation match (INCLUDES_ALL on a nested sub-filter) is not "
+            "implemented yet; see the follow-up issue."
+        )
+    return base
+
+
+def aggregate_to_q(
+    criterion: AggregateCriterion,
+    *,
+    model: Any,
+    reducer: str,
+    accessor: str,
+    source: str | None = None,
+    unit: str | None = None,
+) -> Q:
+    """Filter ``model`` by a reducer (count / sum / avg) over a relation.
+
+    Annotates ``model`` with the aggregate, compares it against the criterion's
+    value(s)/modifier, and returns ``Q(id__in=<matching ids>)``.
+    ``unit="duration_hours"`` compares an hours value against a DurationField
+    aggregate; otherwise a plain numeric comparison is used.
+    """
+    from django.db.models import Avg, Count, Sum
+
+    if reducer == "count":
+        expr: Any = Count(accessor, distinct=True)
+    elif reducer == "sum":
+        expr = Sum(f"{accessor}__{source}")
+    elif reducer == "avg":
+        expr = Avg(f"{accessor}__{source}")
+    else:
+        raise ValueError(f"Unknown aggregate reducer {reducer!r}")
+
+    if unit == "duration_hours":
+        compare = duration_hours_to_q(
+            criterion.value, criterion.value2, criterion.modifier, "_agg"
+        )
+    else:
+        compare = _numeric_to_q(
+            criterion.value, criterion.value2, criterion.modifier, "_agg"
+        )
+
+    ids = model.objects.annotate(_agg=expr).filter(compare).values_list("id", flat=True)
+    return Q(id__in=ids)

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field, fields as dc_fields
 from enum import Enum
-from typing import Any, Self, TypeVar
+from typing import Any, Literal, Self, TypeVar
 
 from django.db.models import Q
 
@@ -76,6 +76,21 @@ class Modifier(str, Enum):
             cls.IS_NULL,
             cls.NOT_NULL,
         ]
+
+
+# ── Relation match-mode ──────────────────────────────────────────────────────
+
+
+class RelationMatch(str, Enum):
+    """Quantifier for a nested cross-entity sub-filter (e.g. a game's sessions).
+
+    A dedicated vocabulary (rather than reusing ``Modifier``) so only the three
+    meaningful quantifiers are representable. ``relation_to_q`` interprets it.
+    """
+
+    ANY = "ANY"  # ≥1 related row matches the sub-filter (EXISTS)
+    NONE = "NONE"  # no related row matches (NOT EXISTS); includes zero-row parents
+    ALL = "ALL"  # every related row matches (reserved; not yet implemented)
 
 
 # ── Base criterion ─────────────────────────────────────────────────────────
@@ -397,9 +412,18 @@ class AggregateCriterion(_Criterion):
     value: int | float = 0
     value2: int | float | None = None
     modifier: Modifier = Modifier.EQUALS
-    # OperatorFilter | None — restricts which related rows are aggregated. Always
-    # None today; widget + JSON round-trip wiring lands with the path serializer.
-    scope: Any = None
+    # Restricts which related rows are aggregated. Always None today; honouring it
+    # needs both the path serializer (to populate it) AND aggregate_to_q (to apply
+    # it as the annotate ``filter=``) — neither is wired yet.
+    scope: "OperatorFilter | None" = None
+
+    def to_q(self, field_name: str) -> Q:
+        # Unlike sibling criteria, an aggregate is not self-contained: its meaning
+        # depends on static config (reducer/relation/source/unit) the filter holds.
+        # It is evaluated via aggregate_to_q(...), never this method.
+        raise NotImplementedError(
+            "AggregateCriterion is evaluated via aggregate_to_q(), not to_q()"
+        )
 
 
 # ── OperatorFilter base ────────────────────────────────────────────────────
@@ -486,11 +510,12 @@ class OperatorFilter:
 
     ``match`` is the relation quantifier, meaningful only when this filter is
     nested as a cross-entity sub-filter (e.g. ``GameFilter.session_filter``):
-    ANY=INCLUDES (default), NONE=EXCLUDES, ALL=INCLUDES_ALL. ``relation_to_q``
-    reads it. At the top level it is ignored.
+    ANY (default), NONE, or ALL (ALL reserved — see ``relation_to_q``).
+    ``relation_to_q`` reads it; at the top level it is ignored (``to_q`` never
+    consults ``self.match``).
     """
 
-    match: Modifier = Modifier.INCLUDES
+    match: RelationMatch = RelationMatch.ANY
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -595,7 +620,7 @@ class OperatorFilter:
             raw = data[f.name]
             # Relation quantifier (meaningful only on a nested sub-filter).
             if f.name == "match":
-                kwargs["match"] = Modifier(raw) if isinstance(raw, str) else raw
+                kwargs["match"] = RelationMatch(raw)
                 continue
             if raw is None:
                 kwargs[f.name] = None
@@ -632,7 +657,7 @@ class OperatorFilter:
         # Relation quantifier: only emit when set to a non-default (a nested
         # sub-filter asking for NONE/ALL); the default ANY stays implicit so
         # existing top-level and ANY-matched filters serialize unchanged.
-        if self.match != Modifier.INCLUDES:
+        if self.match != RelationMatch.ANY:
             result["match"] = self.match
         for f in dc_fields(self):
             v = getattr(self, f.name)
@@ -687,6 +712,8 @@ def filter_to_json(f: OperatorFilter) -> str:
 # bespoke subqueries in each to_q().
 
 Number = int | float
+type Reducer = Literal["count", "sum", "avg"]  # e.g. "count"
+type DurationUnit = Literal["duration_hours"]  # compare hours vs a DurationField
 
 
 def _numeric_to_q(
@@ -713,8 +740,10 @@ def _numeric_to_q(
     if modifier == Modifier.NOT_BETWEEN:
         if value2 is None:
             raise ValueError("NOT_BETWEEN requires value2")
-        lo, hi = min(value, value2), max(value, value2)
-        return Q(**{f"{field_name}__lt": lo}) | Q(**{f"{field_name}__gt": hi})
+        lower_bound, upper_bound = min(value, value2), max(value, value2)
+        return Q(**{f"{field_name}__lt": lower_bound}) | Q(
+            **{f"{field_name}__gt": upper_bound}
+        )
     if modifier == Modifier.IS_NULL:
         return Q(**{f"{field_name}__isnull": True})
     if modifier == Modifier.NOT_NULL:
@@ -729,97 +758,118 @@ def duration_hours_to_q(
 
     Django stores DurationField as microseconds, so hours convert to
     ``timedelta``. EQUALS matches the whole hour bucket ``[h, h+1)``;
-    IS_NULL/NOT_NULL test against a zero duration. This is the single home for
-    the hours<->timedelta logic shared by the direct duration fields (playtime,
-    session durations) and the duration-unit aggregates.
+    IS_NULL/NOT_NULL test against a zero duration. BETWEEN/NOT_BETWEEN require
+    ``value2``. This is the single home for the hours<->timedelta logic shared by
+    the direct duration fields (playtime, session durations) and the
+    duration-unit aggregates. Like ``_numeric_to_q`` it raises on an unsupported
+    or incomplete modifier rather than silently matching everything.
     """
     from datetime import timedelta
 
-    td = timedelta(hours=value)
+    duration = timedelta(hours=value)
     if modifier == Modifier.EQUALS:
         return Q(
             **{
-                f"{field_name}__gte": td,
+                f"{field_name}__gte": duration,
                 f"{field_name}__lt": timedelta(hours=value + 1),
             }
         )
     if modifier == Modifier.NOT_EQUALS:
         return ~Q(
             **{
-                f"{field_name}__gte": td,
+                f"{field_name}__gte": duration,
                 f"{field_name}__lt": timedelta(hours=value + 1),
             }
         )
     if modifier == Modifier.GREATER_THAN:
-        return Q(**{f"{field_name}__gt": td})
+        return Q(**{f"{field_name}__gt": duration})
     if modifier == Modifier.LESS_THAN:
-        return Q(**{f"{field_name}__lt": td})
-    if modifier == Modifier.BETWEEN and value2 is not None:
-        lo = timedelta(hours=min(value, value2))
-        hi = timedelta(hours=max(value, value2))
-        return Q(**{f"{field_name}__gte": lo, f"{field_name}__lte": hi})
-    if modifier == Modifier.NOT_BETWEEN and value2 is not None:
-        lo = timedelta(hours=min(value, value2))
-        hi = timedelta(hours=max(value, value2))
-        return Q(**{f"{field_name}__lt": lo}) | Q(**{f"{field_name}__gt": hi})
+        return Q(**{f"{field_name}__lt": duration})
+    if modifier == Modifier.BETWEEN:
+        if value2 is None:
+            raise ValueError("BETWEEN requires value2")
+        lower_bound = timedelta(hours=min(value, value2))
+        upper_bound = timedelta(hours=max(value, value2))
+        return Q(
+            **{f"{field_name}__gte": lower_bound, f"{field_name}__lte": upper_bound}
+        )
+    if modifier == Modifier.NOT_BETWEEN:
+        if value2 is None:
+            raise ValueError("NOT_BETWEEN requires value2")
+        lower_bound = timedelta(hours=min(value, value2))
+        upper_bound = timedelta(hours=max(value, value2))
+        return Q(**{f"{field_name}__lt": lower_bound}) | Q(
+            **{f"{field_name}__gt": upper_bound}
+        )
     if modifier == Modifier.IS_NULL:
         return Q(**{field_name: timedelta(0)})
     if modifier == Modifier.NOT_NULL:
         return ~Q(**{field_name: timedelta(0)})
-    return Q()
+    raise ValueError(f"Unsupported modifier {modifier} for duration comparison")
+
+
+# The related/parent model is the concrete Django model the filter targets.
+# Typed ``Any`` rather than ``type[Model]`` because django-stubs doesn't expose
+# ``.objects`` on the abstract base ``Model``, so ``type[Model]`` fails mypy here.
+ModelClass = Any  # a concrete Django model class, e.g. Game
 
 
 def relation_to_q(
     sub: OperatorFilter,
     *,
-    related_model: Any,
+    related_model: ModelClass,
     related_lookup: str,
     parent_field: str = "id",
 ) -> Q:
     """EXISTS / NOT-EXISTS subquery for a nested cross-entity sub-filter.
 
     Builds ``parent_field IN (<related rows matching sub>.related_lookup)``; the
-    sub-filter's ``match`` quantifier selects ANY (INCLUDES, default) vs NONE
-    (EXCLUDES, the negation). ALL (INCLUDES_ALL) is reserved but unimplemented.
+    sub-filter's ``match`` quantifier selects ANY (the EXISTS) vs NONE (its
+    negation). ALL is reserved but unimplemented. The branch is exhaustive — an
+    unexpected match raises rather than silently degrading to ANY.
     """
     ids = related_model.objects.filter(sub.to_q()).values_list(
         related_lookup, flat=True
     )
     base = Q(**{f"{parent_field}__in": ids})
-    if sub.match == Modifier.EXCLUDES:
+    if sub.match == RelationMatch.ANY:
+        return base
+    if sub.match == RelationMatch.NONE:
         return ~base
-    if sub.match == Modifier.INCLUDES_ALL:
+    if sub.match == RelationMatch.ALL:
         raise NotImplementedError(
-            "ALL relation match (INCLUDES_ALL on a nested sub-filter) is not "
-            "implemented yet; see the follow-up issue."
+            "ALL relation match on a nested sub-filter is not implemented yet; "
+            "see the follow-up issue (#128)."
         )
-    return base
+    raise ValueError(f"Unsupported relation match {sub.match!r}")
 
 
 def aggregate_to_q(
     criterion: AggregateCriterion,
     *,
-    model: Any,
-    reducer: str,
+    model: ModelClass,
+    reducer: Reducer,
     accessor: str,
     source: str | None = None,
-    unit: str | None = None,
+    unit: DurationUnit | None = None,
 ) -> Q:
     """Filter ``model`` by a reducer (count / sum / avg) over a relation.
 
     Annotates ``model`` with the aggregate, compares it against the criterion's
     value(s)/modifier, and returns ``Q(id__in=<matching ids>)``.
     ``unit="duration_hours"`` compares an hours value against a DurationField
-    aggregate; otherwise a plain numeric comparison is used.
+    aggregate; otherwise a plain numeric comparison is used. ``sum``/``avg``
+    require a ``source`` field; ``count`` aggregates whole rows.
     """
     from django.db.models import Avg, Count, Sum
 
     if reducer == "count":
-        expr: Any = Count(accessor, distinct=True)
-    elif reducer == "sum":
-        expr = Sum(f"{accessor}__{source}")
-    elif reducer == "avg":
-        expr = Avg(f"{accessor}__{source}")
+        aggregate_expression: Any = Count(accessor, distinct=True)
+    elif reducer in ("sum", "avg"):
+        if source is None:
+            raise ValueError(f"{reducer!r} aggregate requires a source field")
+        reduce = Sum if reducer == "sum" else Avg
+        aggregate_expression = reduce(f"{accessor}__{source}")
     else:
         raise ValueError(f"Unknown aggregate reducer {reducer!r}")
 
@@ -832,5 +882,9 @@ def aggregate_to_q(
             criterion.value, criterion.value2, criterion.modifier, "_agg"
         )
 
-    ids = model.objects.annotate(_agg=expr).filter(compare).values_list("id", flat=True)
+    ids = (
+        model.objects.annotate(_agg=aggregate_expression)
+        .filter(compare)
+        .values_list("id", flat=True)
+    )
     return Q(id__in=ids)

--- a/games/filters.py
+++ b/games/filters.py
@@ -19,6 +19,7 @@ from django.urls import reverse
 from django.utils.http import urlencode
 
 from common.criteria import (
+    AggregateCriterion,
     BoolCriterion,
     ChoiceCriterion,
     DateCriterion,
@@ -28,8 +29,11 @@ from common.criteria import (
     MultiCriterion,
     OperatorFilter,
     StringCriterion,
+    aggregate_to_q,
+    duration_hours_to_q,
     filter_from_json,
     filter_to_json,
+    relation_to_q,
 )
 
 # A queryset of object ids (from ``.values_list("id"/"pk", flat=True)``), reused
@@ -76,14 +80,17 @@ class GameFilter(OperatorFilter):
     created_at: StringCriterion | None = None  # date string
     updated_at: StringCriterion | None = None  # date string
 
-    session_count: IntCriterion | None = None
-    session_average: IntCriterion | None = None  # average in hours
-    purchase_count: IntCriterion | None = None  # distinct purchases per game
-    playevent_count: IntCriterion | None = None  # playevents per game
+    # Aggregates over the game's relations (count / sum / avg). The reducer +
+    # relation accessor + source + unit are supplied at query time via
+    # aggregate_to_q; the criterion carries only the numeric comparison.
+    session_count: AggregateCriterion | None = None
+    session_average: AggregateCriterion | None = None  # average in hours
+    purchase_count: AggregateCriterion | None = None  # distinct purchases per game
+    playevent_count: AggregateCriterion | None = None  # playevents per game
 
     # Aggregate session durations (hours), summed across the game's sessions
-    manual_playtime_hours: IntCriterion | None = None
-    calculated_playtime_hours: IntCriterion | None = None
+    manual_playtime_hours: AggregateCriterion | None = None
+    calculated_playtime_hours: AggregateCriterion | None = None
 
     # Cross-entity: any session played on these devices / matching these flags
     device: MultiCriterion | None = None  # game has session on any of these devices
@@ -92,7 +99,7 @@ class GameFilter(OperatorFilter):
     # Cross-entity: matches against the game's purchases
     purchase_refunded: BoolCriterion | None = None  # game has refunded purchase
     purchase_infinite: BoolCriterion | None = None  # game has infinite purchase
-    purchase_price_total: FloatCriterion | None = None  # sum of converted prices
+    purchase_price_total: AggregateCriterion | None = None  # sum of converted prices
     purchase_price_any: FloatCriterion | None = None  # any single purchase in range
     purchase_type: ChoiceCriterion | None = None  # game has purchase of type
     purchase_ownership_type: ChoiceCriterion | None = None  # by ownership
@@ -144,59 +151,44 @@ class GameFilter(OperatorFilter):
             q &= self.platform_group.to_q("platform__group")
 
         if self.session_count is not None:
-            from django.db.models import Count
-
             from games.models import Game
 
-            matching_ids: MatchingIdQuerySet = (
-                Game.objects.annotate(s_count=Count("sessions", distinct=True))
-                .filter(self.session_count.to_q("s_count"))
-                .values_list("id", flat=True)
+            q &= aggregate_to_q(
+                self.session_count, model=Game, reducer="count", accessor="sessions"
             )
-            q &= Q(id__in=matching_ids)
 
         if self.session_average is not None:
-            from django.db.models import Avg
-
             from games.models import Game
 
-            matching_ids = (
-                Game.objects.annotate(s_avg=Avg("sessions__duration_total"))
-                .filter(self._playtime_to_q_for_field(self.session_average, "s_avg"))
-                .values_list("id", flat=True)
+            q &= aggregate_to_q(
+                self.session_average,
+                model=Game,
+                reducer="avg",
+                accessor="sessions",
+                source="duration_total",
+                unit="duration_hours",
             )
-            q &= Q(id__in=matching_ids)
 
         if self.purchase_count is not None:
-            from django.db.models import Count
-
             from games.models import Game
 
-            matching_ids = (
-                Game.objects.annotate(p_count=Count("purchases", distinct=True))
-                .filter(self.purchase_count.to_q("p_count"))
-                .values_list("id", flat=True)
+            q &= aggregate_to_q(
+                self.purchase_count, model=Game, reducer="count", accessor="purchases"
             )
-            q &= Q(id__in=matching_ids)
 
         if self.playevent_count is not None:
-            from django.db.models import Count
-
             from games.models import Game
 
-            matching_ids = (
-                Game.objects.annotate(pe_count=Count("playevents", distinct=True))
-                .filter(self.playevent_count.to_q("pe_count"))
-                .values_list("id", flat=True)
+            q &= aggregate_to_q(
+                self.playevent_count, model=Game, reducer="count", accessor="playevents"
             )
-            q &= Q(id__in=matching_ids)
 
         if self.finished is not None:
             from games.models import Game
 
             # Games with a playevent whose `ended` date is in range. distinct()
             # collapses the row-per-playevent fan-out of the reverse relation.
-            matching_ids = (
+            matching_ids: MatchingIdQuerySet = (
                 Game.objects.filter(self.finished.to_q("playevents__ended"))
                 .distinct()
                 .values_list("id", flat=True)
@@ -204,36 +196,28 @@ class GameFilter(OperatorFilter):
             q &= Q(id__in=matching_ids)
 
         if self.manual_playtime_hours is not None:
-            from django.db.models import Sum
-
             from games.models import Game
 
-            matching_ids = (
-                Game.objects.annotate(s_manual=Sum("sessions__duration_manual"))
-                .filter(
-                    self._playtime_to_q_for_field(
-                        self.manual_playtime_hours, "s_manual"
-                    )
-                )
-                .values_list("id", flat=True)
+            q &= aggregate_to_q(
+                self.manual_playtime_hours,
+                model=Game,
+                reducer="sum",
+                accessor="sessions",
+                source="duration_manual",
+                unit="duration_hours",
             )
-            q &= Q(id__in=matching_ids)
 
         if self.calculated_playtime_hours is not None:
-            from django.db.models import Sum
-
             from games.models import Game
 
-            matching_ids = (
-                Game.objects.annotate(s_calc=Sum("sessions__duration_calculated"))
-                .filter(
-                    self._playtime_to_q_for_field(
-                        self.calculated_playtime_hours, "s_calc"
-                    )
-                )
-                .values_list("id", flat=True)
+            q &= aggregate_to_q(
+                self.calculated_playtime_hours,
+                model=Game,
+                reducer="sum",
+                accessor="sessions",
+                source="duration_calculated",
+                unit="duration_hours",
             )
-            q &= Q(id__in=matching_ids)
 
         if self.device is not None:
             from games.models import Session
@@ -281,16 +265,15 @@ class GameFilter(OperatorFilter):
                 q &= ~Q(id__in=infinite_ids)
 
         if self.purchase_price_total is not None:
-            from django.db.models import Sum
-
             from games.models import Game
 
-            matching_ids = (
-                Game.objects.annotate(p_total=Sum("purchases__converted_price"))
-                .filter(self.purchase_price_total.to_q("p_total"))
-                .values_list("id", flat=True)
+            q &= aggregate_to_q(
+                self.purchase_price_total,
+                model=Game,
+                reducer="sum",
+                accessor="purchases",
+                source="converted_price",
             )
-            q &= Q(id__in=matching_ids)
 
         if self.purchase_price_any is not None:
             from games.models import Purchase
@@ -333,42 +316,37 @@ class GameFilter(OperatorFilter):
                 search_q = ~search_q
             q &= search_q
 
-        # Cross-entity filters
+        # Cross-entity sub-filters (ANY/NONE via each sub-filter's match mode)
         if self.session_filter is not None:
             from games.models import Session
 
-            session_q = self.session_filter.to_q()
-            matching_ids = Session.objects.filter(session_q).values_list(
-                "game_id", flat=True
+            q &= relation_to_q(
+                self.session_filter, related_model=Session, related_lookup="game_id"
             )
-            q &= Q(id__in=matching_ids)
 
         if self.purchase_filter is not None:
             from games.models import Purchase
 
-            purchase_q = self.purchase_filter.to_q()
-            matching_ids = Purchase.objects.filter(purchase_q).values_list(
-                "games__id", flat=True
+            q &= relation_to_q(
+                self.purchase_filter, related_model=Purchase, related_lookup="games__id"
             )
-            q &= Q(id__in=matching_ids)
 
         if self.playevent_filter is not None:
             from games.models import PlayEvent
 
-            playevent_q = self.playevent_filter.to_q()
-            matching_ids = PlayEvent.objects.filter(playevent_q).values_list(
-                "game_id", flat=True
+            q &= relation_to_q(
+                self.playevent_filter, related_model=PlayEvent, related_lookup="game_id"
             )
-            q &= Q(id__in=matching_ids)
 
         if self.platform_filter is not None:
             from games.models import Platform
 
-            platform_q = self.platform_filter.to_q()
-            matching_ids = Platform.objects.filter(platform_q).values_list(
-                "id", flat=True
+            q &= relation_to_q(
+                self.platform_filter,
+                related_model=Platform,
+                related_lookup="id",
+                parent_field="platform_id",
             )
-            q &= Q(platform_id__in=matching_ids)
 
         # ── AND / OR / NOT sub-filters ──
         sub = self.sub_filter()
@@ -388,49 +366,8 @@ class GameFilter(OperatorFilter):
 
     @staticmethod
     def _playtime_to_q_for_field(c: IntCriterion, field: str) -> Q:
-        """Convert hours-based criterion to a DurationField Q object.
-
-        Django stores DurationField as microseconds in SQLite, so we convert
-        hours → timedelta(microseconds=X) and use the appropriate lookups.
-        """
-        from datetime import timedelta
-
-        from common.criteria import Modifier
-
-        m = c.modifier
-        td_val = timedelta(hours=c.value)
-
-        if m == Modifier.EQUALS:
-            return Q(
-                **{
-                    f"{field}__gte": td_val,
-                    f"{field}__lt": timedelta(hours=c.value + 1),
-                }
-            )
-        if m == Modifier.NOT_EQUALS:
-            return ~Q(
-                **{
-                    f"{field}__gte": td_val,
-                    f"{field}__lt": timedelta(hours=c.value + 1),
-                }
-            )
-        if m == Modifier.GREATER_THAN:
-            return Q(**{f"{field}__gt": td_val})
-        if m == Modifier.LESS_THAN:
-            return Q(**{f"{field}__lt": td_val})
-        if m == Modifier.BETWEEN and c.value2 is not None:
-            lo = timedelta(hours=min(c.value, c.value2))
-            hi = timedelta(hours=max(c.value, c.value2))
-            return Q(**{f"{field}__gte": lo, f"{field}__lte": hi})
-        if m == Modifier.NOT_BETWEEN and c.value2 is not None:
-            lo = timedelta(hours=min(c.value, c.value2))
-            hi = timedelta(hours=max(c.value, c.value2))
-            return Q(**{f"{field}__lt": lo}) | Q(**{f"{field}__gt": hi})
-        if m == Modifier.IS_NULL:
-            return Q(**{f"{field}": timedelta(0)})
-        if m == Modifier.NOT_NULL:
-            return ~Q(**{f"{field}": timedelta(0)})
-        return Q()
+        """Convert an hours-based criterion to a DurationField Q object."""
+        return duration_hours_to_q(c.value, c.value2, c.modifier, field)
 
     @staticmethod
     def _playevent_note_to_q(criterion: StringCriterion) -> Q:
@@ -479,42 +416,8 @@ class SessionFilter(OperatorFilter):
     device_filter: DeviceFilter | None = None
 
     def _duration_to_q(self, c: IntCriterion, field: str) -> Q:
-        from datetime import timedelta
-
-        q = Q()
-        td_val = timedelta(hours=c.value)
-        m = c.modifier
-        if m == Modifier.EQUALS:
-            q &= Q(
-                **{
-                    f"{field}__gte": td_val,
-                    f"{field}__lt": timedelta(hours=c.value + 1),
-                }
-            )
-        elif m == Modifier.NOT_EQUALS:
-            q &= ~Q(
-                **{
-                    f"{field}__gte": td_val,
-                    f"{field}__lt": timedelta(hours=c.value + 1),
-                }
-            )
-        elif m == Modifier.GREATER_THAN:
-            q &= Q(**{f"{field}__gt": td_val})
-        elif m == Modifier.LESS_THAN:
-            q &= Q(**{f"{field}__lt": td_val})
-        elif m == Modifier.BETWEEN and c.value2 is not None:
-            lo = timedelta(hours=min(c.value, c.value2))
-            hi = timedelta(hours=max(c.value, c.value2))
-            q &= Q(**{f"{field}__gte": lo, f"{field}__lte": hi})
-        elif m == Modifier.NOT_BETWEEN and c.value2 is not None:
-            lo = timedelta(hours=min(c.value, c.value2))
-            hi = timedelta(hours=max(c.value, c.value2))
-            q &= Q(**{f"{field}__lt": lo}) | Q(**{f"{field}__gt": hi})
-        elif m == Modifier.IS_NULL:
-            q &= Q(**{f"{field}": timedelta(0)})
-        elif m == Modifier.NOT_NULL:
-            q &= ~Q(**{f"{field}": timedelta(0)})
-        return q
+        """Convert an hours-based criterion to a DurationField Q object."""
+        return duration_hours_to_q(c.value, c.value2, c.modifier, field)
 
     def to_q(self) -> Q:
         from datetime import timedelta
@@ -569,23 +472,26 @@ class SessionFilter(OperatorFilter):
                 search_q = ~search_q
             q &= search_q
 
-        # Cross-entity filter: sessions for games matching GameFilter
+        # Cross-entity sub-filters: sessions for matching games / devices
         if self.game_filter is not None:
             from games.models import Game
 
-            game_q = self.game_filter.to_q()
-            matching_ids: MatchingIdQuerySet = Game.objects.filter(game_q).values_list(
-                "id", flat=True
+            q &= relation_to_q(
+                self.game_filter,
+                related_model=Game,
+                related_lookup="id",
+                parent_field="game_id",
             )
-            q &= Q(game_id__in=matching_ids)
 
-        # Cross-entity filter: sessions for devices matching DeviceFilter
         if self.device_filter is not None:
             from games.models import Device
 
-            device_q = self.device_filter.to_q()
-            matching_ids = Device.objects.filter(device_q).values_list("id", flat=True)
-            q &= Q(device_id__in=matching_ids)
+            q &= relation_to_q(
+                self.device_filter,
+                related_model=Device,
+                related_lookup="id",
+                parent_field="device_id",
+            )
 
         # AND / OR / NOT
         sub = self.sub_filter()
@@ -703,25 +609,26 @@ class PurchaseFilter(OperatorFilter):
                 search_q = ~search_q
             q &= search_q
 
-        # Cross-entity filter
+        # Cross-entity sub-filters: purchases for matching games / platforms
         if self.game_filter is not None:
             from games.models import Game
 
-            game_q = self.game_filter.to_q()
-            matching_ids: MatchingIdQuerySet = Game.objects.filter(game_q).values_list(
-                "id", flat=True
+            q &= relation_to_q(
+                self.game_filter,
+                related_model=Game,
+                related_lookup="id",
+                parent_field="games__id",
             )
-            q &= Q(games__id__in=matching_ids)
 
-        # Cross-entity platform filter
         if self.platform_filter is not None:
             from games.models import Platform
 
-            platform_q = self.platform_filter.to_q()
-            matching_ids = Platform.objects.filter(platform_q).values_list(
-                "id", flat=True
+            q &= relation_to_q(
+                self.platform_filter,
+                related_model=Platform,
+                related_lookup="id",
+                parent_field="platform_id",
             )
-            q &= Q(platform_id__in=matching_ids)
 
         sub = self.sub_filter()
         if sub is not None:
@@ -835,15 +742,15 @@ class DeviceFilter(OperatorFilter):
                 search_q = ~search_q
             q &= search_q
 
-        # Cross-entity filter: session_filter
+        # Cross-entity sub-filter: devices that have matching sessions
         if self.session_filter is not None:
             from games.models import Session
 
-            session_q = self.session_filter.to_q()
-            matching_ids = Session.objects.filter(session_q).values_list(
-                "device_id", flat=True
+            q &= relation_to_q(
+                self.session_filter,
+                related_model=Session,
+                related_lookup="device_id",
             )
-            q &= Q(id__in=matching_ids)
 
         sub = self.sub_filter()
         if sub is not None:
@@ -901,25 +808,22 @@ class PlatformFilter(OperatorFilter):
                 search_q = ~search_q
             q &= search_q
 
-        # Cross-entity filter: game_filter
+        # Cross-entity sub-filters: platforms with matching games / purchases
         if self.game_filter is not None:
             from games.models import Game
 
-            game_q = self.game_filter.to_q()
-            matching_ids: MatchingIdQuerySet = Game.objects.filter(game_q).values_list(
-                "platform_id", flat=True
+            q &= relation_to_q(
+                self.game_filter, related_model=Game, related_lookup="platform_id"
             )
-            q &= Q(id__in=matching_ids)
 
-        # Cross-entity filter: purchase_filter
         if self.purchase_filter is not None:
             from games.models import Purchase
 
-            purchase_q = self.purchase_filter.to_q()
-            matching_ids = Purchase.objects.filter(purchase_q).values_list(
-                "platform_id", flat=True
+            q &= relation_to_q(
+                self.purchase_filter,
+                related_model=Purchase,
+                related_lookup="platform_id",
             )
-            q &= Q(id__in=matching_ids)
 
         sub = self.sub_filter()
         if sub is not None:
@@ -982,15 +886,16 @@ class PlayEventFilter(OperatorFilter):
                 search_q = ~search_q
             q &= search_q
 
-        # Cross-entity filter: game_filter
+        # Cross-entity sub-filter: playevents for matching games
         if self.game_filter is not None:
             from games.models import Game
 
-            game_q = self.game_filter.to_q()
-            matching_ids: MatchingIdQuerySet = Game.objects.filter(game_q).values_list(
-                "id", flat=True
+            q &= relation_to_q(
+                self.game_filter,
+                related_model=Game,
+                related_lookup="id",
+                parent_field="game_id",
             )
-            q &= Q(game_id__in=matching_ids)
 
         sub = self.sub_filter()
         if sub is not None:

--- a/tests/test_relation_algebra.py
+++ b/tests/test_relation_algebra.py
@@ -13,8 +13,14 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from common.criteria import AggregateCriterion, BoolCriterion, Modifier
-from games.filters import GameFilter, SessionFilter
+from common.criteria import (
+    AggregateCriterion,
+    BoolCriterion,
+    Modifier,
+    RelationMatch,
+    StringCriterion,
+)
+from games.filters import GameFilter, PurchaseFilter, SessionFilter
 from games.models import Game, Platform, Purchase, Session
 
 
@@ -69,7 +75,7 @@ def test_relation_none_is_not_exists(emulated_world):
     sessions (the case a positive ANY(emulated=False) would miss)."""
     no_emulated = GameFilter(
         session_filter=SessionFilter(
-            emulated=BoolCriterion(value=True), match=Modifier.EXCLUDES
+            emulated=BoolCriterion(value=True), match=RelationMatch.NONE
         )
     )
     assert _ids(no_emulated) == {
@@ -80,7 +86,7 @@ def test_relation_none_is_not_exists(emulated_world):
 
 def test_empty_none_subfilter_means_no_related_rows(emulated_world):
     """A match-only NONE node (no child criteria) = "has no sessions at all"."""
-    no_sessions = GameFilter(session_filter=SessionFilter(match=Modifier.EXCLUDES))
+    no_sessions = GameFilter(session_filter=SessionFilter(match=RelationMatch.NONE))
     assert _ids(no_sessions) == {emulated_world["no_sessions"]}
 
 
@@ -90,7 +96,7 @@ def test_empty_none_subfilter_means_no_related_rows(emulated_world):
 def test_nested_matches_flat_session_emulated(emulated_world):
     """The flat session_emulated bool and the nested match-mode form must select
     identical games for both True (ANY) and False (NONE)."""
-    for value, match in [(True, Modifier.INCLUDES), (False, Modifier.EXCLUDES)]:
+    for value, match in [(True, RelationMatch.ANY), (False, RelationMatch.NONE)]:
         flat = GameFilter(session_emulated=BoolCriterion(value=value))
         nested = GameFilter(
             session_filter=SessionFilter(
@@ -110,21 +116,14 @@ def test_nested_matches_flat_purchase_refunded(db):
     ).games.set([refunded])
     Purchase.objects.create(date_purchased=_dt()).games.set([kept])
 
-    from games.filters import PurchaseFilter
-
-    def purchase_ids(f):
-        return set(
-            Game.objects.filter(f.to_q()).distinct().values_list("id", flat=True)
-        )
-
     flat_false = GameFilter(purchase_refunded=BoolCriterion(value=False))
     nested_none = GameFilter(
         purchase_filter=PurchaseFilter(
-            is_refunded=BoolCriterion(value=True), match=Modifier.EXCLUDES
+            is_refunded=BoolCriterion(value=True), match=RelationMatch.NONE
         )
     )
-    assert purchase_ids(flat_false) == purchase_ids(nested_none)
-    assert purchase_ids(flat_false) == {kept.id, none.id}
+    assert _ids(flat_false) == _ids(nested_none)
+    assert _ids(flat_false) == {kept.id, none.id}
 
 
 # ── match round-trip ─────────────────────────────────────────────────────────
@@ -133,15 +132,15 @@ def test_nested_matches_flat_purchase_refunded(db):
 def test_match_json_round_trip():
     f = GameFilter(
         session_filter=SessionFilter(
-            emulated=BoolCriterion(value=True), match=Modifier.EXCLUDES
+            emulated=BoolCriterion(value=True), match=RelationMatch.NONE
         )
     )
     payload = f.to_json()
-    assert payload["session_filter"]["match"] == Modifier.EXCLUDES
+    assert payload["session_filter"]["match"] == RelationMatch.NONE
 
     restored = GameFilter.from_json(json.loads(json.dumps(payload)))
     assert restored is not None and restored.session_filter is not None
-    assert restored.session_filter.match == Modifier.EXCLUDES
+    assert restored.session_filter.match == RelationMatch.NONE
 
 
 def test_default_any_match_is_not_serialized():
@@ -195,4 +194,125 @@ def test_aggregate_round_trip(aggregate_world):
         session_count=AggregateCriterion(value=2, modifier=Modifier.GREATER_THAN)
     )
     restored = GameFilter.from_json(json.loads(json.dumps(f.to_json())))
+    assert restored is not None
     assert _ids(restored) == _ids(f)
+
+
+def test_aggregate_average_duration(db):
+    """session_average uses Avg over the DurationField + duration-hours compare."""
+    pc = Platform.objects.create(name="PC")
+    high = Game.objects.create(name="High", platform=pc)
+    low = Game.objects.create(name="Low", platform=pc)
+    for day in (1, 2):
+        Session.objects.create(
+            game=high,
+            timestamp_start=_dt(2024, 6, day),
+            duration_manual=timedelta(hours=2),
+        )
+    Session.objects.create(
+        game=low, timestamp_start=_dt(), duration_manual=timedelta(hours=1)
+    )
+    over_one_hour = GameFilter(
+        session_average=AggregateCriterion(value=1, modifier=Modifier.GREATER_THAN)
+    )
+    assert _ids(over_one_hour) == {high.id}  # avg 2h vs 1h
+
+
+def test_aggregate_price_sum(db):
+    """purchase_price_total uses float Sum + numeric compare (not duration)."""
+    from decimal import Decimal
+
+    pc = Platform.objects.create(name="PC")
+    pricey = Game.objects.create(name="Pricey", platform=pc)
+    cheap = Game.objects.create(name="Cheap", platform=pc)
+    for amount in (10, 15):
+        purchase = Purchase.objects.create(
+            date_purchased=_dt(), converted_price=Decimal(amount)
+        )
+        purchase.games.set([pricey])
+    purchase = Purchase.objects.create(date_purchased=_dt(), converted_price=Decimal(5))
+    purchase.games.set([cheap])
+
+    over_twenty = GameFilter(
+        purchase_price_total=AggregateCriterion(
+            value=20, modifier=Modifier.GREATER_THAN
+        )
+    )
+    assert _ids(over_twenty) == {pricey.id}  # 25 vs 5
+
+
+# ── NONE on the M2M parent_field + non-Game parents ──────────────────────────
+
+
+def test_m2m_relation_none_excludes_partial_bundle(db):
+    """PurchaseFilter.game_filter NONE negates over the M2M parent_field
+    (`games__id`): a bundle containing the matching game must be excluded."""
+    pc = Platform.objects.create(name="PC")
+    hit = Game.objects.create(name="Hit", platform=pc)
+    miss = Game.objects.create(name="Miss", platform=pc)
+    bundle = Purchase.objects.create(date_purchased=_dt())
+    bundle.games.set([hit, miss])
+    solo = Purchase.objects.create(date_purchased=_dt())
+    solo.games.set([miss])
+    empty = Purchase.objects.create(date_purchased=_dt())
+
+    no_hit = PurchaseFilter(
+        game_filter=GameFilter(
+            name=StringCriterion(value="Hit"), match=RelationMatch.NONE
+        )
+    )
+    purchase_ids = set(
+        Purchase.objects.filter(no_hit.to_q()).distinct().values_list("id", flat=True)
+    )
+    assert purchase_ids == {solo.id, empty.id}  # bundle (contains Hit) excluded
+
+
+def test_relation_none_on_non_game_parent(db):
+    """The shared relation_to_q NONE path works for a non-Game parent
+    (SessionFilter.game_filter)."""
+    pc = Platform.objects.create(name="PC")
+    hit = Game.objects.create(name="Hit", platform=pc)
+    miss = Game.objects.create(name="Miss", platform=pc)
+    Session.objects.create(game=hit, timestamp_start=_dt())
+    keep = Session.objects.create(game=miss, timestamp_start=_dt(2024, 6, 2))
+
+    not_hit = SessionFilter(
+        game_filter=GameFilter(
+            name=StringCriterion(value="Hit"), match=RelationMatch.NONE
+        )
+    )
+    session_ids = set(
+        Session.objects.filter(not_hit.to_q()).values_list("id", flat=True)
+    )
+    assert session_ids == {keep.id}
+
+
+# ── reserved/invalid quantifiers fail loud ───────────────────────────────────
+
+
+def test_all_relation_match_raises(emulated_world):
+    """ALL is reserved — building its Q must raise, not silently degrade."""
+    f = GameFilter(session_filter=SessionFilter(match=RelationMatch.ALL))
+    with pytest.raises(NotImplementedError):
+        f.to_q()
+
+
+def test_aggregate_to_q_not_callable_directly():
+    """AggregateCriterion is evaluated via aggregate_to_q, not the base to_q."""
+    with pytest.raises(NotImplementedError):
+        AggregateCriterion(value=1).to_q("session_count")
+
+
+def test_two_level_match_round_trip():
+    """match survives a round-trip at a nested-deeper-than-one level."""
+    from games.filters import DeviceFilter
+
+    f = GameFilter(
+        session_filter=SessionFilter(
+            device_filter=DeviceFilter(match=RelationMatch.NONE)
+        )
+    )
+    restored = GameFilter.from_json(json.loads(json.dumps(f.to_json())))
+    assert restored is not None and restored.session_filter is not None
+    assert restored.session_filter.device_filter is not None
+    assert restored.session_filter.device_filter.match == RelationMatch.NONE

--- a/tests/test_relation_algebra.py
+++ b/tests/test_relation_algebra.py
@@ -1,0 +1,198 @@
+"""Tests for the relation algebra added in #123 Phase 1:
+
+- relation match-mode (ANY/NONE) on nested cross-entity sub-filters, and its
+  JSON round-trip;
+- equivalence of the new nested NONE form with the old flat NOT-EXISTS
+  convenience fields (the mapping Phase 2's widgets will rely on);
+- the first-class AggregateCriterion (count / sum) replacing the bespoke
+  annotate subqueries.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from common.criteria import AggregateCriterion, BoolCriterion, Modifier
+from games.filters import GameFilter, SessionFilter
+from games.models import Game, Platform, Purchase, Session
+
+
+def _dt(year=2024, month=6, day=1):
+    return datetime(year, month, day, 12, 0, tzinfo=timezone.utc)
+
+
+def _ids(filter_obj):
+    return set(
+        Game.objects.filter(filter_obj.to_q()).distinct().values_list("id", flat=True)
+    )
+
+
+@pytest.fixture
+def emulated_world(db):
+    """Four games spanning every emulated-session combination, including the
+    zero-session edge case that separates ANY/NONE semantics."""
+    pc = Platform.objects.create(name="PC")
+    emu_only = Game.objects.create(name="EmuOnly", platform=pc)
+    both = Game.objects.create(name="Both", platform=pc)
+    non_emu = Game.objects.create(name="NonEmu", platform=pc)
+    no_sessions = Game.objects.create(name="NoSessions", platform=pc)
+
+    Session.objects.create(game=emu_only, timestamp_start=_dt(), emulated=True)
+    Session.objects.create(game=both, timestamp_start=_dt(2024, 6, 2), emulated=True)
+    Session.objects.create(game=both, timestamp_start=_dt(2024, 6, 3), emulated=False)
+    Session.objects.create(
+        game=non_emu, timestamp_start=_dt(2024, 6, 4), emulated=False
+    )
+
+    return {
+        "emu_only": emu_only.id,
+        "both": both.id,
+        "non_emu": non_emu.id,
+        "no_sessions": no_sessions.id,
+    }
+
+
+# ── match-mode semantics ─────────────────────────────────────────────────────
+
+
+def test_relation_any_matches_existence(emulated_world):
+    """ANY (default) = has at least one session matching the sub-filter."""
+    any_emulated = GameFilter(
+        session_filter=SessionFilter(emulated=BoolCriterion(value=True))
+    )
+    assert _ids(any_emulated) == {emulated_world["emu_only"], emulated_world["both"]}
+
+
+def test_relation_none_is_not_exists(emulated_world):
+    """NONE = has no session matching the sub-filter, including games with zero
+    sessions (the case a positive ANY(emulated=False) would miss)."""
+    no_emulated = GameFilter(
+        session_filter=SessionFilter(
+            emulated=BoolCriterion(value=True), match=Modifier.EXCLUDES
+        )
+    )
+    assert _ids(no_emulated) == {
+        emulated_world["non_emu"],
+        emulated_world["no_sessions"],
+    }
+
+
+def test_empty_none_subfilter_means_no_related_rows(emulated_world):
+    """A match-only NONE node (no child criteria) = "has no sessions at all"."""
+    no_sessions = GameFilter(session_filter=SessionFilter(match=Modifier.EXCLUDES))
+    assert _ids(no_sessions) == {emulated_world["no_sessions"]}
+
+
+# ── equivalence with the flat convenience fields (Phase 2 mapping) ───────────
+
+
+def test_nested_matches_flat_session_emulated(emulated_world):
+    """The flat session_emulated bool and the nested match-mode form must select
+    identical games for both True (ANY) and False (NONE)."""
+    for value, match in [(True, Modifier.INCLUDES), (False, Modifier.EXCLUDES)]:
+        flat = GameFilter(session_emulated=BoolCriterion(value=value))
+        nested = GameFilter(
+            session_filter=SessionFilter(
+                emulated=BoolCriterion(value=True), match=match
+            )
+        )
+        assert _ids(flat) == _ids(nested), f"mismatch for value={value}"
+
+
+def test_nested_matches_flat_purchase_refunded(db):
+    pc = Platform.objects.create(name="PC")
+    refunded = Game.objects.create(name="Refunded", platform=pc)
+    kept = Game.objects.create(name="Kept", platform=pc)
+    none = Game.objects.create(name="NoPurchase", platform=pc)
+    Purchase.objects.create(
+        date_purchased=_dt(), date_refunded=_dt(2024, 7, 1)
+    ).games.set([refunded])
+    Purchase.objects.create(date_purchased=_dt()).games.set([kept])
+
+    from games.filters import PurchaseFilter
+
+    def purchase_ids(f):
+        return set(
+            Game.objects.filter(f.to_q()).distinct().values_list("id", flat=True)
+        )
+
+    flat_false = GameFilter(purchase_refunded=BoolCriterion(value=False))
+    nested_none = GameFilter(
+        purchase_filter=PurchaseFilter(
+            is_refunded=BoolCriterion(value=True), match=Modifier.EXCLUDES
+        )
+    )
+    assert purchase_ids(flat_false) == purchase_ids(nested_none)
+    assert purchase_ids(flat_false) == {kept.id, none.id}
+
+
+# ── match round-trip ─────────────────────────────────────────────────────────
+
+
+def test_match_json_round_trip():
+    f = GameFilter(
+        session_filter=SessionFilter(
+            emulated=BoolCriterion(value=True), match=Modifier.EXCLUDES
+        )
+    )
+    payload = f.to_json()
+    assert payload["session_filter"]["match"] == Modifier.EXCLUDES
+
+    restored = GameFilter.from_json(json.loads(json.dumps(payload)))
+    assert restored is not None and restored.session_filter is not None
+    assert restored.session_filter.match == Modifier.EXCLUDES
+
+
+def test_default_any_match_is_not_serialized():
+    """The default ANY quantifier stays implicit, so existing filters serialize
+    byte-identically (no spurious "match" key)."""
+    f = GameFilter(session_filter=SessionFilter(emulated=BoolCriterion(value=True)))
+    assert "match" not in f.to_json()["session_filter"]
+
+
+# ── AggregateCriterion ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def aggregate_world(db):
+    pc = Platform.objects.create(name="PC")
+    busy = Game.objects.create(name="Busy", platform=pc)
+    quiet = Game.objects.create(name="Quiet", platform=pc)
+    Game.objects.create(name="Idle", platform=pc)  # zero sessions
+
+    for day in (1, 2, 3):
+        Session.objects.create(
+            game=busy,
+            timestamp_start=_dt(2024, 6, day),
+            duration_manual=timedelta(hours=2),
+        )
+    Session.objects.create(
+        game=quiet, timestamp_start=_dt(), duration_manual=timedelta(hours=1)
+    )
+    return {"busy": busy.id, "quiet": quiet.id}
+
+
+def test_aggregate_count(aggregate_world):
+    over_two = GameFilter(
+        session_count=AggregateCriterion(value=2, modifier=Modifier.GREATER_THAN)
+    )
+    assert _ids(over_two) == {aggregate_world["busy"]}
+
+
+def test_aggregate_duration_sum(aggregate_world):
+    """manual_playtime_hours sums duration_manual across the game's sessions."""
+    over_three_hours = GameFilter(
+        manual_playtime_hours=AggregateCriterion(
+            value=3, modifier=Modifier.GREATER_THAN
+        )
+    )
+    assert _ids(over_three_hours) == {aggregate_world["busy"]}  # 6h vs 1h
+
+
+def test_aggregate_round_trip(aggregate_world):
+    f = GameFilter(
+        session_count=AggregateCriterion(value=2, modifier=Modifier.GREATER_THAN)
+    )
+    restored = GameFilter.from_json(json.loads(json.dumps(f.to_json())))
+    assert _ids(restored) == _ids(f)


### PR DESCRIPTION
Phase 1 of #123 — the model-layer foundation that makes the nested cross-entity representation a true superset of the flat convenience fields. No JSON-key or UI changes yet; the bar and flat fields keep working unchanged.

## What's in here

- **Relation match-mode quantifier** on `OperatorFilter` (`match`, reusing the `Modifier` enum: `ANY=INCLUDES` default, `NONE=EXCLUDES`, `ALL=INCLUDES_ALL` reserved) + JSON round-trip. Closes the NOT-EXISTS representational gap that the flat bool fields (`session_emulated=False`, etc.) secretly relied on. Stash-grounded (Stash reuses `CriterionModifier` for the same purpose).
- **First-class `AggregateCriterion`** (count / sum / avg over a relation) plus shared `aggregate_to_q` / `relation_to_q` / `duration_hours_to_q` helpers.
- **Dissolved duplication**: the 7 bespoke aggregate annotate blocks and every nested-relation subquery across all six filters now route through the shared helpers. The hours↔timedelta logic is DRYed into one helper.

Behaviour-preserving: default ANY + identical emitted JSON keys; the full existing suite stays green (709 passing).

## Tests

New `tests/test_relation_algebra.py`: ANY/NONE semantics (incl. the zero-related-rows edge case), nested==flat equivalence (the mapping Phase 2 widgets will use), match round-trip, and the aggregate criterion (count + duration sum + round-trip).

## Not in this PR (follow-ups)

- Phase 2: generic path-based serializer + codegen + prefill (repoints widgets to nested paths).
- Phase 3: delete the flat convenience fields.
- Deferred issues filed: #126 (widget UX rethink), #127 (n-ary boolean), #128 (implement ALL), #129 (field-to-field comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)