### PR TITLE
Implement ALL relation match (#128)

### DIFF
--- a/common/criteria.py
+++ b/common/criteria.py
@@ -90,7 +90,7 @@ class RelationMatch(str, Enum):
 
     ANY = "ANY"  # ≥1 related row matches the sub-filter (EXISTS)
     NONE = "NONE"  # no related row matches (NOT EXISTS); includes zero-row parents
-    ALL = "ALL"  # every related row matches (reserved; not yet implemented)
+    ALL = "ALL"  # every related row matches; vacuously true for zero-row parents
 
 
 # ── Base criterion ─────────────────────────────────────────────────────────
@@ -821,26 +821,37 @@ def relation_to_q(
     related_lookup: str,
     parent_field: str = "id",
 ) -> Q:
-    """EXISTS / NOT-EXISTS subquery for a nested cross-entity sub-filter.
+    """EXISTS / NOT-EXISTS / FOR-ALL subquery for a nested cross-entity sub-filter.
 
-    Builds ``parent_field IN (<related rows matching sub>.related_lookup)``; the
-    sub-filter's ``match`` quantifier selects ANY (the EXISTS) vs NONE (its
-    negation). ALL is reserved but unimplemented. The branch is exhaustive — an
-    unexpected match raises rather than silently degrading to ANY.
+    The sub-filter's ``match`` quantifier picks the set semantics, each expressed
+    as a ``parent_field IN (...)`` membership over a subquery of related rows:
+
+    - ANY (default): ``parent_field IN (<related rows matching sub>)`` — the
+      parent has at least one matching related row (EXISTS).
+    - NONE: the negation of ANY — the parent has no matching related row (NOT
+      EXISTS). Zero-related-row parents are included.
+    - ALL: every related row matches the sub-filter. Implemented as the absence
+      of any *violating* (non-matching) related row:
+      ``~Q(parent_field IN (<related rows NOT matching sub>))``.
+
+      **Vacuous truth is INCLUDED**: a parent with zero related rows has no
+      violating row, so it matches ALL — the standard ∀ semantics. The
+      alternative (requiring ≥1 related row, i.e. ``ANY AND ALL``) was considered
+      and rejected as the default; callers wanting it can AND an ANY sub-filter.
+
+    The branch is exhaustive — an unexpected match raises rather than silently
+    degrading to ANY.
     """
-    ids = related_model.objects.filter(sub.to_q()).values_list(
-        related_lookup, flat=True
-    )
-    base = Q(**{f"{parent_field}__in": ids})
+    related = related_model.objects.all()
     if sub.match == RelationMatch.ANY:
-        return base
+        matching = related.filter(sub.to_q()).values_list(related_lookup, flat=True)
+        return Q(**{f"{parent_field}__in": matching})
     if sub.match == RelationMatch.NONE:
-        return ~base
+        matching = related.filter(sub.to_q()).values_list(related_lookup, flat=True)
+        return ~Q(**{f"{parent_field}__in": matching})
     if sub.match == RelationMatch.ALL:
-        raise NotImplementedError(
-            "ALL relation match on a nested sub-filter is not implemented yet; "
-            "see the follow-up issue (#128)."
-        )
+        violating = related.filter(~sub.to_q()).values_list(related_lookup, flat=True)
+        return ~Q(**{f"{parent_field}__in": violating})
     raise ValueError(f"Unsupported relation match {sub.match!r}")
 
 

--- a/tests/test_relation_algebra.py
+++ b/tests/test_relation_algebra.py
@@ -287,14 +287,63 @@ def test_relation_none_on_non_game_parent(db):
     assert session_ids == {keep.id}
 
 
+# ── ALL relation match (every related row matches; vacuous truth INCLUDED) ────
+
+
+def test_relation_all_every_row_matches_included(emulated_world):
+    """ALL = every related row matches the sub-filter.
+
+    EmuOnly (one emulated session) qualifies; Both (one emulated + one not) has a
+    violating row and is excluded; NonEmu (one non-emulated) is excluded; and
+    NoSessions has no related rows, so it matches vacuously (∀ over an empty set).
+    """
+    all_emulated = GameFilter(
+        session_filter=SessionFilter(
+            emulated=BoolCriterion(value=True), match=RelationMatch.ALL
+        )
+    )
+    assert _ids(all_emulated) == {
+        emulated_world["emu_only"],
+        emulated_world["no_sessions"],
+    }
+
+
+def test_relation_all_excludes_mixed_rows(emulated_world):
+    """A parent with a mix of matching and violating rows is excluded from ALL."""
+    all_emulated = GameFilter(
+        session_filter=SessionFilter(
+            emulated=BoolCriterion(value=True), match=RelationMatch.ALL
+        )
+    )
+    assert emulated_world["both"] not in _ids(all_emulated)
+
+
+def test_relation_all_vacuous_truth_includes_zero_row_parent(emulated_world):
+    """A parent with ZERO related rows matches ALL (vacuous truth)."""
+    all_emulated = GameFilter(
+        session_filter=SessionFilter(
+            emulated=BoolCriterion(value=True), match=RelationMatch.ALL
+        )
+    )
+    assert emulated_world["no_sessions"] in _ids(all_emulated)
+
+
+def test_all_match_json_round_trip():
+    """match=ALL serializes as {"match": "ALL"} and rebuilds identically."""
+    f = GameFilter(
+        session_filter=SessionFilter(
+            emulated=BoolCriterion(value=True), match=RelationMatch.ALL
+        )
+    )
+    payload = f.to_json()
+    assert payload["session_filter"]["match"] == RelationMatch.ALL
+
+    restored = GameFilter.from_json(json.loads(json.dumps(payload)))
+    assert restored is not None and restored.session_filter is not None
+    assert restored.session_filter.match == RelationMatch.ALL
+
+
 # ── reserved/invalid quantifiers fail loud ───────────────────────────────────
-
-
-def test_all_relation_match_raises(emulated_world):
-    """ALL is reserved — building its Q must raise, not silently degrade."""
-    f = GameFilter(session_filter=SessionFilter(match=RelationMatch.ALL))
-    with pytest.raises(NotImplementedError):
-        f.to_q()
 
 
 def test_aggregate_to_q_not_callable_directly():


### PR DESCRIPTION
Closes #128. Follow-up from #123 (relation algebra Phase 1).

## What

Implements `RelationMatch.ALL` in `relation_to_q` (`common/criteria.py`), which previously raised `NotImplementedError`. `ALL` means "every related row matches the sub-filter".

It is expressed as the absence of any *violating* (non-matching) related row:

```python
violating = related_model.objects.filter(~sub.to_q()).values_list(related_lookup, flat=True)
return ~Q(**{f"{parent_field}__in": violating})
```

`relation_to_q` is restructured so each branch builds its own membership subquery:

- **ANY** (default) → `Q(parent_field__in = related.filter(sub.to_q()))` (EXISTS)
- **NONE** → the negation of the ANY set (NOT EXISTS)
- **ALL** → `~Q(parent_field__in = related.filter(~sub.to_q()))`

The branch stays exhaustive — an unexpected `match` raises `ValueError` rather than silently degrading to ANY.

## Vacuous-truth decision

**Vacuous truth is INCLUDED**: a parent with zero related rows has no violating row, so it matches `ALL`. This is the standard ∀ ("for all") semantics — a universally-quantified statement over an empty set is true.

The alternative — requiring ≥1 related row (i.e. `ANY AND ALL`) — was **considered and rejected** as the default. Callers who want the non-vacuous variant can AND an `ANY` sub-filter alongside. This decision is documented in both the `relation_to_q` docstring and the `RelationMatch.ALL` enum comment.

## Tests

In `tests/test_relation_algebra.py`, `test_all_relation_match_raises` is replaced with real ALL-behaviour coverage:

- every related row matches → parent included
- a mix of matching + violating rows → parent excluded
- zero related rows → parent included (vacuous truth)
- `match=RelationMatch.ALL` JSON round-trip (`{"match": "ALL"}` serializes and rebuilds)

## Verification

- `pytest tests/test_relation_algebra.py tests/test_filters.py tests/test_stats_links.py` → 164 passed
- `ruff check common/ tests/` → all checks passed
- `ruff format` applied; `mypy common/criteria.py` → no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)