### PR TITLE
Generic path-driven filter serialization + validation (#123 Phase 2 mechanism)

### DIFF
--- a/common/components/date_range_picker.py
+++ b/common/components/date_range_picker.py
@@ -19,7 +19,13 @@ widget into a ``DateCriterion`` unchanged. All behaviour is wired by
 
 from common.components.core import Element, Node, Safe
 from common.components.custom_elements import _DateRangePicker
-from common.components.primitives import Div, Input, Span
+from common.components.primitives import (
+    Div,
+    FilterWidgetPath,
+    Input,
+    Span,
+    filter_widget_attributes,
+)
 from common.time import DatePartSpec, date_parts
 
 _FIELD_CONTAINER_CLASS = (
@@ -175,6 +181,7 @@ def DateRangeField(
                     ("id", min_input_id),
                     ("value", min_value),
                     ("data-date-range-hidden", "min"),
+                    ("data-range-min", ""),
                 ],
             ),
             Input(
@@ -184,6 +191,7 @@ def DateRangeField(
                     ("id", max_input_id),
                     ("value", max_value),
                     ("data-date-range-hidden", "max"),
+                    ("data-range-max", ""),
                 ],
             ),
             _segment_group(side="min", label=label, iso_value=min_value),
@@ -325,6 +333,7 @@ def DateRangePicker(
     input_name_prefix: str,
     min_value: str = "",
     max_value: str = "",
+    path: FilterWidgetPath | None = None,
 ) -> Node:
     """A date-range widget: segmented manual entry plus a calendar popup.
 
@@ -332,8 +341,15 @@ def DateRangePicker(
     ``{prefix}-min`` / ``{prefix}-max`` ISO inputs, so the filter-bar
     serializer needs no changes. ``min_value`` / ``max_value`` are ISO
     ``YYYY-MM-DD`` strings used to prefill both the segments and the hidden
-    inputs."""
-    return _DateRangePicker(class_="relative")[
+    inputs.
+
+    Filter-bar callers pass ``path`` so the root self-describes for the generic
+    filter serializer; non-filter callers (e.g. a standalone date picker) leave
+    it None and the extra attributes are omitted."""
+    widget_attributes = (
+        filter_widget_attributes(path, "date") if path is not None else []
+    )
+    return _DateRangePicker(widget_attributes, class_="relative")[
         DateRangeField(
             label=label,
             input_name_prefix=input_name_prefix,

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -5,7 +5,16 @@ from typing import NamedTuple
 from common.components.core import BaseComponent, Element, Node, Safe
 from common.components.custom_elements import _FilterBarElement
 from common.components.date_range_picker import DateRangePicker
-from common.components.primitives import Checkbox, Div, Input, Label, Radio, Span
+from common.components.primitives import (
+    Checkbox,
+    Div,
+    FilterWidgetPath,
+    Input,
+    Label,
+    Radio,
+    Span,
+    filter_widget_attributes,
+)
 from common.components.search_select import (
     DEFAULT_PREFETCH,
     FilterSelect,
@@ -228,6 +237,7 @@ def _enum_filter(field_name: str, options, choice: FilterChoice, *, nullable) ->
         excluded=excluded,
         modifier=modifier,
         modifier_options=_modifier_options(nullable),
+        path=[field_name],
     )
 
 
@@ -255,6 +265,7 @@ def _model_filter(
         modifier_options=_modifier_options(nullable, m2m_modifiers),
         search_url=search_url,
         prefetch=DEFAULT_PREFETCH,
+        path=[field_name],
     )
 
 
@@ -307,10 +318,15 @@ def _filter_checkbox(name: str, label: str, checked: bool) -> Node:
     return Checkbox(name=name, label=label, checked=checked)
 
 
-def _filter_boolean_radio(name: str, label: str, value: bool | None) -> Node:
+def _filter_boolean_radio(
+    name: str, label: str, value: bool | None, *, path: FilterWidgetPath
+) -> Node:
     """Renders a filter-specific boolean radio button group with 'True' and 'False' options."""
     return Div(
-        attributes=[("class", "flex flex-col gap-1")],
+        attributes=[
+            ("class", "flex flex-col gap-1"),
+            *filter_widget_attributes(path, "bool"),
+        ],
         children=[
             Span(
                 attributes=[("class", _FILTER_LABEL_CLASS)],
@@ -339,6 +355,7 @@ def DateRangeFilter(
     *,
     label: str,
     input_name_prefix: str,
+    path: FilterWidgetPath,
     min_value: str = "",
     max_value: str = "",
     min_placeholder: str = "From",
@@ -354,7 +371,10 @@ def DateRangeFilter(
     min_input_id = f"{input_name_prefix}-min"
     max_input_id = f"{input_name_prefix}-max"
     return Div(
-        attributes=[("class", "date-range-block mb-4")],
+        attributes=[
+            ("class", "date-range-block mb-4"),
+            *filter_widget_attributes(path, "date"),
+        ],
         children=[
             Div(
                 attributes=[("class", "flex items-center gap-2")],
@@ -367,6 +387,7 @@ def DateRangeFilter(
                             ("value", min_value),
                             ("placeholder", min_placeholder),
                             ("aria-label", f"{label} from"),
+                            ("data-range-min", ""),
                             ("class", _DATE_RANGE_INPUT_CLASS),
                         ],
                     ),
@@ -382,6 +403,7 @@ def DateRangeFilter(
                             ("value", max_value),
                             ("placeholder", max_placeholder),
                             ("aria-label", f"{label} to"),
+                            ("data-range-max", ""),
                             ("class", _DATE_RANGE_INPUT_CLASS),
                         ],
                     ),
@@ -713,6 +735,7 @@ def _game_fields(
                         value=playevent_note_value,
                         modifier=playevent_note_modifier,
                         placeholder="e.g. Completed, Started",
+                        path=["playevent_note"],
                     ),
                 ),
                 _filter_field(
@@ -724,6 +747,7 @@ def _game_fields(
                         modifier=year.modifier,
                         placeholder="e.g. 2020",
                         placeholder2="e.g. 2024",
+                        path=["year_released"],
                     ),
                 ),
                 _filter_field(
@@ -735,6 +759,7 @@ def _game_fields(
                         modifier=original_year.modifier,
                         placeholder="e.g. 1985",
                         placeholder2="e.g. 2010",
+                        path=["original_year_released"],
                     ),
                 ),
                 _filter_field(
@@ -746,6 +771,7 @@ def _game_fields(
                         modifier=playtime.modifier,
                         placeholder="e.g. 1",
                         placeholder2="e.g. 100",
+                        path=["playtime_hours"],
                     ),
                 ),
                 _filter_field(
@@ -757,6 +783,7 @@ def _game_fields(
                         modifier=manual_pt.modifier,
                         placeholder="e.g. 1",
                         placeholder2="e.g. 10",
+                        path=["manual_playtime_hours"],
                     ),
                 ),
                 _filter_field(
@@ -768,6 +795,7 @@ def _game_fields(
                         modifier=calc_pt.modifier,
                         placeholder="e.g. 1",
                         placeholder2="e.g. 10",
+                        path=["calculated_playtime_hours"],
                     ),
                 ),
                 _filter_field(
@@ -779,6 +807,7 @@ def _game_fields(
                         modifier=session_count.modifier,
                         placeholder="e.g. 1",
                         placeholder2="e.g. 50",
+                        path=["session_count"],
                     ),
                 ),
                 _filter_field(
@@ -790,6 +819,7 @@ def _game_fields(
                         modifier=session_avg.modifier,
                         placeholder="e.g. 10",
                         placeholder2="e.g. 120",
+                        path=["session_average"],
                     ),
                 ),
                 _filter_field(
@@ -801,6 +831,7 @@ def _game_fields(
                         modifier=purchase_count.modifier,
                         placeholder="e.g. 1",
                         placeholder2="e.g. 5",
+                        path=["purchase_count"],
                     ),
                 ),
                 _filter_field(
@@ -812,6 +843,7 @@ def _game_fields(
                         modifier=playevent_count.modifier,
                         placeholder="e.g. 1",
                         placeholder2="e.g. 5",
+                        path=["playevent_count"],
                     ),
                 ),
                 _filter_field(
@@ -821,6 +853,7 @@ def _game_fields(
                         input_name_prefix="filter-finished",
                         min_value=finished_min,
                         max_value=finished_max,
+                        path=["finished"],
                     ),
                 ),
                 _filter_field(
@@ -833,6 +866,7 @@ def _game_fields(
                         placeholder="0",
                         placeholder2="e.g. 100",
                         step="0.01",
+                        path=["purchase_price_total"],
                     ),
                 ),
                 _filter_field(
@@ -845,6 +879,7 @@ def _game_fields(
                         placeholder="0",
                         placeholder2="e.g. 100",
                         step="0.01",
+                        path=["purchase_price_any"],
                     ),
                 ),
             ],
@@ -852,15 +887,26 @@ def _game_fields(
         Div(
             attributes=[("class", "flex items-end gap-6 mb-4 flex-wrap")],
             children=[
-                _filter_boolean_radio("filter-mastered", "Mastered", mastered_value),
                 _filter_boolean_radio(
-                    "filter-purchase-refunded", "Refunded", purchase_refunded_value
+                    "filter-mastered", "Mastered", mastered_value, path=["mastered"]
                 ),
                 _filter_boolean_radio(
-                    "filter-purchase-infinite", "Infinite", purchase_infinite_value
+                    "filter-purchase-refunded",
+                    "Refunded",
+                    purchase_refunded_value,
+                    path=["purchase_refunded"],
                 ),
                 _filter_boolean_radio(
-                    "filter-session-emulated", "Emulated", session_emulated_value
+                    "filter-purchase-infinite",
+                    "Infinite",
+                    purchase_infinite_value,
+                    path=["purchase_infinite"],
+                ),
+                _filter_boolean_radio(
+                    "filter-session-emulated",
+                    "Emulated",
+                    session_emulated_value,
+                    path=["session_emulated"],
                 ),
             ],
         ),
@@ -925,6 +971,7 @@ def _session_fields(existing: dict) -> list:
                         value=note_value,
                         modifier=note_modifier,
                         placeholder="e.g. Boss fight, speedrun",
+                        path=["note"],
                     ),
                 ),
             ],
@@ -938,6 +985,7 @@ def _session_fields(existing: dict) -> list:
                 modifier=dur_tot.modifier,
                 placeholder="e.g. 1",
                 placeholder2="e.g. 10",
+                path=["duration_total_hours"],
             ),
         ),
         _filter_field(
@@ -949,6 +997,7 @@ def _session_fields(existing: dict) -> list:
                 modifier=dur_man.modifier,
                 placeholder="e.g. 1",
                 placeholder2="e.g. 10",
+                path=["duration_manual_hours"],
             ),
         ),
         _filter_field(
@@ -960,13 +1009,18 @@ def _session_fields(existing: dict) -> list:
                 modifier=dur_calc.modifier,
                 placeholder="e.g. 1",
                 placeholder2="e.g. 10",
+                path=["duration_calculated_hours"],
             ),
         ),
         Div(
             attributes=[("class", "flex gap-6 mb-4")],
             children=[
-                _filter_boolean_radio("filter-emulated", "Emulated", emulated_value),
-                _filter_boolean_radio("filter-active", "Active", is_active_value),
+                _filter_boolean_radio(
+                    "filter-emulated", "Emulated", emulated_value, path=["emulated"]
+                ),
+                _filter_boolean_radio(
+                    "filter-active", "Active", is_active_value, path=["is_active"]
+                ),
             ],
         ),
     ]
@@ -1062,6 +1116,7 @@ def _purchase_fields(existing: dict) -> list:
                                 value=price_currency_value,
                                 modifier=price_currency_modifier,
                                 placeholder="e.g. USD, EUR",
+                                path=["price_currency"],
                             ),
                         ),
                         _filter_field(
@@ -1071,6 +1126,7 @@ def _purchase_fields(existing: dict) -> list:
                                 value=converted_currency_value,
                                 modifier=converted_currency_modifier,
                                 placeholder="e.g. USD, EUR",
+                                path=["converted_currency"],
                             ),
                         ),
                     ],
@@ -1082,6 +1138,7 @@ def _purchase_fields(existing: dict) -> list:
                         input_name_prefix="filter-date-purchased",
                         min_value=date_purchased_min,
                         max_value=date_purchased_max,
+                        path=["date_purchased"],
                     ),
                 ),
                 _filter_field(
@@ -1091,6 +1148,7 @@ def _purchase_fields(existing: dict) -> list:
                         input_name_prefix="filter-date-refunded",
                         min_value=date_refunded_min,
                         max_value=date_refunded_max,
+                        path=["date_refunded"],
                     ),
                 ),
                 _filter_field(
@@ -1100,6 +1158,7 @@ def _purchase_fields(existing: dict) -> list:
                         input_name_prefix="filter-finished",
                         min_value=finished_min,
                         max_value=finished_max,
+                        path=["finished"],
                     ),
                 ),
                 _filter_field(
@@ -1112,6 +1171,7 @@ def _purchase_fields(existing: dict) -> list:
                         placeholder="0.00",
                         placeholder2="100.00",
                         step="0.01",
+                        path=["price"],
                     ),
                 ),
                 _filter_field(
@@ -1123,21 +1183,29 @@ def _purchase_fields(existing: dict) -> list:
                         modifier=num.modifier,
                         placeholder="e.g. 1",
                         placeholder2="e.g. 5",
+                        path=["num_purchases"],
                     ),
                 ),
                 Div(
                     attributes=[("class", "flex flex-col items-start gap-4 mb-4")],
                     children=[
                         _filter_boolean_radio(
-                            "filter-refunded", "Refunded", is_refunded_value
+                            "filter-refunded",
+                            "Refunded",
+                            is_refunded_value,
+                            path=["is_refunded"],
                         ),
                         _filter_boolean_radio(
-                            "filter-infinite", "Infinite", infinite_value
+                            "filter-infinite",
+                            "Infinite",
+                            infinite_value,
+                            path=["infinite"],
                         ),
                         _filter_boolean_radio(
                             "filter-needs-price-update",
                             "Needs Price Update",
                             needs_price_update_value,
+                            path=["needs_price_update"],
                         ),
                     ],
                 ),
@@ -1203,6 +1271,7 @@ def _platform_fields(existing: dict) -> list:
                         value=name_value,
                         modifier=name_modifier,
                         placeholder="e.g. Nintendo Switch",
+                        path=["name"],
                     ),
                 ),
                 _filter_field(
@@ -1212,6 +1281,7 @@ def _platform_fields(existing: dict) -> list:
                         value=group_value,
                         modifier=group_modifier,
                         placeholder="e.g. Nintendo",
+                        path=["group"],
                     ),
                 ),
             ],
@@ -1255,6 +1325,7 @@ def _playevent_fields(existing: dict) -> list:
                 input_name_prefix="filter-started",
                 min_value=started_min,
                 max_value=started_max,
+                path=["started"],
             ),
         ),
         _filter_field(
@@ -1264,6 +1335,7 @@ def _playevent_fields(existing: dict) -> list:
                 input_name_prefix="filter-ended",
                 min_value=ended_min,
                 max_value=ended_max,
+                path=["ended"],
             ),
         ),
         _filter_field(
@@ -1275,6 +1347,7 @@ def _playevent_fields(existing: dict) -> list:
                 modifier=days.modifier,
                 placeholder="e.g. 1",
                 placeholder2="e.g. 30",
+                path=["days_to_finish"],
             ),
         ),
     ]
@@ -1286,6 +1359,8 @@ def StringFilter(
     value: str = "",
     modifier: str = "EQUALS",
     placeholder: str = "",
+    *,
+    path: FilterWidgetPath,
 ) -> Node:
     """Renders a string filter with 8 modifier radio options and a text input."""
     from common.criteria import Modifier
@@ -1341,7 +1416,10 @@ def StringFilter(
         input_attrs.append(("disabled", "true"))
 
     return Div(
-        attributes=[("class", "flex flex-col gap-2 @container")],
+        attributes=[
+            ("class", "flex flex-col gap-2 @container"),
+            *filter_widget_attributes(path, "string"),
+        ],
         children=[
             Div(
                 attributes=[
@@ -1372,6 +1450,8 @@ def NumberFilter(
     placeholder: str = "",
     placeholder2: str = "",
     step: str = "1",
+    *,
+    path: FilterWidgetPath,
 ) -> Node:
     """Renders a numeric filter with 8 modifier radio options and two inputs.
 
@@ -1440,7 +1520,10 @@ def NumberFilter(
         value2_attrs.append(("disabled", "true"))
 
     return Div(
-        attributes=[("class", "flex flex-col gap-2 @container")],
+        attributes=[
+            ("class", "flex flex-col gap-2 @container"),
+            *filter_widget_attributes(path, "number"),
+        ],
         children=[
             Div(
                 attributes=[

--- a/common/components/primitives.py
+++ b/common/components/primitives.py
@@ -7,6 +7,7 @@ classes or behaviour (``StyledButton``, ``Pill``, ``Checkbox`` …) are written 
 Everything returns a :class:`Node`; string-built widgets return :class:`Safe`.
 """
 
+import json
 from collections.abc import Mapping, Sequence
 from typing import Literal, NamedTuple, NotRequired, TypedDict
 
@@ -56,6 +57,31 @@ _SIZE_CLASSES = {
 # SearchSelect), on the wrapper via :has() (DISABLED_WITHIN_CLASS).
 DISABLED_CONTROL_CLASS = "disabled:opacity-50 disabled:cursor-not-allowed"
 DISABLED_WITHIN_CLASS = "has-[:disabled]:opacity-50 has-[:disabled]:cursor-not-allowed"
+
+
+# A filter widget's canonical filter-JSON key chain. Length-1 today (one JSON
+# key per widget); typed as a list so nested paths stay expressible later.
+# Example: ["year_released"].
+type FilterWidgetPath = list[str]
+
+# What the future generic TS serializer reads a widget's value as.
+type FilterWidgetKind = str  # "string" | "number" | "date" | "bool" | "set"
+
+
+def filter_widget_attributes(
+    path: FilterWidgetPath, kind: FilterWidgetKind
+) -> list[HTMLAttribute]:
+    """The three self-describe attributes every filter-bar widget root carries.
+
+    A later generic TS serializer reads ``data-path`` (the widget's filter-JSON
+    key, as a JSON array) and ``data-kind`` off any ``[data-filter-widget]`` root
+    to handle all widgets uniformly. See issue #123 Phase 2. This slice only
+    emits the attributes; nothing reads them yet, so behaviour is unchanged."""
+    return [
+        ("data-filter-widget", ""),
+        ("data-path", json.dumps(path)),
+        ("data-kind", kind),
+    ]
 
 # The single max-width every content container obeys — navbar, page bodies
 # (lists, detail, stats), and popovers. Only a cap: callers add

--- a/common/components/primitives.py
+++ b/common/components/primitives.py
@@ -32,6 +32,7 @@ from common.components.core import (
     randomid,
 )
 from common.components.icons_generated import ICON_NODES
+from common.criteria import FilterWidgetKind, FilterWidgetPath
 from common.sorting import SortString, SortTerm, collapse_sort, cycle_sort
 from common.utils import truncate
 
@@ -59,29 +60,23 @@ DISABLED_CONTROL_CLASS = "disabled:opacity-50 disabled:cursor-not-allowed"
 DISABLED_WITHIN_CLASS = "has-[:disabled]:opacity-50 has-[:disabled]:cursor-not-allowed"
 
 
-# A filter widget's canonical filter-JSON key chain. Length-1 today (one JSON
-# key per widget); typed as a list so nested paths stay expressible later.
-# Example: ["year_released"].
-type FilterWidgetPath = list[str]
-
-# What the future generic TS serializer reads a widget's value as.
-type FilterWidgetKind = str  # "string" | "number" | "date" | "bool" | "set"
-
-
 def filter_widget_attributes(
     path: FilterWidgetPath, kind: FilterWidgetKind
 ) -> list[HTMLAttribute]:
     """The three self-describe attributes every filter-bar widget root carries.
 
-    A later generic TS serializer reads ``data-path`` (the widget's filter-JSON
-    key, as a JSON array) and ``data-kind`` off any ``[data-filter-widget]`` root
-    to handle all widgets uniformly. See issue #123 Phase 2. This slice only
-    emits the attributes; nothing reads them yet, so behaviour is unchanged."""
+    The generic serializer in ``ts/elements/filter-bar.ts`` reads ``data-path``
+    (the widget's filter-JSON key, as a JSON array) and ``data-kind`` off any
+    ``[data-filter-widget]`` root to handle all widgets uniformly. See issue #123
+    Phase 2. Behaviour is unchanged because that serializer is a behaviour-
+    preserving port of the former hardcoded per-field loops, not because the
+    attributes go unread."""
     return [
         ("data-filter-widget", ""),
         ("data-path", json.dumps(path)),
         ("data-kind", kind),
     ]
+
 
 # The single max-width every content container obeys — navbar, page bodies
 # (lists, detail, stats), and popovers. Only a cap: callers add

--- a/common/components/search_select.py
+++ b/common/components/search_select.py
@@ -40,10 +40,12 @@ from common.components.custom_elements import _SearchSelect
 from common.components.primitives import (
     DISABLED_WITHIN_CLASS,
     Div,
+    FilterWidgetPath,
     Input,
     Pill,
     Span,
     Template,
+    filter_widget_attributes,
 )
 
 
@@ -459,6 +461,7 @@ def FilterSelect(
     placeholder: str = "Search…",
     id: str = "",
     free_text: bool = False,
+    path: FilterWidgetPath | None = None,
 ) -> Node:
     """Include/exclude filter combobox built on the shared ``_combobox_shell``.
 
@@ -567,7 +570,14 @@ def FilterSelect(
         items_visible=items_visible,
         templates=templates,
     )
+    # The self-describe root attributes for the generic filter serializer. Only
+    # filter-bar callers pass ``path``; synthetic/test callers leave it None and
+    # get no extra attributes (kind is always "set" for a FilterSelect).
+    widget_attributes = (
+        filter_widget_attributes(path, "set") if path is not None else []
+    )
     return _SearchSelect(
+        widget_attributes,
         name=field_name,
         search_url=search_url,
         multi="true",

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -504,12 +504,23 @@ def _filter_class_for(
     return None
 
 
+# A filter widget's canonical filter-JSON key chain. Length-1 today (one JSON
+# key per widget); typed as a list so nested cross-entity paths stay expressible.
+# Example: ["session_filter", "emulated"].
+type FilterWidgetPath = list[str]
+
+# The widget ``data-kind`` token a criterion advertises to the generic filter-bar
+# serializer (ts/elements/filter-bar.ts). One token per value shape; several
+# criterion types share a kind (every numeric criterion → "number").
+type FilterWidgetKind = Literal["string", "number", "date", "bool", "set"]
+
+
 # Maps a criterion class to the widget ``data-kind`` token a filter-bar widget
 # advertises for it (see ``filter_widget_attributes``). The server↔client
 # contract: a widget's ``data-kind`` must equal the kind of the criterion its
 # ``data-path`` resolves to. Several criterion types share a kind (every numeric
 # criterion → "number"; both set criteria → "set").
-_CRITERION_KINDS: dict[type[_Criterion], str] = {
+_CRITERION_KINDS: dict[type[_Criterion], FilterWidgetKind] = {
     StringCriterion: "string",
     IntCriterion: "number",
     FloatCriterion: "number",
@@ -521,7 +532,7 @@ _CRITERION_KINDS: dict[type[_Criterion], str] = {
 }
 
 
-def criterion_kind(criterion_cls: type[_Criterion]) -> str:
+def criterion_kind(criterion_cls: type[_Criterion]) -> FilterWidgetKind:
     """Return the widget ``data-kind`` token for a criterion class.
 
     Raises ``ValueError`` for a criterion type with no registered kind, so a new
@@ -534,7 +545,9 @@ def criterion_kind(criterion_cls: type[_Criterion]) -> str:
         ) from None
 
 
-def resolve_path_kind(filter_cls: type["OperatorFilter"], path: list[str]) -> str:
+def resolve_path_kind(
+    filter_cls: type["OperatorFilter"], path: FilterWidgetPath
+) -> FilterWidgetKind:
     """Resolve a filter-widget ``data-path`` against a filter dataclass tree and
     return the expected ``data-kind``.
 

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -476,6 +476,96 @@ def _criterion_class_for(
     return None
 
 
+def _filter_class_for(
+    cls: type["OperatorFilter"], field_name: str
+) -> type["OperatorFilter"] | None:
+    """Resolve the cross-entity sub-filter class declared for ``field_name`` on a
+    filter, or None if the field is absent or isn't a sub-filter field.
+
+    Mirrors ``_criterion_class_for`` but resolves the field's (string) annotation
+    through ``_FILTER_TYPES`` — e.g. ``GameFilter.session_filter`` annotated
+    ``"SessionFilter | None"`` resolves to ``SessionFilter``. The same-class
+    AND/OR/NOT operator fields are deliberately excluded: they compose a filter
+    with itself rather than crossing to another entity, and a widget path never
+    steps through them."""
+    if field_name in _OPERATOR_FIELDS:
+        return None
+    for dataclass_field in dc_fields(cls):
+        if dataclass_field.name != field_name:
+            continue
+        field_type = dataclass_field.type
+        if isinstance(field_type, str):
+            # e.g. "SessionFilter | None" → "SessionFilter"
+            field_type = field_type.split("|")[0].strip()
+            return _FILTER_TYPES.get(field_type)
+        if isinstance(field_type, type) and issubclass(field_type, OperatorFilter):
+            return field_type
+        return None
+    return None
+
+
+# Maps a criterion class to the widget ``data-kind`` token a filter-bar widget
+# advertises for it (see ``filter_widget_attributes``). The server↔client
+# contract: a widget's ``data-kind`` must equal the kind of the criterion its
+# ``data-path`` resolves to. Several criterion types share a kind (every numeric
+# criterion → "number"; both set criteria → "set").
+_CRITERION_KINDS: dict[type[_Criterion], str] = {
+    StringCriterion: "string",
+    IntCriterion: "number",
+    FloatCriterion: "number",
+    AggregateCriterion: "number",
+    DateCriterion: "date",
+    BoolCriterion: "bool",
+    MultiCriterion: "set",
+    ChoiceCriterion: "set",
+}
+
+
+def criterion_kind(criterion_cls: type[_Criterion]) -> str:
+    """Return the widget ``data-kind`` token for a criterion class.
+
+    Raises ``ValueError`` for a criterion type with no registered kind, so a new
+    criterion class can't silently slip past the widget-contract check."""
+    try:
+        return _CRITERION_KINDS[criterion_cls]
+    except KeyError:
+        raise ValueError(
+            f"No widget kind registered for criterion {criterion_cls.__name__}"
+        ) from None
+
+
+def resolve_path_kind(filter_cls: type["OperatorFilter"], path: list[str]) -> str:
+    """Resolve a filter-widget ``data-path`` against a filter dataclass tree and
+    return the expected ``data-kind``.
+
+    Walks ``path[:-1]`` through cross-entity sub-filter fields (via
+    ``_filter_class_for``), then resolves the final segment to a criterion (via
+    ``_criterion_class_for``) and maps it to a kind (via ``criterion_kind``).
+    Raises ``ValueError`` if the path is empty, a non-leaf segment isn't a
+    sub-filter, or the leaf isn't a criterion — so a widget pointing at a
+    non-existent path fails loudly. Used to guard the rendered server↔client
+    widget contract (issue #123 Phase 2)."""
+    if not path:
+        raise ValueError("resolve_path_kind requires a non-empty path")
+    current = filter_cls
+    for segment in path[:-1]:
+        sub_filter_cls = _filter_class_for(current, segment)
+        if sub_filter_cls is None:
+            raise ValueError(
+                f"{current.__name__} has no sub-filter field {segment!r} "
+                f"(resolving path {path})"
+            )
+        current = sub_filter_cls
+    leaf = path[-1]
+    criterion_cls = _criterion_class_for(current, leaf)
+    if criterion_cls is None:
+        raise ValueError(
+            f"{current.__name__} has no criterion field {leaf!r} "
+            f"(resolving path {path})"
+        )
+    return criterion_kind(criterion_cls)
+
+
 # Lookup suffix → Modifier. A missing suffix defaults per criterion type
 # (EQUALS for scalars, INCLUDES for set criteria) and is handled in where().
 _SUFFIX_MODIFIER: dict[str, Modifier] = {

--- a/e2e/test_set_filter_e2e.py
+++ b/e2e/test_set_filter_e2e.py
@@ -1,0 +1,149 @@
+"""End-to-end Playwright test for the ``set``-kind FilterSelect widget.
+
+Covers the one layer the Python-side tests cannot reach: the generic
+serializer in ``ts/elements/filter-bar.ts`` reading a FilterSelect's
+include/exclude pills (and pinned presence modifier) off its
+``data-included``/``data-excluded``/``data-modifier`` attributes, building the
+set-criterion JSON, and navigating to ``?filter=<encoded>``.
+
+Uses ``DeviceFilterBar`` because its single ``type`` field is an enum
+FilterSelect with pre-rendered option rows (no search endpoint) and both pinned
+modifiers — ``(Any)`` (NOT_NULL) and ``(None)`` (IS_NULL) — so include, exclude,
+and presence paths are all reachable from a static page. Renders the bar at its
+own custom URL so the test needs no auth — the bar's JS doesn't care what route
+serves it.
+"""
+
+import json
+import urllib.parse
+
+import pytest
+from django.http import HttpResponse
+from django.test import override_settings
+from django.urls import path
+
+from common.components import DeviceFilterBar
+
+
+def _bar_page(filter_json: str = "") -> str:
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>Set filter E2E</title>
+    <script src="/static/js/htmx.min.js"></script>
+    <script src="/static/js/dist/elements/search-select.js" type="module"></script>
+    <script src="/static/js/dist/elements/filter-bar.js" type="module"></script>
+</head>
+<body>
+    {DeviceFilterBar(filter_json=filter_json, preset_list_url="/p/l", preset_save_url="/p/s")}
+</body>
+</html>"""
+
+
+def empty_bar_view(request):
+    return HttpResponse(_bar_page())
+
+
+urlpatterns = [
+    path("test-set-filter/", empty_bar_view),
+]
+
+
+def _filter_from_url(url: str) -> dict:
+    """Extract and parse the ?filter=... query param from a URL."""
+    query = urllib.parse.urlparse(url).query
+    params = urllib.parse.parse_qs(query)
+    raw = params.get("filter", [""])[0]
+    return json.loads(raw) if raw else {}
+
+
+def _widget(page):
+    return page.locator('search-select[name="type"]')
+
+
+def _open_panel(page):
+    """Focus the search box so the FilterSelect options panel is interactable."""
+    _widget(page).locator("[data-search-select-search]").click()
+
+
+def _add_value(page, value: str, action: str):
+    """Click the include (+) or exclude (−) button on a value row."""
+    _widget(page).locator(
+        f'[data-search-select-option][data-value="{value}"] '
+        f'[data-search-select-action="{action}"]'
+    ).click()
+
+
+def _choose_modifier(page, modifier: str):
+    """Click a pinned modifier pseudo-option (e.g. (Any)/(None))."""
+    _widget(page).locator(f'[data-search-select-modifier-option="{modifier}"]').click()
+
+
+def _submit(page):
+    with page.expect_navigation():
+        page.evaluate(
+            "document.getElementById('filter-bar-form')"
+            ".dispatchEvent(new Event('submit', {cancelable: true}))"
+        )
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_set_filter_e2e")
+def test_set_filter_empty_omits_field(live_server, page):
+    page.goto(live_server.url + "/test-set-filter/")
+    _submit(page)
+    parsed = _filter_from_url(page.url)
+    assert "type" not in parsed
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_set_filter_e2e")
+def test_set_filter_include_only(live_server, page):
+    page.goto(live_server.url + "/test-set-filter/")
+    _open_panel(page)
+    _add_value(page, "PC", "include")
+    _submit(page)
+    parsed = _filter_from_url(page.url)
+    assert parsed["type"] == {
+        "value": [{"id": "PC", "label": "PC"}],
+        "excludes": [],
+        "modifier": "INCLUDES",
+    }
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_set_filter_e2e")
+def test_set_filter_include_and_exclude(live_server, page):
+    page.goto(live_server.url + "/test-set-filter/")
+    _open_panel(page)
+    _add_value(page, "PC", "include")
+    _add_value(page, "Console", "exclude")
+    _submit(page)
+    parsed = _filter_from_url(page.url)
+    assert parsed["type"] == {
+        "value": [{"id": "PC", "label": "PC"}],
+        "excludes": [{"id": "Console", "label": "Console"}],
+        "modifier": "INCLUDES",
+    }
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_set_filter_e2e")
+def test_set_filter_presence_is_null(live_server, page):
+    page.goto(live_server.url + "/test-set-filter/")
+    _open_panel(page)
+    _choose_modifier(page, "IS_NULL")
+    _submit(page)
+    parsed = _filter_from_url(page.url)
+    assert parsed["type"] == {"modifier": "IS_NULL"}
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_set_filter_e2e")
+def test_set_filter_presence_not_null(live_server, page):
+    page.goto(live_server.url + "/test-set-filter/")
+    _open_panel(page)
+    _choose_modifier(page, "NOT_NULL")
+    _submit(page)
+    parsed = _filter_from_url(page.url)
+    assert parsed["type"] == {"modifier": "NOT_NULL"}

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -492,7 +492,9 @@ class NumberFilterRenderTest(TestCase):
     """Render-level contract for the Stash-style NumberFilter component."""
 
     def test_renders_all_eight_modifier_radios(self):
-        html = str(NumberFilter(input_name_prefix="filter-year"))
+        html = str(
+            NumberFilter(input_name_prefix="filter-year", path=["year_released"])
+        )
         for modifier in (
             "EQUALS",
             "NOT_EQUALS",
@@ -507,14 +509,18 @@ class NumberFilterRenderTest(TestCase):
         self.assertIn("data-number-modifier-radio", html)
 
     def test_renders_two_number_inputs(self):
-        html = str(NumberFilter(input_name_prefix="filter-year"))
+        html = str(
+            NumberFilter(input_name_prefix="filter-year", path=["year_released"])
+        )
         self.assertIn('type="number"', html)
         self.assertIn('name="filter-year"', html)
         self.assertIn('name="filter-year-value2"', html)
         self.assertIn("data-number-value2", html)
 
     def test_default_modifier_hides_second_input_and_enables_inputs(self):
-        html = str(NumberFilter(input_name_prefix="filter-year"))
+        html = str(
+            NumberFilter(input_name_prefix="filter-year", path=["year_released"])
+        )
         # value2 is hidden for the default EQUALS modifier.
         self.assertRegex(html, r'data-number-value2="" class="[^"]*\bhidden\b')
         # Inputs are not disabled by default.
@@ -527,6 +533,7 @@ class NumberFilterRenderTest(TestCase):
                 value="2000",
                 value2="2010",
                 modifier="BETWEEN",
+                path=["year_released"],
             )
         )
         self.assertIn('value="2000"', html)
@@ -541,6 +548,7 @@ class NumberFilterRenderTest(TestCase):
                 value="2000",
                 value2="2010",
                 modifier="IS_NULL",
+                path=["year_released"],
             )
         )
         self.assertIn("disabled", html)
@@ -550,7 +558,13 @@ class NumberFilterRenderTest(TestCase):
         self.assertNotIn('value="2010"', html)
 
     def test_invalid_modifier_falls_back_to_equals(self):
-        html = str(NumberFilter(input_name_prefix="filter-year", modifier="INCLUDES"))
+        html = str(
+            NumberFilter(
+                input_name_prefix="filter-year",
+                modifier="INCLUDES",
+                path=["year_released"],
+            )
+        )
         # EQUALS is the only checked radio when an invalid modifier is given.
         self.assertRegex(html, r'value="EQUALS"[^>]*checked="true"')
         self.assertNotRegex(html, r'value="INCLUDES"')

--- a/tests/test_filter_paths.py
+++ b/tests/test_filter_paths.py
@@ -1,0 +1,148 @@
+"""Guard the server↔client filter-widget contract at test time.
+
+Every filter-bar widget advertises a ``data-path`` (its filter-JSON key chain,
+as a JSON array) and a ``data-kind`` (string/number/date/bool/set). This module
+renders each entity's filter bar, extracts those attributes from the real HTML,
+and asserts that every path resolves through the Python filter dataclass tree
+(``resolve_path_kind``) to a criterion whose kind matches the widget. A widget
+pointing at a non-existent path or the wrong kind fails here — the rendered-widget
+analogue of ``gen_icons --check`` (issue #123 Phase 2, slice 2e).
+"""
+
+import json
+from html.parser import HTMLParser
+from typing import NamedTuple
+
+import pytest
+
+from common.components.filters import (
+    DeviceFilterBar,
+    FilterBar,
+    PlatformFilterBar,
+    PlayEventFilterBar,
+    PurchaseFilterBar,
+    SessionFilterBar,
+)
+from common.criteria import OperatorFilter, resolve_path_kind
+from games.filters import (
+    DeviceFilter,
+    GameFilter,
+    PlatformFilter,
+    PlayEventFilter,
+    PurchaseFilter,
+    SessionFilter,
+)
+
+
+class WidgetDescriptor(NamedTuple):
+    """A filter widget's self-described contract, as read off the rendered HTML."""
+
+    path: list[str]
+    kind: str
+
+
+class _FilterWidgetCollector(HTMLParser):
+    """Collect ``(path, kind)`` from every ``[data-filter-widget]`` start tag.
+
+    Pairs ``data-path``/``data-kind`` within a single element by reading the
+    start tag's own attribute list — no regex pairing across the document.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.widgets: list[WidgetDescriptor] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        if "data-filter-widget" not in attributes:
+            return
+        raw_path = attributes.get("data-path")
+        kind = attributes.get("data-kind")
+        assert raw_path is not None, f"<{tag}> has data-filter-widget but no data-path"
+        assert kind is not None, f"<{tag}> has data-filter-widget but no data-kind"
+        self.widgets.append(WidgetDescriptor(json.loads(raw_path), kind))
+
+
+def _collect_widgets(html: str) -> list[WidgetDescriptor]:
+    collector = _FilterWidgetCollector()
+    collector.feed(html)
+    return collector.widgets
+
+
+# Each filter bar paired with the dataclass its widget paths resolve against.
+class _BarCase(NamedTuple):
+    name: str
+    bar_factory: type
+    filter_cls: type[OperatorFilter]
+
+
+_BAR_CASES = [
+    _BarCase("game", FilterBar, GameFilter),
+    _BarCase("session", SessionFilterBar, SessionFilter),
+    _BarCase("purchase", PurchaseFilterBar, PurchaseFilter),
+    _BarCase("device", DeviceFilterBar, DeviceFilter),
+    _BarCase("platform", PlatformFilterBar, PlatformFilter),
+    _BarCase("playevent", PlayEventFilterBar, PlayEventFilter),
+]
+
+
+@pytest.mark.parametrize("case", _BAR_CASES, ids=lambda case: case.name)
+def test_every_widget_path_resolves_to_its_kind(case: _BarCase) -> None:
+    """Every rendered widget's path resolves to a criterion whose kind matches."""
+    html = str(case.bar_factory(""))
+    widgets = _collect_widgets(html)
+    assert widgets, f"{case.name} bar rendered no filter widgets"
+    for widget in widgets:
+        resolved = resolve_path_kind(case.filter_cls, widget.path)
+        assert resolved == widget.kind, (
+            f"{case.name} widget {widget.path} declares kind {widget.kind!r} "
+            f"but resolves to {resolved!r}"
+        )
+
+
+@pytest.mark.parametrize("case", _BAR_CASES, ids=lambda case: case.name)
+def test_no_widget_path_is_a_prefix_of_another(case: _BarCase) -> None:
+    """No declared path may be a strict prefix of another within a bar.
+
+    A leaf/branch collision (one widget targeting a sub-filter another widget
+    steps through) would make the contract ambiguous; forbid it up front."""
+    html = str(case.bar_factory(""))
+    paths = [widget.path for widget in _collect_widgets(html)]
+    for outer in paths:
+        for inner in paths:
+            if outer is inner:
+                continue
+            is_strict_prefix = len(outer) < len(inner) and inner[: len(outer)] == outer
+            assert not is_strict_prefix, (
+                f"{case.name}: path {outer} is a strict prefix of {inner}"
+            )
+
+
+def test_resolve_path_kind_walks_nested_path() -> None:
+    """A nested cross-entity path resolves through the sub-filter to its leaf kind."""
+    assert resolve_path_kind(GameFilter, ["session_filter", "emulated"]) == "bool"
+
+
+def test_resolve_path_kind_resolves_leaf_kinds() -> None:
+    """Spot-check each kind on a top-level GameFilter field."""
+    assert resolve_path_kind(GameFilter, ["name"]) == "string"
+    assert resolve_path_kind(GameFilter, ["year_released"]) == "number"
+    assert resolve_path_kind(GameFilter, ["finished"]) == "date"
+    assert resolve_path_kind(GameFilter, ["mastered"]) == "bool"
+    assert resolve_path_kind(GameFilter, ["status"]) == "set"
+
+
+def test_resolve_path_kind_rejects_unknown_leaf() -> None:
+    with pytest.raises(ValueError):
+        resolve_path_kind(GameFilter, ["does_not_exist"])
+
+
+def test_resolve_path_kind_rejects_non_subfilter_step() -> None:
+    """A non-leaf segment that isn't a sub-filter (here a criterion) raises."""
+    with pytest.raises(ValueError):
+        resolve_path_kind(GameFilter, ["name", "emulated"])
+
+
+def test_resolve_path_kind_rejects_empty_path() -> None:
+    with pytest.raises(ValueError):
+        resolve_path_kind(GameFilter, [])

--- a/tests/test_filter_paths.py
+++ b/tests/test_filter_paths.py
@@ -23,7 +23,14 @@ from common.components.filters import (
     PurchaseFilterBar,
     SessionFilterBar,
 )
-from common.criteria import OperatorFilter, resolve_path_kind
+from common.criteria import (
+    _CRITERION_KINDS,
+    _CRITERION_TYPES,
+    OperatorFilter,
+    _Criterion,
+    criterion_kind,
+    resolve_path_kind,
+)
 from games.filters import (
     DeviceFilter,
     GameFilter,
@@ -69,20 +76,27 @@ def _collect_widgets(html: str) -> list[WidgetDescriptor]:
     return collector.widgets
 
 
-# Each filter bar paired with the dataclass its widget paths resolve against.
+# Each filter bar paired with the dataclass its widget paths resolve against and
+# the exact number of widgets it is expected to render.
 class _BarCase(NamedTuple):
     name: str
     bar_factory: type
     filter_cls: type[OperatorFilter]
+    widget_count: int
 
 
+# ``widget_count`` is the intended widget inventory for each bar. A forgotten
+# ``path=`` on a FilterSelect/DateRangePicker silently drops that widget (it
+# stops emitting ``data-filter-widget``), which the per-path checks below cannot
+# catch — only an exact count does. Update these numbers deliberately whenever a
+# filter field is added or removed.
 _BAR_CASES = [
-    _BarCase("game", FilterBar, GameFilter),
-    _BarCase("session", SessionFilterBar, SessionFilter),
-    _BarCase("purchase", PurchaseFilterBar, PurchaseFilter),
-    _BarCase("device", DeviceFilterBar, DeviceFilter),
-    _BarCase("platform", PlatformFilterBar, PlatformFilter),
-    _BarCase("playevent", PlayEventFilterBar, PlayEventFilter),
+    _BarCase("game", FilterBar, GameFilter, 23),
+    _BarCase("session", SessionFilterBar, SessionFilter, 8),
+    _BarCase("purchase", PurchaseFilterBar, PurchaseFilter, 14),
+    _BarCase("device", DeviceFilterBar, DeviceFilter, 1),
+    _BarCase("platform", PlatformFilterBar, PlatformFilter, 2),
+    _BarCase("playevent", PlayEventFilterBar, PlayEventFilter, 4),
 ]
 
 
@@ -91,7 +105,10 @@ def test_every_widget_path_resolves_to_its_kind(case: _BarCase) -> None:
     """Every rendered widget's path resolves to a criterion whose kind matches."""
     html = str(case.bar_factory(""))
     widgets = _collect_widgets(html)
-    assert widgets, f"{case.name} bar rendered no filter widgets"
+    assert len(widgets) == case.widget_count, (
+        f"{case.name} bar rendered {len(widgets)} filter widgets, "
+        f"expected {case.widget_count} (a forgotten path= silently drops a widget)"
+    )
     for widget in widgets:
         resolved = resolve_path_kind(case.filter_cls, widget.path)
         assert resolved == widget.kind, (
@@ -146,3 +163,22 @@ def test_resolve_path_kind_rejects_non_subfilter_step() -> None:
 def test_resolve_path_kind_rejects_empty_path() -> None:
     with pytest.raises(ValueError):
         resolve_path_kind(GameFilter, [])
+
+
+def test_every_criterion_type_has_a_kind() -> None:
+    """Every criterion registered for from_json/where also has a widget kind.
+
+    Adding a criterion to ``_CRITERION_TYPES`` without giving it a kind in
+    ``_CRITERION_KINDS`` would let ``resolve_path_kind`` raise at render time;
+    this catches the drift loudly at test time instead."""
+    assert set(_CRITERION_KINDS) == set(_CRITERION_TYPES.values())
+
+
+def test_criterion_kind_rejects_unregistered_class() -> None:
+    """A criterion subclass with no registered kind raises ``ValueError``."""
+
+    class _UnregisteredCriterion(_Criterion):
+        pass
+
+    with pytest.raises(ValueError):
+        criterion_kind(_UnregisteredCriterion)

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -31,16 +31,10 @@ function criterion(value: unknown, value2: unknown, modifier: string): Criterion
   return result;
 }
 
-function numberValue(form: HTMLElement, name: string): number | "" {
-  const element = form.querySelector<HTMLInputElement>(`[name="${name}"]`);
+function parseNumberInputValue(element: HTMLInputElement | null): number | "" {
   if (!element || element.value === "") return "";
   const value = parseFloat(element.value);
   return isNaN(value) ? "" : value;
-}
-
-function stringValue(form: HTMLElement, name: string): string {
-  const element = form.querySelector<HTMLInputElement>(`[name="${name}"]`);
-  return element ? element.value : "";
 }
 
 function buildRangeCriterion(
@@ -86,129 +80,134 @@ function getCsrfToken(): string {
   return element ? element.value : "";
 }
 
+// Deep-merge a single leaf criterion into `target` by its JSON path. Branch
+// objects are created lazily, and only when a non-null leaf is being written —
+// never pre-create empty intermediates (an empty sub-filter would change query
+// semantics). For length-1 paths this is just `target[key] = leaf`.
+function setPath(
+  target: Record<string, unknown>,
+  path: string[],
+  leaf: unknown,
+): void {
+  let node = target;
+  for (let index = 0; index < path.length - 1; index++) {
+    const key = path[index];
+    if (node[key] == null || typeof node[key] !== "object") node[key] = {};
+    node = node[key] as Record<string, unknown>;
+  }
+  node[path[path.length - 1]] = leaf;
+}
+
+// Per-kind readers: each is scoped to a single widget element and returns a
+// criterion object, or null to omit the field entirely. The value/modifier
+// logic is a verbatim port of the former hardcoded field loops; only the
+// element lookup changed (within the widget element instead of global [name=…]).
+
+function readStringWidget(element: HTMLElement): Record<string, unknown> | null {
+  const modifier =
+    element.querySelector<HTMLInputElement>('input[data-string-modifier-radio]:checked')
+      ?.value ?? "EQUALS";
+  if (modifier === "IS_NULL" || modifier === "NOT_NULL") {
+    return { modifier };
+  }
+  const textInput = element.querySelector<HTMLInputElement>('input[type="text"]');
+  if (textInput && textInput.value.trim()) {
+    return { value: textInput.value.trim(), modifier };
+  }
+  return null;
+}
+
+function readNumberWidget(element: HTMLElement): Criterion | Record<string, unknown> | null {
+  const modifier =
+    element.querySelector<HTMLInputElement>('input[data-number-modifier-radio]:checked')
+      ?.value ?? "EQUALS";
+  if (modifier === "IS_NULL" || modifier === "NOT_NULL") {
+    return { modifier };
+  }
+  const value = parseNumberInputValue(
+    element.querySelector<HTMLInputElement>('input[type="number"]:not([data-number-value2])'),
+  );
+  if (modifier === "BETWEEN" || modifier === "NOT_BETWEEN") {
+    const value2Marker = element.querySelector('[data-number-value2]');
+    const value2Input =
+      value2Marker instanceof HTMLInputElement
+        ? value2Marker
+        : (value2Marker?.querySelector<HTMLInputElement>("input") ?? null);
+    const value2 = parseNumberInputValue(value2Input);
+    if (value !== "") return criterion(value, value2, modifier);
+    return null;
+  }
+  if (value !== "") return criterion(value, null, modifier);
+  return null;
+}
+
+function readDateWidget(element: HTMLElement): Criterion | null {
+  const valueMin =
+    element.querySelector<HTMLInputElement>("[data-range-min]")?.value ?? "";
+  const valueMax =
+    element.querySelector<HTMLInputElement>("[data-range-max]")?.value ?? "";
+  return buildRangeCriterion(valueMin, valueMax);
+}
+
+function readBoolWidget(element: HTMLElement): Criterion | null {
+  const checked = element.querySelector<HTMLInputElement>('input[type="radio"]:checked');
+  if (!checked) return null;
+  return criterion(checked.value === "true", null, "EQUALS");
+}
+
+function readSetWidget(element: HTMLElement): Record<string, unknown> | null {
+  const included = parseJSONAttr<PillEntry>(element, "data-included");
+  const excluded = parseJSONAttr<PillEntry>(element, "data-excluded");
+  const modifier = element.getAttribute("data-modifier");
+  const isPresence = modifier === "NOT_NULL" || modifier === "IS_NULL";
+  if (isPresence) {
+    return { modifier };
+  }
+  if (included.length > 0 || excluded.length > 0) {
+    return {
+      value: included.map((item) => ({ id: item.id, label: item.label })),
+      excludes: excluded.map((item) => ({ id: item.id, label: item.label })),
+      modifier: modifier || "INCLUDES",
+    };
+  }
+  return null;
+}
+
+function readWidget(element: HTMLElement, kind: string | null): unknown {
+  switch (kind) {
+    case "string":
+      return readStringWidget(element);
+    case "number":
+      return readNumberWidget(element);
+    case "date":
+      return readDateWidget(element);
+    case "bool":
+      return readBoolWidget(element);
+    case "set":
+      return readSetWidget(element);
+    default:
+      return null;
+  }
+}
+
 function buildFilterJSON(form: HTMLElement): Record<string, unknown> {
   const filter: Record<string, unknown> = {};
 
   const searchInput = form.querySelector<HTMLInputElement>('[name="filter-search"]');
   if (searchInput && searchInput.value.trim()) {
-    filter.search = { value: searchInput.value.trim(), modifier: "INCLUDES" };
+    setPath(filter, ["search"], { value: searchInput.value.trim(), modifier: "INCLUDES" });
   }
 
+  // Serialise every search-select's state into its data-included/excluded/
+  // modifier attributes once, so the generic loop below can read set widgets
+  // uniformly with the rest.
   readSearchSelect(form);
-  const widgets = form.querySelectorAll<HTMLElement>('search-select[filter-mode="true"]');
-  widgets.forEach((widget) => {
-    const field = widget.getAttribute("name");
-    if (!field) return;
-    const included = parseJSONAttr<PillEntry>(widget, "data-included");
-    const excluded = parseJSONAttr<PillEntry>(widget, "data-excluded");
-    const modifier = widget.getAttribute("data-modifier");
-    const isPresence = modifier === "NOT_NULL" || modifier === "IS_NULL";
-    if (isPresence) {
-      filter[field] = { modifier };
-    } else if (included.length > 0 || excluded.length > 0) {
-      filter[field] = {
-        value: included.map((item) => ({ id: item.id, label: item.label })),
-        excludes: excluded.map((item) => ({ id: item.id, label: item.label })),
-        modifier: modifier || "INCLUDES",
-      };
-    }
-  });
 
-  const textFields = [
-    { name: "filter-price_currency", key: "price_currency" },
-    { name: "filter-converted_currency", key: "converted_currency" },
-    { name: "filter-name", key: "name" },
-    { name: "filter-group", key: "group" },
-    { name: "filter-playevent_note", key: "playevent_note" },
-    { name: "filter-note", key: "note" },
-  ];
-  textFields.forEach((textField) => {
-    const modifierElement = form.querySelector<HTMLInputElement>(
-      `[name="${textField.name}-modifier"]:checked`,
-    );
-    const modifier = modifierElement ? modifierElement.value : "EQUALS";
-    const isPresence = modifier === "IS_NULL" || modifier === "NOT_NULL";
-    if (isPresence) {
-      filter[textField.key] = { modifier };
-    } else {
-      const element = form.querySelector<HTMLInputElement>(`[name="${textField.name}"]`);
-      if (element && element.value.trim()) {
-        filter[textField.key] = { value: element.value.trim(), modifier };
-      }
-    }
-  });
-
-  const booleanFields = [
-    { name: "filter-mastered", key: "mastered" },
-    { name: "filter-emulated", key: "emulated" },
-    { name: "filter-active", key: "is_active" },
-    { name: "filter-refunded", key: "is_refunded" },
-    { name: "filter-infinite", key: "infinite" },
-    { name: "filter-needs-price-update", key: "needs_price_update" },
-    { name: "filter-purchase-refunded", key: "purchase_refunded" },
-    { name: "filter-purchase-infinite", key: "purchase_infinite" },
-    { name: "filter-session-emulated", key: "session_emulated" },
-  ];
-  booleanFields.forEach((booleanField) => {
-    const element = form.querySelector<HTMLInputElement>(
-      `[name="${booleanField.name}"]:checked`,
-    );
-    if (element) {
-      const value = element.value === "true";
-      filter[booleanField.key] = criterion(value, null, "EQUALS");
-    }
-  });
-
-  const numberFields = [
-    { prefix: "filter-year", key: "year_released" },
-    { prefix: "filter-original-year", key: "original_year_released" },
-    { prefix: "filter-session-count", key: "session_count" },
-    { prefix: "filter-session-average", key: "session_average" },
-    { prefix: "filter-purchase-count", key: "purchase_count" },
-    { prefix: "filter-playevent-count", key: "playevent_count" },
-    { prefix: "filter-duration-total-hours", key: "duration_total_hours" },
-    { prefix: "filter-duration-manual-hours", key: "duration_manual_hours" },
-    { prefix: "filter-duration-calculated-hours", key: "duration_calculated_hours" },
-    { prefix: "filter-manual-playtime-hours", key: "manual_playtime_hours" },
-    { prefix: "filter-calculated-playtime-hours", key: "calculated_playtime_hours" },
-    { prefix: "filter-num-purchases", key: "num_purchases" },
-    { prefix: "filter-price", key: "price" },
-    { prefix: "filter-purchase-price-total", key: "purchase_price_total" },
-    { prefix: "filter-purchase-price-any", key: "purchase_price_any" },
-    { prefix: "filter-days-to-finish", key: "days_to_finish" },
-    { prefix: "filter-playtime-hours", key: "playtime_hours" },
-  ];
-
-  numberFields.forEach((numberField) => {
-    const modifierElement = form.querySelector<HTMLInputElement>(
-      `[name="${numberField.prefix}-modifier"]:checked`,
-    );
-    const modifier = modifierElement ? modifierElement.value : "EQUALS";
-    if (modifier === "IS_NULL" || modifier === "NOT_NULL") {
-      filter[numberField.key] = { modifier };
-      return;
-    }
-    const value = numberValue(form, numberField.prefix);
-    if (modifier === "BETWEEN" || modifier === "NOT_BETWEEN") {
-      const value2 = numberValue(form, numberField.prefix + "-value2");
-      if (value !== "") filter[numberField.key] = criterion(value, value2, modifier);
-      return;
-    }
-    if (value !== "") filter[numberField.key] = criterion(value, null, modifier);
-  });
-
-  const dateRangeFields = [
-    { prefix: "filter-date-purchased", key: "date_purchased" },
-    { prefix: "filter-date-refunded", key: "date_refunded" },
-    { prefix: "filter-started", key: "started" },
-    { prefix: "filter-ended", key: "ended" },
-    { prefix: "filter-finished", key: "finished" },
-  ];
-  dateRangeFields.forEach((dateField) => {
-    const valueMin = stringValue(form, dateField.prefix + "-min");
-    const valueMax = stringValue(form, dateField.prefix + "-max");
-    const result = buildRangeCriterion(valueMin, valueMax);
-    if (result !== null) filter[dateField.key] = result;
+  form.querySelectorAll<HTMLElement>("[data-filter-widget]").forEach((widget) => {
+    const path = parseJSONAttr<string>(widget, "data-path");
+    if (path.length === 0) return;
+    const result = readWidget(widget, widget.getAttribute("data-kind"));
+    if (result !== null) setPath(filter, path, result);
   });
 
   return filter;

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -53,6 +53,7 @@ function parseJSONAttr<T>(element: Element, attr: string): T[] {
   try {
     return JSON.parse(raw);
   } catch {
+    console.warn("filter-bar: malformed JSON attribute", attr, raw);
     return [];
   }
 }
@@ -81,14 +82,16 @@ function getCsrfToken(): string {
 }
 
 // Deep-merge a single leaf criterion into `target` by its JSON path. Branch
-// objects are created lazily, and only when a non-null leaf is being written —
-// never pre-create empty intermediates (an empty sub-filter would change query
-// semantics). For length-1 paths this is just `target[key] = leaf`.
+// objects are created lazily as the path is walked. setPath writes the leaf
+// unconditionally; it is the *caller's* contract to only invoke it with a
+// non-null leaf, so an empty sub-filter (which would change query semantics) is
+// never pre-created here. For length-1 paths this is just `target[key] = leaf`.
 function setPath(
   target: Record<string, unknown>,
   path: string[],
   leaf: unknown,
 ): void {
+  if (path.length === 0) return;
   let node = target;
   for (let index = 0; index < path.length - 1; index++) {
     const key = path[index];
@@ -186,6 +189,7 @@ function readWidget(element: HTMLElement, kind: string | null): unknown {
     case "set":
       return readSetWidget(element);
     default:
+      console.warn(`filter-bar: no reader for data-kind="${kind}"`, element);
       return null;
   }
 }


### PR DESCRIPTION
Phase 2 mechanism for #123 (slices 2a + 2b + 2e). Behaviour-preserving: emitted filter JSON is byte-identical for the existing (length-1-path) widgets. This lands the generic serializer + self-guarding validation; the cross-entity *repointing* (2d) follows after n-ary boolean (#127).

## 2a — widgets self-describe
Every filter widget root now carries `data-filter-widget` + `data-path` (JSON array) + `data-kind` (string/number/date/bool/set), via a shared `filter_widget_attributes(path, kind)` helper. `path` threaded through every widget builder + per-entity call site (length-1 = the JSON key). Date builders mark min/max inputs `data-range-min`/`data-range-max`. Pure attribute addition.

## 2b — generic buildFilterJSON
`ts/elements/filter-bar.ts` replaces the four hardcoded per-type lists (textFields/booleanFields/numberFields/dateRangeFields) + the search-select loop with one generic pass: iterate `[data-filter-widget]`, dispatch by `data-kind` to a per-kind reader scoped to the widget, deep-merge by `data-path` via `setPath` (never creating empty intermediates). Each per-kind reader ports the old per-type body verbatim — byte-identical criterion shapes; only key order changes (DOM order, JSON-irrelevant).

## 2e — contract validation
`common/criteria.py`: `_filter_class_for`, `criterion_kind`, `resolve_path_kind`. `tests/test_filter_paths.py` renders all six bars and asserts every widget's `data-path` resolves to a criterion whose kind == its `data-kind` (52 widgets), and that no path is a strict prefix of another. A mistyped path/kind now fails a test.

## Verification
- 736 Python tests pass (+17 new); `make ts` compiles clean; widget e2e green.
- ruff + mypy clean.

## Not in this PR
- #127 (n-ary boolean) — prerequisite for 2d, because several flat cross-entity fields target the same relation with independent-EXISTS semantics that need AND-composition.
- 2d (repoint cross-entity widgets to nested paths) and Phase 3 (delete flat fields) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)