### PR TITLE
n-ary boolean filter composition (#127)

### DIFF
--- a/common/criteria.py
+++ b/common/criteria.py
@@ -601,15 +601,24 @@ _SUFFIX_MODIFIER: dict[str, Modifier] = {
 class OperatorFilter:
     """Mixin providing AND/OR/NOT composition for entity filter types.
 
-    Subclasses should declare nullable references to themselves::
+    Each operator field is a *list* of sub-filters (n-ary boolean composition),
+    so one node can compose several independent sub-filters — the prerequisite
+    for AND-composing two uncorrelated EXISTS constraints over the same relation.
+    Subclasses declare list-valued references to themselves::
 
         @dataclass
         class GameFilter(OperatorFilter):
-            AND: "GameFilter | None" = None
-            OR:  "GameFilter | None" = None
-            NOT: "GameFilter | None" = None
+            AND: list["GameFilter"] = field(default_factory=list)
+            OR:  list["GameFilter"] = field(default_factory=list)
+            NOT: list["GameFilter"] = field(default_factory=list)
             name: StringCriterion | None = None
             ...
+
+    Application order (see ``_apply_operators``): this node's own criteria first,
+    then each ``AND`` sub-filter (``&=``), then each ``OR`` (``|=``), then each
+    ``NOT`` (``&= ~``). Mixing operator families on one node therefore composes
+    left-to-right in that order; the common case keeps a node to a single
+    operator family.
 
     ``match`` is the relation quantifier, meaningful only when this filter is
     nested as a cross-entity sub-filter (e.g. ``GameFilter.session_filter``):
@@ -619,6 +628,15 @@ class OperatorFilter:
     """
 
     match: RelationMatch = RelationMatch.ANY
+
+    # N-ary boolean composition: each operator is a list of sub-filters. Declared
+    # on the base (typed ``list[Any]``) so ``_apply_operators`` can read them and
+    # subclasses can narrow them to ``list[XFilter]`` (``list`` is invariant, so a
+    # narrower base type would reject the override). Concrete filters redeclare
+    # these with their own type — see games/filters.py.
+    AND: list[Any] = field(default_factory=list)
+    OR: list[Any] = field(default_factory=list)
+    NOT: list[Any] = field(default_factory=list)
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -673,14 +691,22 @@ class OperatorFilter:
             field_criteria[field_name] = criterion_class(**criterion_arguments)
         return cls(**field_criteria)
 
-    def sub_filter(self) -> OperatorFilter | None:
-        """Return the first non-None of AND / OR / NOT."""
-        for attr in _OPERATOR_FIELDS:
-            if hasattr(self, attr):
-                v = getattr(self, attr)
-                if v is not None:
-                    return v
-        return None
+    def _apply_operators(self, q: Q) -> Q:
+        """Compose this node's sub-filters onto ``q`` (which already holds this
+        node's own criteria).
+
+        Each operator field is a list, applied in order: every ``AND`` sub-filter
+        is AND'd, every ``OR`` sub-filter is OR'd, every ``NOT`` sub-filter is
+        AND'd-negated. Mixing families on one node composes left-to-right in that
+        order (criteria → AND → OR → NOT); the common case uses one family.
+        """
+        for sub in self.AND:
+            q &= sub.to_q()
+        for sub in self.OR:
+            q |= sub.to_q()
+        for sub in self.NOT:
+            q &= ~sub.to_q()
+        return q
 
     def _criterion_fields(self) -> list[str]:
         """Return field names that hold a _Criterion instance."""
@@ -700,15 +726,7 @@ class OperatorFilter:
             c = getattr(self, field_name)
             if c is not None:
                 q &= c.to_q(field_name)
-        sub = self.sub_filter()
-        if sub is not None:
-            if getattr(self, "AND", None) is not None:
-                q &= sub.to_q()
-            elif getattr(self, "OR", None) is not None:
-                q |= sub.to_q()
-            elif getattr(self, "NOT", None) is not None:
-                q &= ~sub.to_q()
-        return q
+        return self._apply_operators(q)
 
     @classmethod
     def from_json(cls, data: dict[str, Any] | None) -> Self | None:
@@ -728,9 +746,13 @@ class OperatorFilter:
             if raw is None:
                 kwargs[f.name] = None
                 continue
-            # Recurse into sub-filters (AND / OR / NOT)
+            # Recurse into sub-filters (AND / OR / NOT), each a list of sub-filters.
+            # A legacy single object is tolerated by wrapping it as a one-element
+            # list; None results (malformed entries) are filtered out.
             if f.name in _OPERATOR_FIELDS:
-                kwargs[f.name] = cls.from_json(raw) if isinstance(raw, dict) else None
+                items = raw if isinstance(raw, list) else [raw]
+                parsed = [cls.from_json(item) for item in items]
+                kwargs[f.name] = [sub for sub in parsed if sub is not None]
                 continue
             # Resolve criterion fields from string type annotation
             f_type = f.type
@@ -768,8 +790,11 @@ class OperatorFilter:
                 continue
             if f.name == "match":
                 continue
+            # Operator fields are lists; emit a JSON array only when non-empty so
+            # an unused operator stays out of the serialized form.
             if f.name in _OPERATOR_FIELDS:
-                result[f.name] = v.to_json()
+                if v:
+                    result[f.name] = [sub.to_json() for sub in v]
             elif isinstance(v, _Criterion):
                 j = v.to_json()
                 if j:

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -9,6 +9,7 @@ filtering from *how* you're comparing, and makes filter serialization trivial.
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from dataclasses import dataclass, field, fields as dc_fields
 from enum import Enum
 from typing import Any, Literal, Self, TypeVar
@@ -630,13 +631,14 @@ class OperatorFilter:
     match: RelationMatch = RelationMatch.ANY
 
     # N-ary boolean composition: each operator is a list of sub-filters. Declared
-    # on the base (typed ``list[Any]``) so ``_apply_operators`` can read them and
-    # subclasses can narrow them to ``list[XFilter]`` (``list`` is invariant, so a
-    # narrower base type would reject the override). Concrete filters redeclare
-    # these with their own type — see games/filters.py.
-    AND: list[Any] = field(default_factory=list)
-    OR: list[Any] = field(default_factory=list)
-    NOT: list[Any] = field(default_factory=list)
+    # on the base as ``Sequence["OperatorFilter"]`` so ``_apply_operators`` reads a
+    # typed ``.to_q()`` while subclasses narrow to ``list[XFilter]`` (``Sequence``
+    # is covariant, so the narrower override is accepted — a ``list[OperatorFilter]``
+    # base would be rejected because ``list`` is invariant). Concrete filters
+    # redeclare these with their own type — see games/filters.py.
+    AND: Sequence["OperatorFilter"] = field(default_factory=list)
+    OR: Sequence["OperatorFilter"] = field(default_factory=list)
+    NOT: Sequence["OperatorFilter"] = field(default_factory=list)
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -743,16 +745,22 @@ class OperatorFilter:
             if f.name == "match":
                 kwargs["match"] = RelationMatch(raw)
                 continue
-            if raw is None:
-                kwargs[f.name] = None
-                continue
-            # Recurse into sub-filters (AND / OR / NOT), each a list of sub-filters.
-            # A legacy single object is tolerated by wrapping it as a one-element
-            # list; None results (malformed entries) are filtered out.
+            # Operator fields are list-valued; handle them before the generic
+            # ``raw is None`` guard so a JSON ``null`` (or absent) operator
+            # normalizes to ``[]`` and never violates the list invariant — leaving
+            # it as ``None`` would crash ``_apply_operators``' iteration. A legacy
+            # single object is tolerated by wrapping it as a one-element list;
+            # None results (malformed entries) are filtered out.
             if f.name in _OPERATOR_FIELDS:
+                if raw is None:
+                    kwargs[f.name] = []
+                    continue
                 items = raw if isinstance(raw, list) else [raw]
                 parsed = [cls.from_json(item) for item in items]
                 kwargs[f.name] = [sub for sub in parsed if sub is not None]
+                continue
+            if raw is None:
+                kwargs[f.name] = None
                 continue
             # Resolve criterion fields from string type annotation
             f_type = f.type

--- a/games/filters.py
+++ b/games/filters.py
@@ -11,7 +11,7 @@ with AND/OR/NOT composition and typed criterion fields.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from django.db.models import Q, QuerySet
@@ -63,9 +63,9 @@ class FindFilter:
 class GameFilter(OperatorFilter):
     """Filter for the Game model."""
 
-    AND: GameFilter | None = None
-    OR: GameFilter | None = None
-    NOT: GameFilter | None = None
+    AND: list[GameFilter] = field(default_factory=list)
+    OR: list[GameFilter] = field(default_factory=list)
+    NOT: list[GameFilter] = field(default_factory=list)
 
     name: StringCriterion | None = None
     sort_name: StringCriterion | None = None
@@ -348,17 +348,8 @@ class GameFilter(OperatorFilter):
                 parent_field="platform_id",
             )
 
-        # ── AND / OR / NOT sub-filters ──
-        sub = self.sub_filter()
-        if sub is not None:
-            if self.AND is not None:
-                q &= sub.to_q()
-            elif self.OR is not None:
-                q |= sub.to_q()
-            elif self.NOT is not None:
-                q &= ~sub.to_q()
-
-        return q
+        # ── AND / OR / NOT sub-filters (n-ary; see OperatorFilter) ──
+        return self._apply_operators(q)
 
     @staticmethod
     def _playtime_to_q(c: IntCriterion) -> Q:
@@ -388,9 +379,9 @@ class GameFilter(OperatorFilter):
 class SessionFilter(OperatorFilter):
     """Filter for the Session model."""
 
-    AND: SessionFilter | None = None
-    OR: SessionFilter | None = None
-    NOT: SessionFilter | None = None
+    AND: list[SessionFilter] = field(default_factory=list)
+    OR: list[SessionFilter] = field(default_factory=list)
+    NOT: list[SessionFilter] = field(default_factory=list)
 
     game: MultiCriterion | None = None  # filters on game_id
     device: MultiCriterion | None = None  # filters on device_id
@@ -493,17 +484,8 @@ class SessionFilter(OperatorFilter):
                 parent_field="device_id",
             )
 
-        # AND / OR / NOT
-        sub = self.sub_filter()
-        if sub is not None:
-            if self.AND is not None:
-                q &= sub.to_q()
-            elif self.OR is not None:
-                q |= sub.to_q()
-            elif self.NOT is not None:
-                q &= ~sub.to_q()
-
-        return q
+        # AND / OR / NOT (n-ary; see OperatorFilter)
+        return self._apply_operators(q)
 
 
 # ── PurchaseFilter ─────────────────────────────────────────────────────────
@@ -513,9 +495,9 @@ class SessionFilter(OperatorFilter):
 class PurchaseFilter(OperatorFilter):
     """Filter for the Purchase model."""
 
-    AND: PurchaseFilter | None = None
-    OR: PurchaseFilter | None = None
-    NOT: PurchaseFilter | None = None
+    AND: list[PurchaseFilter] = field(default_factory=list)
+    OR: list[PurchaseFilter] = field(default_factory=list)
+    NOT: list[PurchaseFilter] = field(default_factory=list)
 
     name: StringCriterion | None = None
     platform: ChoiceCriterion | None = None  # platform_id
@@ -630,16 +612,8 @@ class PurchaseFilter(OperatorFilter):
                 parent_field="platform_id",
             )
 
-        sub = self.sub_filter()
-        if sub is not None:
-            if self.AND is not None:
-                q &= sub.to_q()
-            elif self.OR is not None:
-                q |= sub.to_q()
-            elif self.NOT is not None:
-                q &= ~sub.to_q()
-
-        return q
+        # AND / OR / NOT (n-ary; see OperatorFilter)
+        return self._apply_operators(q)
 
     @staticmethod
     def _games_to_q(criterion: ChoiceCriterion) -> Q:
@@ -709,9 +683,9 @@ class PurchaseFilter(OperatorFilter):
 class DeviceFilter(OperatorFilter):
     """Filter for the Device model."""
 
-    AND: DeviceFilter | None = None
-    OR: DeviceFilter | None = None
-    NOT: DeviceFilter | None = None
+    AND: list[DeviceFilter] = field(default_factory=list)
+    OR: list[DeviceFilter] = field(default_factory=list)
+    NOT: list[DeviceFilter] = field(default_factory=list)
 
     name: StringCriterion | None = None
     type: ChoiceCriterion | None = None
@@ -752,16 +726,8 @@ class DeviceFilter(OperatorFilter):
                 related_lookup="device_id",
             )
 
-        sub = self.sub_filter()
-        if sub is not None:
-            if self.AND is not None:
-                q &= sub.to_q()
-            elif self.OR is not None:
-                q |= sub.to_q()
-            elif self.NOT is not None:
-                q &= ~sub.to_q()
-
-        return q
+        # AND / OR / NOT (n-ary; see OperatorFilter)
+        return self._apply_operators(q)
 
 
 # ── PlatformFilter ─────────────────────────────────────────────────────────
@@ -771,9 +737,9 @@ class DeviceFilter(OperatorFilter):
 class PlatformFilter(OperatorFilter):
     """Filter for the Platform model."""
 
-    AND: PlatformFilter | None = None
-    OR: PlatformFilter | None = None
-    NOT: PlatformFilter | None = None
+    AND: list[PlatformFilter] = field(default_factory=list)
+    OR: list[PlatformFilter] = field(default_factory=list)
+    NOT: list[PlatformFilter] = field(default_factory=list)
 
     name: StringCriterion | None = None
     group: StringCriterion | None = None
@@ -825,16 +791,8 @@ class PlatformFilter(OperatorFilter):
                 related_lookup="platform_id",
             )
 
-        sub = self.sub_filter()
-        if sub is not None:
-            if self.AND is not None:
-                q &= sub.to_q()
-            elif self.OR is not None:
-                q |= sub.to_q()
-            elif self.NOT is not None:
-                q &= ~sub.to_q()
-
-        return q
+        # AND / OR / NOT (n-ary; see OperatorFilter)
+        return self._apply_operators(q)
 
 
 # ── PlayEventFilter ────────────────────────────────────────────────────────
@@ -844,9 +802,9 @@ class PlatformFilter(OperatorFilter):
 class PlayEventFilter(OperatorFilter):
     """Filter for the PlayEvent model."""
 
-    AND: PlayEventFilter | None = None
-    OR: PlayEventFilter | None = None
-    NOT: PlayEventFilter | None = None
+    AND: list[PlayEventFilter] = field(default_factory=list)
+    OR: list[PlayEventFilter] = field(default_factory=list)
+    NOT: list[PlayEventFilter] = field(default_factory=list)
 
     game: MultiCriterion | None = None  # filters on game_id
     started: DateCriterion | None = None  # DateField, bare lookup
@@ -897,16 +855,8 @@ class PlayEventFilter(OperatorFilter):
                 parent_field="game_id",
             )
 
-        sub = self.sub_filter()
-        if sub is not None:
-            if self.AND is not None:
-                q &= sub.to_q()
-            elif self.OR is not None:
-                q |= sub.to_q()
-            elif self.NOT is not None:
-                q &= ~sub.to_q()
-
-        return q
+        # AND / OR / NOT (n-ary; see OperatorFilter)
+        return self._apply_operators(q)
 
 
 # ── Convenience helpers ────────────────────────────────────────────────────

--- a/games/views/stats_links.py
+++ b/games/views/stats_links.py
@@ -118,7 +118,7 @@ def _not_finished_game(year, excluded_statuses: list) -> GameFilter:
     game_filter = GameFilter(
         status=ChoiceCriterion(value=excluded_statuses, modifier=Modifier.EXCLUDES)
     )
-    game_filter.NOT = GameFilter(playevent_filter=_ended_in_scope(year))
+    game_filter.NOT = [GameFilter(playevent_filter=_ended_in_scope(year))]
     return game_filter
 
 
@@ -130,7 +130,7 @@ def purchases_finished(year) -> PurchaseFilter:
         )
     # All-time `.finished()`: game status FINISHED *or* any ended playevent.
     game_filter = GameFilter(status=ChoiceCriterion(value=[Game.Status.FINISHED]))
-    game_filter.OR = GameFilter(playevent_filter=_ended_in_scope(year))
+    game_filter.OR = [GameFilter(playevent_filter=_ended_in_scope(year))]
     return PurchaseFilter(game_filter=game_filter)
 
 
@@ -156,7 +156,7 @@ def _abandoned_or_refunded() -> PurchaseFilter:
     purchase_filter = PurchaseFilter(
         game_filter=GameFilter(status=ChoiceCriterion(value=[Game.Status.ABANDONED]))
     )
-    purchase_filter.OR = PurchaseFilter(is_refunded=BoolCriterion(value=True))
+    purchase_filter.OR = [PurchaseFilter(is_refunded=BoolCriterion(value=True))]
     return purchase_filter
 
 
@@ -167,7 +167,7 @@ def purchases_dropped(year) -> PurchaseFilter:
         **_purchase_bounds(year),
     )
     purchase_filter.game_filter = _not_finished_game(year, [Game.Status.FINISHED])
-    purchase_filter.AND = _abandoned_or_refunded()
+    purchase_filter.AND = [_abandoned_or_refunded()]
     return purchase_filter
 
 

--- a/tests/test_relation_algebra.py
+++ b/tests/test_relation_algebra.py
@@ -17,11 +17,12 @@ from common.criteria import (
     AggregateCriterion,
     BoolCriterion,
     Modifier,
+    MultiCriterion,
     RelationMatch,
     StringCriterion,
 )
 from games.filters import GameFilter, PurchaseFilter, SessionFilter
-from games.models import Game, Platform, Purchase, Session
+from games.models import Device, Game, Platform, Purchase, Session
 
 
 def _dt(year=2024, month=6, day=1):
@@ -365,3 +366,173 @@ def test_two_level_match_round_trip():
     assert restored is not None and restored.session_filter is not None
     assert restored.session_filter.device_filter is not None
     assert restored.session_filter.device_filter.match == RelationMatch.NONE
+
+
+# ── n-ary boolean composition (#127): AND/OR/NOT as lists ─────────────────────
+
+
+@pytest.fixture
+def boolean_world(db):
+    """Games spanning combinations of an emulated session and a refunded purchase,
+    plus a game (``split``) whose two qualifying sessions are *distinct* rows — the
+    case only n-ary AND over one relation can express (the flat single-session
+    conjunction misses it)."""
+    pc = Platform.objects.create(name="PC")
+    deck = Device.objects.create(name="SteamDeck", type=Device.HANDHELD)
+    desktop = Device.objects.create(name="Desktop", type=Device.PC)
+
+    both = Game.objects.create(name="Both", platform=pc)
+    emu_only = Game.objects.create(name="EmuOnly", platform=pc)
+    refund_only = Game.objects.create(name="RefundOnly", platform=pc)
+    neither = Game.objects.create(name="Neither", platform=pc)
+
+    Session.objects.create(game=both, timestamp_start=_dt(), emulated=True)
+    Session.objects.create(game=emu_only, timestamp_start=_dt(), emulated=True)
+    Session.objects.create(game=refund_only, timestamp_start=_dt(), emulated=False)
+    Session.objects.create(game=neither, timestamp_start=_dt(), emulated=False)
+
+    Purchase.objects.create(
+        date_purchased=_dt(), date_refunded=_dt(2024, 7, 1)
+    ).games.set([both])
+    Purchase.objects.create(date_purchased=_dt()).games.set([emu_only])
+    Purchase.objects.create(
+        date_purchased=_dt(), date_refunded=_dt(2024, 7, 1)
+    ).games.set([refund_only])
+    Purchase.objects.create(date_purchased=_dt()).games.set([neither])
+
+    # split: emulated session and deck session are two different rows.
+    split = Game.objects.create(name="Split", platform=pc)
+    Session.objects.create(
+        game=split, timestamp_start=_dt(), emulated=True, device=desktop
+    )
+    Session.objects.create(
+        game=split, timestamp_start=_dt(2024, 6, 2), emulated=False, device=deck
+    )
+    # combined: a single session that is both emulated and on the deck.
+    combined = Game.objects.create(name="Combined", platform=pc)
+    Session.objects.create(
+        game=combined, timestamp_start=_dt(), emulated=True, device=deck
+    )
+
+    return {
+        "both": both.id,
+        "emu_only": emu_only.id,
+        "refund_only": refund_only.id,
+        "neither": neither.id,
+        "split": split.id,
+        "combined": combined.id,
+        "deck": deck.id,
+    }
+
+
+def test_and_list_two_independent_subfilters_both_required(boolean_world):
+    """Two AND sub-filters over *different* relations: a game must have BOTH an
+    emulated session AND a refunded purchase."""
+    both_required = GameFilter(
+        AND=[
+            GameFilter(
+                session_filter=SessionFilter(emulated=BoolCriterion(value=True))
+            ),
+            GameFilter(
+                purchase_filter=PurchaseFilter(is_refunded=BoolCriterion(value=True))
+            ),
+        ]
+    )
+    assert _ids(both_required) == {boolean_world["both"]}
+
+
+def test_and_list_two_subfilters_same_relation(boolean_world):
+    """Two AND sub-filters over the SAME relation are two independent EXISTS, so a
+    game qualifies when *different* sessions satisfy each — the unary form could
+    not express this. The flat single-session conjunction misses ``split``."""
+    deck = boolean_world["deck"]
+    nary = GameFilter(
+        AND=[
+            GameFilter(
+                session_filter=SessionFilter(emulated=BoolCriterion(value=True))
+            ),
+            GameFilter(
+                session_filter=SessionFilter(device=MultiCriterion(value=[deck]))
+            ),
+        ]
+    )
+    nary_ids = _ids(nary)
+    assert boolean_world["split"] in nary_ids
+    assert boolean_world["combined"] in nary_ids
+
+    # One session required to be BOTH emulated AND on the deck: split is excluded.
+    single_session = GameFilter(
+        session_filter=SessionFilter(
+            emulated=BoolCriterion(value=True), device=MultiCriterion(value=[deck])
+        )
+    )
+    single_ids = _ids(single_session)
+    assert boolean_world["combined"] in single_ids
+    assert boolean_world["split"] not in single_ids
+
+
+def test_or_list_two_subfilters_union(boolean_world):
+    """Two OR sub-filters on a criteria-free node = the union of the two EXISTS
+    (Django drops the empty base ``Q()`` from the OR)."""
+    either = GameFilter(
+        OR=[
+            GameFilter(
+                session_filter=SessionFilter(emulated=BoolCriterion(value=True))
+            ),
+            GameFilter(
+                purchase_filter=PurchaseFilter(is_refunded=BoolCriterion(value=True))
+            ),
+        ]
+    )
+    assert _ids(either) == {
+        boolean_world["both"],
+        boolean_world["emu_only"],
+        boolean_world["refund_only"],
+        boolean_world["split"],
+        boolean_world["combined"],
+    }
+
+
+def test_legacy_single_object_and_is_wrapped_to_list(boolean_world):
+    """A legacy single-object AND payload (pre-#127) parses as a one-element list
+    and evaluates identically to the explicit list form."""
+    legacy = GameFilter.from_json(
+        {"AND": {"session_filter": {"emulated": {"value": True, "modifier": "EQUALS"}}}}
+    )
+    assert legacy is not None
+    assert isinstance(legacy.AND, list) and len(legacy.AND) == 1
+    explicit = GameFilter(
+        AND=[
+            GameFilter(session_filter=SessionFilter(emulated=BoolCriterion(value=True)))
+        ]
+    )
+    assert _ids(legacy) == _ids(explicit)
+
+
+def test_multi_element_and_list_round_trip(boolean_world):
+    """A two-element AND list survives the JSON round-trip and selects the same
+    games."""
+    original = GameFilter(
+        AND=[
+            GameFilter(
+                session_filter=SessionFilter(emulated=BoolCriterion(value=True))
+            ),
+            GameFilter(
+                purchase_filter=PurchaseFilter(is_refunded=BoolCriterion(value=True))
+            ),
+        ]
+    )
+    payload = original.to_json()
+    assert isinstance(payload["AND"], list) and len(payload["AND"]) == 2
+
+    restored = GameFilter.from_json(json.loads(json.dumps(payload)))
+    assert restored is not None
+    assert isinstance(restored.AND, list) and len(restored.AND) == 2
+    assert _ids(restored) == _ids(original)
+
+
+def test_unused_operator_list_is_not_serialized():
+    """An empty operator list stays out of the serialized form."""
+    f = GameFilter(name=StringCriterion(value="x"))
+    payload = f.to_json()
+    assert "AND" not in payload and "OR" not in payload and "NOT" not in payload

--- a/tests/test_relation_algebra.py
+++ b/tests/test_relation_algebra.py
@@ -536,3 +536,73 @@ def test_unused_operator_list_is_not_serialized():
     f = GameFilter(name=StringCriterion(value="x"))
     payload = f.to_json()
     assert "AND" not in payload and "OR" not in payload and "NOT" not in payload
+
+
+def test_not_list_single_and_multi(boolean_world):
+    """NOT negates each sub-filter (AND'd). One element excludes emulated-session
+    games; a second element additionally excludes refunded-purchase games."""
+    emulated = GameFilter(
+        session_filter=SessionFilter(emulated=BoolCriterion(value=True))
+    )
+    refunded = GameFilter(
+        purchase_filter=PurchaseFilter(is_refunded=BoolCriterion(value=True))
+    )
+    not_emulated = GameFilter(NOT=[emulated])
+    assert _ids(not_emulated) == {
+        boolean_world["refund_only"],
+        boolean_world["neither"],
+    }
+
+    not_either = GameFilter(NOT=[emulated, refunded])
+    assert _ids(not_either) == {boolean_world["neither"]}
+
+
+def test_mixed_and_or_not_composition_order(boolean_world):
+    """A node mixing all three families composes in the documented order
+    ``(criteria & AND) | OR) & ~NOT`` — here ``(emulated | refunded) & ~has-deck``."""
+    deck = boolean_world["deck"]
+    mixed = GameFilter(
+        AND=[
+            GameFilter(session_filter=SessionFilter(emulated=BoolCriterion(value=True)))
+        ],
+        OR=[
+            GameFilter(
+                purchase_filter=PurchaseFilter(is_refunded=BoolCriterion(value=True))
+            )
+        ],
+        NOT=[
+            GameFilter(
+                session_filter=SessionFilter(device=MultiCriterion(value=[deck]))
+            )
+        ],
+    )
+    # (emulated ∪ refunded) = both,emu_only,refund_only,split,combined; minus
+    # has-deck-session (split, combined).
+    assert _ids(mixed) == {
+        boolean_world["both"],
+        boolean_world["emu_only"],
+        boolean_world["refund_only"],
+    }
+
+
+def test_null_operator_normalizes_to_empty_list():
+    """A JSON ``null`` operator value deserializes to ``[]`` (not None) so it can't
+    crash ``_apply_operators``' iteration — a hand-crafted ?filter= must not 500."""
+    restored = GameFilter.from_json({"AND": None})
+    assert restored is not None
+    assert restored.AND == []
+    restored.to_q()  # must not raise
+
+
+def test_from_json_drops_null_list_element():
+    """A malformed (None) element inside an operator list is filtered out."""
+    restored = GameFilter.from_json(
+        {
+            "AND": [
+                None,
+                {"session_filter": {"emulated": {"value": True, "modifier": "EQUALS"}}},
+            ]
+        }
+    )
+    assert restored is not None
+    assert isinstance(restored.AND, list) and len(restored.AND) == 1


### PR DESCRIPTION
Closes #127.

Upgrades `OperatorFilter`'s `AND`/`OR`/`NOT` composition from **unary** (each operator was a single nested sub-filter; `sub_filter()` returned the first non-None and only one branch applied) to **n-ary** (each operator is a *list* of sub-filters). One node can now compose several independent sub-filters — the prerequisite for AND-composing two uncorrelated EXISTS constraints over the *same* relation (e.g. "a game with an emulated session AND, separately, a session on device X"), which the unary form could not express.

## List semantics

- Each of `AND` / `OR` / `NOT` is a `list[XFilter]` (default `[]`).
- Composition (`OperatorFilter._apply_operators`, which DRYs the six previously-duplicated per-entity `to_q()` tails) applies in this order:
  1. this node's own criteria,
  2. each `AND` sub-filter (`q &= sub.to_q()`),
  3. each `OR` sub-filter (`q |= sub.to_q()`),
  4. each `NOT` sub-filter (`q &= ~sub.to_q()`).
- Mixing operator families on one node composes left-to-right in that order; the common case keeps a node to a single family.
- A criteria-free node with only `OR` sub-filters yields a clean union — Django drops the empty base `Q()` from the OR.

## Serialization

- `to_json` emits a JSON array per operator, **only when the list is non-empty** (an unused operator stays out of the serialized form).
- `from_json` parses an operator value as a list, **tolerating a legacy single object** (pre-#127 payloads) by wrapping it as a one-element list; malformed (`None`) entries are filtered out.

## Notes

- The operator fields are declared on the base `OperatorFilter` as `list[Any]` so `_apply_operators` can read them while subclasses narrow them to `list[XFilter]` (`list` is invariant, so a narrower base type would reject the override).
- No existing tests constructed `AND`/`OR`/`NOT` operator fields directly (they were exercised only via `stats_links.py`), so there was no mutual-exclusivity assumption to unwind. New tests in `tests/test_relation_algebra.py` cover n-ary AND/OR over different and same relations, the legacy single-object `from_json` tolerance, the multi-element AND round-trip, and the empty-list non-serialization. `tests/test_stats_links.py` (the parity oracle) stays green.

Verification: `pytest tests/ --ignore=e2e` → 744 passed; `mypy common/ games/` clean; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)