### PR TITLE
Repoint cross-entity filter widgets to nested AND sub-filters (#123 Phase 2d)

### DIFF
--- a/common/components/date_range_picker.py
+++ b/common/components/date_range_picker.py
@@ -334,6 +334,7 @@ def DateRangePicker(
     min_value: str = "",
     max_value: str = "",
     path: FilterWidgetPath | None = None,
+    compose: bool = False,
 ) -> Node:
     """A date-range widget: segmented manual entry plus a calendar popup.
 
@@ -347,7 +348,9 @@ def DateRangePicker(
     filter serializer; non-filter callers (e.g. a standalone date picker) leave
     it None and the extra attributes are omitted."""
     widget_attributes = (
-        filter_widget_attributes(path, "date") if path is not None else []
+        filter_widget_attributes(path, "date", compose=compose)
+        if path is not None
+        else []
     )
     return _DateRangePicker(widget_attributes, class_="relative")[
         DateRangeField(

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -13,6 +13,7 @@ from common.components.primitives import (
     Input,
     Label,
     Radio,
+    RelationChild,
     Span,
     filter_widget_attributes,
 )
@@ -48,6 +49,13 @@ class NumberValues(NamedTuple):
 
     value: str
     value2: str
+    modifier: str
+
+
+class StringValues(NamedTuple):
+    """(value, modifier) parsed from a string filter criterion."""
+
+    value: str
     modifier: str
 
 
@@ -151,11 +159,13 @@ def _parse_number(existing: dict, key: str) -> NumberValues:
     return _number_from_field(existing.get(key, {}))
 
 
-def _string_from_field(field: dict) -> tuple[str, str]:
+def _string_from_field(field: dict) -> StringValues:
     """Extract (value, modifier) from a string criterion dict."""
     if not isinstance(field, dict):
-        return "", "EQUALS"
-    return str(field.get("value", "")), str(field.get("modifier") or "EQUALS")
+        return StringValues("", "EQUALS")
+    return StringValues(
+        str(field.get("value", "")), str(field.get("modifier") or "EQUALS")
+    )
 
 
 # ── Cross-entity (nested AND) prefill (#123 Phase 2d) ────────────────────────
@@ -412,7 +422,7 @@ def _filter_boolean_radio(
     value: bool | None,
     *,
     path: FilterWidgetPath,
-    relation_child: dict | None = None,
+    relation_child: RelationChild | None = None,
 ) -> Node:
     """Renders a filter-specific boolean radio button group with 'True' and 'False' options.
 
@@ -426,10 +436,12 @@ def _filter_boolean_radio(
     return Div(
         attributes=[
             ("class", "flex flex-col gap-1"),
+            # No ``compose=True``: the relation-bool serializer branch builds and
+            # appends its own AND element directly, returning before it ever reads
+            # ``data-compose`` — so emitting it would be inert and misleading.
             *filter_widget_attributes(
                 path,
                 kind,
-                compose=relation_child is not None,
                 relation_child=relation_child,
             ),
         ],

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -8,6 +8,7 @@ from common.components.date_range_picker import DateRangePicker
 from common.components.primitives import (
     Checkbox,
     Div,
+    FilterWidgetKind,
     FilterWidgetPath,
     Input,
     Label,
@@ -95,8 +96,8 @@ def _extract_labeled(items: list) -> list[LabeledOption]:
     return pairs
 
 
-def _filter_get_choice(existing: dict, field: str) -> FilterChoice:
-    raw = existing.get(field, {})
+def _choice_from_raw(raw: dict) -> FilterChoice:
+    """Parse a set criterion dict (value/excludes/modifier) into a FilterChoice."""
     if not isinstance(raw, dict):
         return FilterChoice([], [], "")
     return FilterChoice(
@@ -106,14 +107,12 @@ def _filter_get_choice(existing: dict, field: str) -> FilterChoice:
     )
 
 
-def _parse_range(existing: dict, key: str) -> RangeValues:
-    """Extract (min, max) from a range filter criterion, defaulting to ("", "").
+def _filter_get_choice(existing: dict, field: str) -> FilterChoice:
+    return _choice_from_raw(existing.get(field, {}))
 
-    A one-sided range stores its single bound in ``value`` regardless of side
-    (GREATER_THAN → min, LESS_THAN → max), so the modifier decides which slot it
-    fills; only BETWEEN carries both ``value`` (min) and ``value2`` (max).
-    """
-    field = existing.get(key, {})
+
+def _range_from_field(field: dict) -> RangeValues:
+    """Extract (min, max) from a range criterion dict, defaulting to ("", "")."""
     if not isinstance(field, dict):
         return RangeValues("", "")
     value = str(field.get("value", ""))
@@ -122,13 +121,18 @@ def _parse_range(existing: dict, key: str) -> RangeValues:
     return RangeValues(value, str(field.get("value2", "")))
 
 
-def _parse_number(existing: dict, key: str) -> NumberValues:
-    """Extract (value, value2, modifier) from a numeric filter criterion.
+def _parse_range(existing: dict, key: str) -> RangeValues:
+    """Extract (min, max) from a range filter criterion, defaulting to ("", "").
 
-    Backward compatible with old RangeSlider JSON: a stored GREATER_THAN /
-    LESS_THAN / BETWEEN criterion maps straight onto value/value2/modifier.
+    A one-sided range stores its single bound in ``value`` regardless of side
+    (GREATER_THAN → min, LESS_THAN → max), so the modifier decides which slot it
+    fills; only BETWEEN carries both ``value`` (min) and ``value2`` (max).
     """
-    field = existing.get(key, {})
+    return _range_from_field(existing.get(key, {}))
+
+
+def _number_from_field(field: dict) -> NumberValues:
+    """Extract (value, value2, modifier) from a numeric criterion dict."""
     if not isinstance(field, dict):
         return NumberValues("", "", "EQUALS")
     return NumberValues(
@@ -136,6 +140,74 @@ def _parse_number(existing: dict, key: str) -> NumberValues:
         str(field.get("value2", "")),
         str(field.get("modifier") or "EQUALS"),
     )
+
+
+def _parse_number(existing: dict, key: str) -> NumberValues:
+    """Extract (value, value2, modifier) from a numeric filter criterion.
+
+    Backward compatible with old RangeSlider JSON: a stored GREATER_THAN /
+    LESS_THAN / BETWEEN criterion maps straight onto value/value2/modifier.
+    """
+    return _number_from_field(existing.get(key, {}))
+
+
+def _string_from_field(field: dict) -> tuple[str, str]:
+    """Extract (value, modifier) from a string criterion dict."""
+    if not isinstance(field, dict):
+        return "", "EQUALS"
+    return str(field.get("value", "")), str(field.get("modifier") or "EQUALS")
+
+
+# ── Cross-entity (nested AND) prefill (#123 Phase 2d) ────────────────────────
+# Repointed cross-entity widgets serialize into ``existing["AND"]`` as their own
+# sub-filter element (independent EXISTS), so prefill scans that list rather than
+# reading a flat top-level key. Each helper is matched to a widget by the same
+# ``data-path`` the widget serializes to — a single source of truth.
+
+
+def _deep_get(value: dict, keys: FilterWidgetPath) -> object:
+    """Walk ``keys`` through nested dicts, returning None if any step is absent."""
+    current: object = value
+    for key in keys:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def _cross_entity_criterion(existing: dict, path: FilterWidgetPath) -> dict:
+    """Find the leaf criterion a composed widget at ``path`` serialized into AND.
+
+    Scans ``existing["AND"]`` for the element whose nested chain ``path[:-1]``
+    contains ``path[-1]`` as a dict (the leaf criterion), returning that dict (or
+    ``{}`` when no element matches). Example: ``["session_filter", "device"]``
+    finds ``{"session_filter": {"device": {...}}}`` and returns the inner dict.
+    """
+    for element in existing.get("AND", []) or []:
+        if not isinstance(element, dict):
+            continue
+        parent = _deep_get(element, path[:-1])
+        if isinstance(parent, dict) and isinstance(parent.get(path[-1]), dict):
+            return parent[path[-1]]
+    return {}
+
+
+def _cross_entity_bool(
+    existing: dict, relation_field: str, child_key: str
+) -> bool | None:
+    """Read a relation-bool widget's tri-state from the AND list.
+
+    Returns True when an AND element's ``[relation_field][child_key]`` exists and
+    its relation is matched ANY (no ``match`` / not NONE), False when that element
+    sets ``match: "NONE"``, and None when no such element is present.
+    """
+    for element in existing.get("AND", []) or []:
+        if not isinstance(element, dict):
+            continue
+        relation = element.get(relation_field)
+        if isinstance(relation, dict) and child_key in relation:
+            return relation.get("match") != "NONE"
+    return None
 
 
 def _parse_bool(existing: dict, key: str) -> bool:
@@ -216,11 +288,21 @@ def _split_modifier(modifier: str, has_m2m: bool = False) -> str:
     return ""
 
 
-def _enum_filter(field_name: str, options, choice: FilterChoice, *, nullable) -> Node:
+def _enum_filter(
+    field_name: str,
+    options,
+    choice: FilterChoice,
+    *,
+    nullable,
+    path: FilterWidgetPath | None = None,
+    compose: bool = False,
+) -> Node:
     """A FilterSelect over a small, fully pre-rendered option set (enum field).
 
     Enum fields are single-valued, so no M2M modifiers (all/only are
-    meaningless); only the presence modifier is surfaced.
+    meaningless); only the presence modifier is surfaced. ``path``/``compose``
+    let a cross-entity widget point at a nested sub-filter leaf (defaults to the
+    flat ``[field_name]``).
     """
     options_str = [(str(value), label) for value, label in options]
     included = [
@@ -237,7 +319,8 @@ def _enum_filter(field_name: str, options, choice: FilterChoice, *, nullable) ->
         excluded=excluded,
         modifier=modifier,
         modifier_options=_modifier_options(nullable),
-        path=[field_name],
+        path=path if path is not None else [field_name],
+        compose=compose,
     )
 
 
@@ -248,13 +331,17 @@ def _model_filter(
     search_url,
     nullable,
     m2m_modifiers: list[LabeledOption] | None = None,
+    path: FilterWidgetPath | None = None,
+    compose: bool = False,
 ) -> Node:
     """A FilterSelect backed by a search endpoint.
 
     Labels are embedded in the filter JSON (Stash-style), so pills render
     directly from ``choice`` with no DB round-trip. Pass ``m2m_modifiers`` for
     many-to-many fields to surface ``(All)`` / ``(Only)`` pseudo-options in the
-    dropdown alongside the presence options.
+    dropdown alongside the presence options. ``path``/``compose`` let a
+    cross-entity widget point at a nested sub-filter leaf (defaults to the flat
+    ``[field_name]``).
     """
     modifier = _split_modifier(choice.modifier, has_m2m=bool(m2m_modifiers))
     return FilterSelect(
@@ -265,7 +352,8 @@ def _model_filter(
         modifier_options=_modifier_options(nullable, m2m_modifiers),
         search_url=search_url,
         prefetch=DEFAULT_PREFETCH,
-        path=[field_name],
+        path=path if path is not None else [field_name],
+        compose=compose,
     )
 
 
@@ -319,13 +407,31 @@ def _filter_checkbox(name: str, label: str, checked: bool) -> Node:
 
 
 def _filter_boolean_radio(
-    name: str, label: str, value: bool | None, *, path: FilterWidgetPath
+    name: str,
+    label: str,
+    value: bool | None,
+    *,
+    path: FilterWidgetPath,
+    relation_child: dict | None = None,
 ) -> Node:
-    """Renders a filter-specific boolean radio button group with 'True' and 'False' options."""
+    """Renders a filter-specific boolean radio button group with 'True' and 'False' options.
+
+    When ``relation_child`` is given the widget becomes a cross-entity
+    relation-bool (``data-kind="relation-bool"``): ``path`` is the relation chain
+    (no leaf), the radio toggles ANY (True) vs NONE (False) over the fixed child
+    criterion, and the serializer appends it as its own AND element. See
+    ``filter_widget_attributes``.
+    """
+    kind: FilterWidgetKind = "relation-bool" if relation_child is not None else "bool"
     return Div(
         attributes=[
             ("class", "flex flex-col gap-1"),
-            *filter_widget_attributes(path, "bool"),
+            *filter_widget_attributes(
+                path,
+                kind,
+                compose=relation_child is not None,
+                relation_child=relation_child,
+            ),
         ],
         children=[
             Span(
@@ -645,12 +751,20 @@ def _game_fields(
     status_choice = _filter_get_choice(existing, "status")
     platform_choice = _filter_get_choice(existing, "platform")
     platform_group_choice = _filter_get_choice(existing, "platform_group")
-    device_choice = _filter_get_choice(existing, "device")
-    purchase_type_choice = _filter_get_choice(existing, "purchase_type")
-    purchase_ownership_choice = _filter_get_choice(existing, "purchase_ownership_type")
-    playevent_note_value = existing.get("playevent_note", {}).get("value", "")
-    playevent_note_modifier = existing.get("playevent_note", {}).get(
-        "modifier", "EQUALS"
+    # Cross-entity widgets serialize into existing["AND"] as independent EXISTS
+    # sub-filters (#123 Phase 2d), so prefill reads them back from that list,
+    # matched by the same data-path each widget serializes to.
+    device_choice = _choice_from_raw(
+        _cross_entity_criterion(existing, ["session_filter", "device"])
+    )
+    purchase_type_choice = _choice_from_raw(
+        _cross_entity_criterion(existing, ["purchase_filter", "type"])
+    )
+    purchase_ownership_choice = _choice_from_raw(
+        _cross_entity_criterion(existing, ["purchase_filter", "ownership_type"])
+    )
+    playevent_note_value, playevent_note_modifier = _string_from_field(
+        _cross_entity_criterion(existing, ["playevent_filter", "note"])
     )
 
     year = _parse_number(existing, "year_released")
@@ -661,14 +775,22 @@ def _game_fields(
     session_avg = _parse_number(existing, "session_average")
     purchase_count = _parse_number(existing, "purchase_count")
     playevent_count = _parse_number(existing, "playevent_count")
-    finished_min, finished_max = _parse_range(existing, "finished")
+    finished_min, finished_max = _range_from_field(
+        _cross_entity_criterion(existing, ["playevent_filter", "ended"])
+    )
     manual_pt = _parse_number(existing, "manual_playtime_hours")
     calc_pt = _parse_number(existing, "calculated_playtime_hours")
     price_total = _parse_number(existing, "purchase_price_total")
-    price_any = _parse_number(existing, "purchase_price_any")
-    purchase_refunded_value = _parse_bool_nullable(existing, "purchase_refunded")
-    purchase_infinite_value = _parse_bool_nullable(existing, "purchase_infinite")
-    session_emulated_value = _parse_bool_nullable(existing, "session_emulated")
+    price_any = _number_from_field(
+        _cross_entity_criterion(existing, ["purchase_filter", "converted_price"])
+    )
+    purchase_refunded_value = _cross_entity_bool(
+        existing, "purchase_filter", "is_refunded"
+    )
+    purchase_infinite_value = _cross_entity_bool(
+        existing, "purchase_filter", "infinite"
+    )
+    session_emulated_value = _cross_entity_bool(existing, "session_filter", "emulated")
 
     fields = [
         Div(
@@ -708,15 +830,21 @@ def _game_fields(
                         device_choice,
                         search_url="/api/devices/search",
                         nullable=False,
+                        path=["session_filter", "device"],
+                        compose=True,
                     ),
                 ),
                 _filter_field(
                     "Purchase Type",
                     _enum_filter(
+                        # Element name stays flat (a DOM identifier); the nested
+                        # leaf comes from data-path, decoupled from the name.
                         "purchase_type",
                         Purchase.TYPES,
                         purchase_type_choice,
                         nullable=False,
+                        path=["purchase_filter", "type"],
+                        compose=True,
                     ),
                 ),
                 _filter_field(
@@ -726,6 +854,8 @@ def _game_fields(
                         Purchase.OWNERSHIP_TYPES,
                         purchase_ownership_choice,
                         nullable=False,
+                        path=["purchase_filter", "ownership_type"],
+                        compose=True,
                     ),
                 ),
                 _filter_field(
@@ -735,7 +865,8 @@ def _game_fields(
                         value=playevent_note_value,
                         modifier=playevent_note_modifier,
                         placeholder="e.g. Completed, Started",
-                        path=["playevent_note"],
+                        path=["playevent_filter", "note"],
+                        compose=True,
                     ),
                 ),
                 _filter_field(
@@ -853,7 +984,8 @@ def _game_fields(
                         input_name_prefix="filter-finished",
                         min_value=finished_min,
                         max_value=finished_max,
-                        path=["finished"],
+                        path=["playevent_filter", "ended"],
+                        compose=True,
                     ),
                 ),
                 _filter_field(
@@ -879,7 +1011,8 @@ def _game_fields(
                         placeholder="0",
                         placeholder2="e.g. 100",
                         step="0.01",
-                        path=["purchase_price_any"],
+                        path=["purchase_filter", "converted_price"],
+                        compose=True,
                     ),
                 ),
             ],
@@ -894,19 +1027,24 @@ def _game_fields(
                     "filter-purchase-refunded",
                     "Refunded",
                     purchase_refunded_value,
-                    path=["purchase_refunded"],
+                    path=["purchase_filter"],
+                    relation_child={
+                        "is_refunded": {"value": True, "modifier": "EQUALS"}
+                    },
                 ),
                 _filter_boolean_radio(
                     "filter-purchase-infinite",
                     "Infinite",
                     purchase_infinite_value,
-                    path=["purchase_infinite"],
+                    path=["purchase_filter"],
+                    relation_child={"infinite": {"value": True, "modifier": "EQUALS"}},
                 ),
                 _filter_boolean_radio(
                     "filter-session-emulated",
                     "Emulated",
                     session_emulated_value,
-                    path=["session_emulated"],
+                    path=["session_filter"],
+                    relation_child={"emulated": {"value": True, "modifier": "EQUALS"}},
                 ),
             ],
         ),
@@ -1057,7 +1195,11 @@ def _purchase_fields(existing: dict) -> list:
     )
     date_purchased_min, date_purchased_max = _parse_range(existing, "date_purchased")
     date_refunded_min, date_refunded_max = _parse_range(existing, "date_refunded")
-    finished_min, finished_max = _parse_range(existing, "finished")
+    # Cross-entity: purchase of a game finished in range (#123 Phase 2d). Reads
+    # from the AND list, matched by the data-path the widget serializes to.
+    finished_min, finished_max = _range_from_field(
+        _cross_entity_criterion(existing, ["game_filter", "playevent_filter", "ended"])
+    )
     num = _parse_number(existing, "num_purchases")
 
     fields = [
@@ -1158,7 +1300,8 @@ def _purchase_fields(existing: dict) -> list:
                         input_name_prefix="filter-finished",
                         min_value=finished_min,
                         max_value=finished_max,
-                        path=["finished"],
+                        path=["game_filter", "playevent_filter", "ended"],
+                        compose=True,
                     ),
                 ),
                 _filter_field(
@@ -1361,6 +1504,7 @@ def StringFilter(
     placeholder: str = "",
     *,
     path: FilterWidgetPath,
+    compose: bool = False,
 ) -> Node:
     """Renders a string filter with 8 modifier radio options and a text input."""
     from common.criteria import Modifier
@@ -1418,7 +1562,7 @@ def StringFilter(
     return Div(
         attributes=[
             ("class", "flex flex-col gap-2 @container"),
-            *filter_widget_attributes(path, "string"),
+            *filter_widget_attributes(path, "string", compose=compose),
         ],
         children=[
             Div(
@@ -1452,6 +1596,7 @@ def NumberFilter(
     step: str = "1",
     *,
     path: FilterWidgetPath,
+    compose: bool = False,
 ) -> Node:
     """Renders a numeric filter with 8 modifier radio options and two inputs.
 
@@ -1522,7 +1667,7 @@ def NumberFilter(
     return Div(
         attributes=[
             ("class", "flex flex-col gap-2 @container"),
-            *filter_widget_attributes(path, "number"),
+            *filter_widget_attributes(path, "number", compose=compose),
         ],
         children=[
             Div(

--- a/common/components/primitives.py
+++ b/common/components/primitives.py
@@ -32,7 +32,7 @@ from common.components.core import (
     randomid,
 )
 from common.components.icons_generated import ICON_NODES
-from common.criteria import FilterWidgetKind, FilterWidgetPath
+from common.criteria import FilterWidgetKind, FilterWidgetPath, RelationChild
 from common.sorting import SortString, SortTerm, collapse_sort, cycle_sort
 from common.utils import truncate
 
@@ -65,7 +65,7 @@ def filter_widget_attributes(
     kind: FilterWidgetKind,
     *,
     compose: bool = False,
-    relation_child: dict | None = None,
+    relation_child: RelationChild | None = None,
 ) -> list[HTMLAttribute]:
     """The self-describe attributes every filter-bar widget root carries.
 

--- a/common/components/primitives.py
+++ b/common/components/primitives.py
@@ -61,21 +61,42 @@ DISABLED_WITHIN_CLASS = "has-[:disabled]:opacity-50 has-[:disabled]:cursor-not-a
 
 
 def filter_widget_attributes(
-    path: FilterWidgetPath, kind: FilterWidgetKind
+    path: FilterWidgetPath,
+    kind: FilterWidgetKind,
+    *,
+    compose: bool = False,
+    relation_child: dict | None = None,
 ) -> list[HTMLAttribute]:
-    """The three self-describe attributes every filter-bar widget root carries.
+    """The self-describe attributes every filter-bar widget root carries.
 
     The generic serializer in ``ts/elements/filter-bar.ts`` reads ``data-path``
     (the widget's filter-JSON key, as a JSON array) and ``data-kind`` off any
     ``[data-filter-widget]`` root to handle all widgets uniformly. See issue #123
-    Phase 2. Behaviour is unchanged because that serializer is a behaviour-
-    preserving port of the former hardcoded per-field loops, not because the
-    attributes go unread."""
-    return [
+    Phase 2.
+
+    Cross-entity widgets (issue #123 Phase 2d) add two optional markers:
+
+    - ``compose=True`` emits ``data-compose="and"``: instead of writing the leaf
+      at ``data-path`` top-level, the serializer folds ``data-path`` into a nested
+      object and appends it as its own element of the parent's n-ary ``AND`` list,
+      so several widgets targeting the same relation compose as *independent*
+      EXISTS rather than merging into one shared relation node.
+    - ``relation_child`` (with ``kind="relation-bool"``) supplies the fixed child
+      criterion of a relation toggled by a boolean radio: ``data-path`` is the
+      relation chain *without* a leaf and ``data-relation-child`` is the child
+      keyed by field, e.g. ``{"emulated": {"value": True, "modifier": "EQUALS"}}``.
+      A ``True`` radio matches ANY, ``False`` sets ``match: "NONE"``.
+    """
+    attributes: list[HTMLAttribute] = [
         ("data-filter-widget", ""),
         ("data-path", json.dumps(path)),
         ("data-kind", kind),
     ]
+    if compose:
+        attributes.append(("data-compose", "and"))
+    if relation_child is not None:
+        attributes.append(("data-relation-child", json.dumps(relation_child)))
+    return attributes
 
 
 # The single max-width every content container obeys — navbar, page bodies

--- a/common/components/search_select.py
+++ b/common/components/search_select.py
@@ -462,6 +462,7 @@ def FilterSelect(
     id: str = "",
     free_text: bool = False,
     path: FilterWidgetPath | None = None,
+    compose: bool = False,
 ) -> Node:
     """Include/exclude filter combobox built on the shared ``_combobox_shell``.
 
@@ -574,7 +575,9 @@ def FilterSelect(
     # filter-bar callers pass ``path``; synthetic/test callers leave it None and
     # get no extra attributes (kind is always "set" for a FilterSelect).
     widget_attributes = (
-        filter_widget_attributes(path, "set") if path is not None else []
+        filter_widget_attributes(path, "set", compose=compose)
+        if path is not None
+        else []
     )
     return _SearchSelect(
         widget_attributes,

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -513,7 +513,16 @@ type FilterWidgetPath = list[str]
 # The widget ``data-kind`` token a criterion advertises to the generic filter-bar
 # serializer (ts/elements/filter-bar.ts). One token per value shape; several
 # criterion types share a kind (every numeric criterion → "number").
-type FilterWidgetKind = Literal["string", "number", "date", "bool", "set"]
+#
+# ``relation-bool`` is special: it does not describe a *leaf criterion* but a
+# whole cross-entity sub-filter toggled by a boolean radio (ANY vs NONE) with a
+# fixed child criterion (e.g. ``session_filter`` with ``emulated=true``). It is
+# therefore never produced by ``criterion_kind`` / ``resolve_path_kind`` — those
+# only resolve leaf criteria — but it is a valid widget ``data-kind`` the serializer
+# dispatches on. See ``filter_widget_attributes`` and ``ts/elements/filter-bar.ts``.
+type FilterWidgetKind = Literal[
+    "string", "number", "date", "bool", "set", "relation-bool"
+]
 
 
 # Maps a criterion class to the widget ``data-kind`` token a filter-bar widget

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -505,24 +505,31 @@ def _filter_class_for(
     return None
 
 
-# A filter widget's canonical filter-JSON key chain. Length-1 today (one JSON
-# key per widget); typed as a list so nested cross-entity paths stay expressible.
-# Example: ["session_filter", "emulated"].
+# A filter widget's canonical filter-JSON key chain: single-segment for a flat
+# field (e.g. ["year_released"]), multi-segment for a cross-entity widget that
+# steps through nested sub-filters (e.g. ["session_filter", "device"] or
+# ["game_filter", "playevent_filter", "ended"]).
 type FilterWidgetPath = list[str]
 
-# The widget ``data-kind`` token a criterion advertises to the generic filter-bar
-# serializer (ts/elements/filter-bar.ts). One token per value shape; several
-# criterion types share a kind (every numeric criterion → "number").
-#
-# ``relation-bool`` is special: it does not describe a *leaf criterion* but a
-# whole cross-entity sub-filter toggled by a boolean radio (ANY vs NONE) with a
-# fixed child criterion (e.g. ``session_filter`` with ``emulated=true``). It is
-# therefore never produced by ``criterion_kind`` / ``resolve_path_kind`` — those
-# only resolve leaf criteria — but it is a valid widget ``data-kind`` the serializer
-# dispatches on. See ``filter_widget_attributes`` and ``ts/elements/filter-bar.ts``.
-type FilterWidgetKind = Literal[
-    "string", "number", "date", "bool", "set", "relation-bool"
-]
+# The fixed child criterion of a relation-bool widget, keyed by the related field
+# name. The serializer wraps it in the relation sub-filter (adding ``match: NONE``
+# for the False radio).
+type RelationChild = dict[
+    str, dict[str, object]
+]  # {"emulated": {"value": True, "modifier": "EQUALS"}}
+
+# The widget ``data-kind`` tokens for leaf criteria — one token per value shape;
+# several criterion types share a kind (every numeric criterion → "number"). These
+# are the only kinds ``criterion_kind`` / ``resolve_path_kind`` ever produce.
+type LeafWidgetKind = Literal["string", "number", "date", "bool", "set"]
+
+# Every widget ``data-kind`` token the filter-bar serializer dispatches on.
+# ``relation-bool`` extends the leaf kinds: it describes not a leaf criterion but
+# a whole cross-entity sub-filter toggled by a boolean radio (ANY vs NONE) over a
+# fixed child criterion, so it is a valid widget kind yet never produced by the
+# leaf resolvers above. See ``filter_widget_attributes`` and
+# ``ts/elements/filter-bar.ts``.
+type FilterWidgetKind = LeafWidgetKind | Literal["relation-bool"]
 
 
 # Maps a criterion class to the widget ``data-kind`` token a filter-bar widget
@@ -530,7 +537,7 @@ type FilterWidgetKind = Literal[
 # contract: a widget's ``data-kind`` must equal the kind of the criterion its
 # ``data-path`` resolves to. Several criterion types share a kind (every numeric
 # criterion → "number"; both set criteria → "set").
-_CRITERION_KINDS: dict[type[_Criterion], FilterWidgetKind] = {
+_CRITERION_KINDS: dict[type[_Criterion], LeafWidgetKind] = {
     StringCriterion: "string",
     IntCriterion: "number",
     FloatCriterion: "number",
@@ -542,7 +549,7 @@ _CRITERION_KINDS: dict[type[_Criterion], FilterWidgetKind] = {
 }
 
 
-def criterion_kind(criterion_cls: type[_Criterion]) -> FilterWidgetKind:
+def criterion_kind(criterion_cls: type[_Criterion]) -> LeafWidgetKind:
     """Return the widget ``data-kind`` token for a criterion class.
 
     Raises ``ValueError`` for a criterion type with no registered kind, so a new
@@ -557,7 +564,7 @@ def criterion_kind(criterion_cls: type[_Criterion]) -> FilterWidgetKind:
 
 def resolve_path_kind(
     filter_cls: type["OperatorFilter"], path: FilterWidgetPath
-) -> FilterWidgetKind:
+) -> LeafWidgetKind:
     """Resolve a filter-widget ``data-path`` against a filter dataclass tree and
     return the expected ``data-kind``.
 

--- a/e2e/test_boolean_filter_e2e.py
+++ b/e2e/test_boolean_filter_e2e.py
@@ -60,6 +60,9 @@ def test_no_selection_omits_boolean_filters(live_server, page):
     parsed = _filter_from_url(page.url)
     assert "mastered" not in parsed
     assert "purchase_refunded" not in parsed
+    # No selection means no AND element is created (purchase_refunded is now a
+    # cross-entity relation-bool composed into AND; #123 Phase 2d).
+    assert "AND" not in parsed
 
 
 @pytest.mark.django_db
@@ -67,13 +70,14 @@ def test_no_selection_omits_boolean_filters(live_server, page):
 def test_select_true_and_false_serializes_correctly(live_server, page):
     page.goto(live_server.url + "/test-boolean-filter/")
 
-    # Select "True" for Mastered
-    # Under PurchaseFilterBar: "filter-mastered" is the mastered radio name.
-    # The true radio has value="true", false radio has value="false"
+    # Select "True" for Mastered — a flat (same-entity) bool, unchanged.
+    # "filter-mastered" is the mastered radio name; true/false radios carry
+    # value="true"/value="false".
     true_radio = page.locator('input[name="filter-mastered"][value="true"]')
     true_radio.click()
 
-    # Select "False" for Refunded (filter-purchase-refunded)
+    # Select "False" for Refunded (filter-purchase-refunded) — a cross-entity
+    # relation-bool: False composes into AND as match=NONE over is_refunded=true.
     false_radio = page.locator('input[name="filter-purchase-refunded"][value="false"]')
     false_radio.click()
 
@@ -84,7 +88,14 @@ def test_select_true_and_false_serializes_correctly(live_server, page):
         )
     parsed = _filter_from_url(page.url)
     assert parsed.get("mastered") == {"value": True, "modifier": "EQUALS"}
-    assert parsed.get("purchase_refunded") == {"value": False, "modifier": "EQUALS"}
+    assert parsed.get("AND") == [
+        {
+            "purchase_filter": {
+                "match": "NONE",
+                "is_refunded": {"value": True, "modifier": "EQUALS"},
+            }
+        }
+    ]
 
 
 @pytest.mark.django_db

--- a/e2e/test_cross_entity_filter_e2e.py
+++ b/e2e/test_cross_entity_filter_e2e.py
@@ -1,0 +1,168 @@
+"""End-to-end Playwright tests for repointed cross-entity filter widgets (#123 2d).
+
+Covers the one layer the Python-side tests cannot reach: the generic serializer
+in ``ts/elements/filter-bar.ts`` building the NESTED ``AND`` sub-filter form for
+cross-entity widgets — both a composed leaf (``purchase_type`` → set) and a
+relation-bool (``session_emulated`` → ANY/NONE) — and the bar prefilling those
+widgets back from a reloaded ``?filter=`` URL.
+
+Uses the games ``FilterBar`` rendered at a custom URL so the test needs no auth.
+``purchase_type`` is an enum FilterSelect with pre-rendered option rows (no
+search endpoint), so its include path is reachable from a static page.
+"""
+
+import json
+import urllib.parse
+
+import pytest
+from django.http import HttpResponse
+from django.test import override_settings
+from django.urls import path
+
+from common.components import FilterBar
+
+
+def _bar_page(filter_json: str = "") -> str:
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>Cross-entity filter E2E</title>
+    <script src="/static/js/htmx.min.js"></script>
+    <script src="/static/js/dist/elements/search-select.js" type="module"></script>
+    <script src="/static/js/dist/elements/filter-bar.js" type="module"></script>
+</head>
+<body>
+    {FilterBar(filter_json=filter_json, preset_list_url="/p/l", preset_save_url="/p/s")}
+</body>
+</html>"""
+
+
+def bar_view(request):
+    return HttpResponse(_bar_page(request.GET.get("filter", "")))
+
+
+urlpatterns = [
+    path("test-cross-entity/", bar_view),
+]
+
+
+def _filter_from_url(url: str) -> dict:
+    query = urllib.parse.urlparse(url).query
+    params = urllib.parse.parse_qs(query)
+    raw = params.get("filter", [""])[0]
+    return json.loads(raw) if raw else {}
+
+
+def _submit(page):
+    with page.expect_navigation():
+        page.evaluate(
+            "document.getElementById('filter-bar-form')"
+            ".dispatchEvent(new Event('submit', {cancelable: true}))"
+        )
+
+
+# ── composed leaf: purchase_type (set) → AND[{purchase_filter:{type:…}}] ──────
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_cross_entity_filter_e2e")
+def test_purchase_type_composes_into_and(live_server, page):
+    page.goto(live_server.url + "/test-cross-entity/")
+    widget = page.locator('search-select[name="purchase_type"]')
+    widget.locator("[data-search-select-search]").click()
+    widget.locator(
+        '[data-search-select-option][data-value="game"] '
+        '[data-search-select-action="include"]'
+    ).click()
+    _submit(page)
+
+    parsed = _filter_from_url(page.url)
+    assert parsed == {
+        "AND": [
+            {
+                "purchase_filter": {
+                    "type": {
+                        "value": [{"id": "game", "label": "Game"}],
+                        "excludes": [],
+                        "modifier": "INCLUDES",
+                    }
+                }
+            }
+        ]
+    }
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_cross_entity_filter_e2e")
+def test_purchase_type_prefills_from_url(live_server, page):
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "purchase_filter": {
+                        "type": {
+                            "value": [{"id": "game", "label": "Game"}],
+                            "excludes": [],
+                            "modifier": "INCLUDES",
+                        }
+                    }
+                }
+            ]
+        }
+    )
+    page.goto(
+        live_server.url
+        + "/test-cross-entity/?filter="
+        + urllib.parse.quote(filter_json)
+    )
+    pill = page.locator(
+        'search-select[name="purchase_type"] [data-search-select-pills] [data-value="game"]'
+    )
+    assert pill.count() >= 1
+
+
+# ── relation-bool: session_emulated = No → AND[{session_filter:{match:NONE…}}] ─
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_cross_entity_filter_e2e")
+def test_session_emulated_no_composes_relation_none(live_server, page):
+    page.goto(live_server.url + "/test-cross-entity/")
+    page.locator('input[name="filter-session-emulated"][value="false"]').click()
+    _submit(page)
+
+    parsed = _filter_from_url(page.url)
+    assert parsed == {
+        "AND": [
+            {
+                "session_filter": {
+                    "match": "NONE",
+                    "emulated": {"value": True, "modifier": "EQUALS"},
+                }
+            }
+        ]
+    }
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_cross_entity_filter_e2e")
+def test_session_emulated_no_prefills_from_url(live_server, page):
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "session_filter": {
+                        "match": "NONE",
+                        "emulated": {"value": True, "modifier": "EQUALS"},
+                    }
+                }
+            ]
+        }
+    )
+    page.goto(
+        live_server.url
+        + "/test-cross-entity/?filter="
+        + urllib.parse.quote(filter_json)
+    )
+    false_radio = page.locator('input[name="filter-session-emulated"][value="false"]')
+    assert false_radio.is_checked()

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -422,9 +422,24 @@ class FilterBarRenderingTest(TestCase):
 
     def test_finished_filter_prepopulates_less_than_into_max(self):
         """A LESS_THAN (max-only) finished filter fills the max slot, not min —
-        guards the modifier-aware _parse_range fix."""
+        guards the modifier-aware _range_from_field fix. The purchase `finished`
+        widget is cross-entity (#123 Phase 2d), so it prefills from the nested AND
+        sub-filter form (game_filter→playevent_filter→ended), not a flat key."""
         filter_json = json.dumps(
-            {"finished": {"value": "2024-12-31", "modifier": "LESS_THAN"}}
+            {
+                "AND": [
+                    {
+                        "game_filter": {
+                            "playevent_filter": {
+                                "ended": {
+                                    "value": "2024-12-31",
+                                    "modifier": "LESS_THAN",
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
         )
         html = str(
             PurchaseFilterBar(
@@ -443,9 +458,23 @@ class FilterBarRenderingTest(TestCase):
 
     def test_finished_filter_prepopulates_greater_than_into_min(self):
         """A GREATER_THAN (min-only) finished filter fills the min slot — the
-        symmetric counterpart to the LESS_THAN case above."""
+        symmetric counterpart to the LESS_THAN case above, in the nested AND
+        cross-entity form."""
         filter_json = json.dumps(
-            {"finished": {"value": "2024-01-01", "modifier": "GREATER_THAN"}}
+            {
+                "AND": [
+                    {
+                        "game_filter": {
+                            "playevent_filter": {
+                                "ended": {
+                                    "value": "2024-01-01",
+                                    "modifier": "GREATER_THAN",
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
         )
         html = str(
             PurchaseFilterBar(

--- a/tests/test_filter_cross_entity.py
+++ b/tests/test_filter_cross_entity.py
@@ -13,13 +13,31 @@ parent's n-ary ``AND`` list. This module asserts:
 """
 
 import json
+import re
 from datetime import date, datetime, timezone
 
 import pytest
 
 from common.components.filters import FilterBar, PurchaseFilterBar
-from games.filters import GameFilter, parse_game_filter, parse_purchase_filter
-from games.models import Device, Game, Platform, Purchase, Session
+from common.criteria import (
+    BoolCriterion,
+    ChoiceCriterion,
+    DateCriterion,
+    FloatCriterion,
+    Modifier,
+    MultiCriterion,
+    RelationMatch,
+    StringCriterion,
+)
+from games.filters import (
+    GameFilter,
+    PlayEventFilter,
+    PurchaseFilter,
+    SessionFilter,
+    parse_game_filter,
+    parse_purchase_filter,
+)
+from games.models import Device, Game, Platform, PlayEvent, Purchase, Session
 
 
 def _dt(year=2024, month=6, day=1):
@@ -448,3 +466,345 @@ def test_purchase_bar_prefills_finished_from_and(db):
     html = str(PurchaseFilterBar(filter_json))
     assert "2024-01-01" in html
     assert "2024-12-31" in html
+
+
+# ── parametrized parity: each repointed widget's NESTED form selects the same
+#    rows as its still-live FLAT oracle field (#123 Phase 2d permanent guard) ──
+#
+# The 10 repointed widgets are now the canonical path; the flat GameFilter /
+# PurchaseFilter convenience fields remain as oracles. Each case builds BOTH the
+# flat and the nested filter dataclass over one shared world and asserts they
+# select the identical id set. A mismatch is a real bug (the repoint changed
+# behaviour), not a test to weaken.
+
+
+@pytest.fixture
+def parity_world(db):
+    """One world exercising every repointed widget's dimension at once.
+
+    Each repointed criterion matches a strict, non-empty subset so an equal
+    flat/nested result is a meaningful (non-vacuous) check."""
+    pc = Platform.objects.create(name="PC")
+    deck = Device.objects.create(name="SteamDeck", type=Device.HANDHELD)
+    desktop = Device.objects.create(name="Desktop", type=Device.PC)
+
+    # session: device + emulated dimension
+    deck_game = Game.objects.create(name="DeckGame", platform=pc)
+    Session.objects.create(
+        game=deck_game, timestamp_start=_dt(), device=deck, emulated=False
+    )
+    emulated_game = Game.objects.create(name="EmulatedGame", platform=pc)
+    Session.objects.create(
+        game=emulated_game, timestamp_start=_dt(), device=desktop, emulated=True
+    )
+
+    # purchase: type / ownership / price / refunded / infinite dimension
+    game_buyer = Game.objects.create(name="GameBuyer", platform=pc)
+    cheap = Purchase.objects.create(
+        date_purchased=date(2024, 1, 1),
+        type=Purchase.GAME,
+        ownership_type=Purchase.DIGITAL,
+        converted_price=10.0,
+        infinite=False,
+    )
+    cheap.games.set([game_buyer])
+
+    dlc_buyer = Game.objects.create(name="DlcBuyer", platform=pc)
+    pricey = Purchase.objects.create(
+        date_purchased=date(2024, 1, 1),
+        type=Purchase.DLC,
+        related_game=dlc_buyer,
+        ownership_type=Purchase.PHYSICAL,
+        converted_price=50.0,
+        date_refunded=date(2024, 2, 1),
+        infinite=True,
+    )
+    pricey.games.set([dlc_buyer])
+
+    # playevent: note + ended dimension
+    finished_game = Game.objects.create(name="FinishedGame", platform=pc)
+    PlayEvent.objects.create(
+        game=finished_game, ended=date(2024, 6, 15), note="Completed the run"
+    )
+    started_game = Game.objects.create(name="StartedGame", platform=pc)
+    PlayEvent.objects.create(
+        game=started_game, ended=date(2023, 1, 1), note="Just started"
+    )
+
+    # a bare game touching no relation (matters for the NONE/False branches)
+    Game.objects.create(name="Bare", platform=pc)
+
+    # purchase-bar finished: a purchase of a finished game vs one of an unfinished
+    bought_finished = Purchase.objects.create(date_purchased=date(2024, 1, 1))
+    bought_finished.games.set([finished_game])
+    bought_other = Purchase.objects.create(date_purchased=date(2024, 1, 1))
+    bought_other.games.set([started_game])
+
+    return {"deck": deck.id}
+
+
+def _ids(model, filt) -> set[int]:
+    return set(
+        model.objects.filter(filt.to_q()).distinct().values_list("id", flat=True)
+    )
+
+
+def _between_2024() -> DateCriterion:
+    return DateCriterion(
+        value="2024-01-01", value2="2024-12-31", modifier=Modifier.BETWEEN
+    )
+
+
+# Each case: (model, flat-filter builder, nested-filter builder). Builders take
+# the world dict (only the device case needs an id from it).
+PARITY_CASES = {
+    "device_set": (
+        Game,
+        lambda w: GameFilter(
+            device=MultiCriterion(value=[w["deck"]], modifier=Modifier.INCLUDES)
+        ),
+        lambda w: GameFilter(
+            session_filter=SessionFilter(
+                device=MultiCriterion(value=[w["deck"]], modifier=Modifier.INCLUDES)
+            )
+        ),
+    ),
+    "purchase_type_set": (
+        Game,
+        lambda w: GameFilter(
+            purchase_type=ChoiceCriterion(value=["game"], modifier=Modifier.INCLUDES)
+        ),
+        lambda w: GameFilter(
+            purchase_filter=PurchaseFilter(
+                type=ChoiceCriterion(value=["game"], modifier=Modifier.INCLUDES)
+            )
+        ),
+    ),
+    "purchase_ownership_set": (
+        Game,
+        lambda w: GameFilter(
+            purchase_ownership_type=ChoiceCriterion(
+                value=["ph"], modifier=Modifier.INCLUDES
+            )
+        ),
+        lambda w: GameFilter(
+            purchase_filter=PurchaseFilter(
+                ownership_type=ChoiceCriterion(value=["ph"], modifier=Modifier.INCLUDES)
+            )
+        ),
+    ),
+    "purchase_price_any_number": (
+        Game,
+        lambda w: GameFilter(
+            purchase_price_any=FloatCriterion(
+                value=20.0, modifier=Modifier.GREATER_THAN
+            )
+        ),
+        lambda w: GameFilter(
+            purchase_filter=PurchaseFilter(
+                converted_price=FloatCriterion(
+                    value=20.0, modifier=Modifier.GREATER_THAN
+                )
+            )
+        ),
+    ),
+    "playevent_note_string": (
+        Game,
+        lambda w: GameFilter(
+            playevent_note=StringCriterion(
+                value="Completed", modifier=Modifier.INCLUDES
+            )
+        ),
+        lambda w: GameFilter(
+            playevent_filter=PlayEventFilter(
+                note=StringCriterion(value="Completed", modifier=Modifier.INCLUDES)
+            )
+        ),
+    ),
+    "game_finished_date": (
+        Game,
+        lambda w: GameFilter(finished=_between_2024()),
+        lambda w: GameFilter(playevent_filter=PlayEventFilter(ended=_between_2024())),
+    ),
+    "session_emulated_true": (
+        Game,
+        lambda w: GameFilter(session_emulated=BoolCriterion(value=True)),
+        lambda w: GameFilter(
+            session_filter=SessionFilter(
+                match=RelationMatch.ANY, emulated=BoolCriterion(value=True)
+            )
+        ),
+    ),
+    "session_emulated_false": (
+        Game,
+        lambda w: GameFilter(session_emulated=BoolCriterion(value=False)),
+        lambda w: GameFilter(
+            session_filter=SessionFilter(
+                match=RelationMatch.NONE, emulated=BoolCriterion(value=True)
+            )
+        ),
+    ),
+    "purchase_refunded_true": (
+        Game,
+        lambda w: GameFilter(purchase_refunded=BoolCriterion(value=True)),
+        lambda w: GameFilter(
+            purchase_filter=PurchaseFilter(
+                match=RelationMatch.ANY, is_refunded=BoolCriterion(value=True)
+            )
+        ),
+    ),
+    "purchase_refunded_false": (
+        Game,
+        lambda w: GameFilter(purchase_refunded=BoolCriterion(value=False)),
+        lambda w: GameFilter(
+            purchase_filter=PurchaseFilter(
+                match=RelationMatch.NONE, is_refunded=BoolCriterion(value=True)
+            )
+        ),
+    ),
+    "purchase_infinite_true": (
+        Game,
+        lambda w: GameFilter(purchase_infinite=BoolCriterion(value=True)),
+        lambda w: GameFilter(
+            purchase_filter=PurchaseFilter(
+                match=RelationMatch.ANY, infinite=BoolCriterion(value=True)
+            )
+        ),
+    ),
+    "purchase_infinite_false": (
+        Game,
+        lambda w: GameFilter(purchase_infinite=BoolCriterion(value=False)),
+        lambda w: GameFilter(
+            purchase_filter=PurchaseFilter(
+                match=RelationMatch.NONE, infinite=BoolCriterion(value=True)
+            )
+        ),
+    ),
+    "purchase_bar_finished_date": (
+        Purchase,
+        lambda w: PurchaseFilter(finished=_between_2024()),
+        lambda w: PurchaseFilter(
+            game_filter=GameFilter(
+                playevent_filter=PlayEventFilter(ended=_between_2024())
+            )
+        ),
+    ),
+}
+
+
+@pytest.mark.parametrize("case_id", list(PARITY_CASES), ids=list(PARITY_CASES))
+def test_repointed_widget_nested_equals_flat_oracle(parity_world, case_id):
+    model, build_flat, build_nested = PARITY_CASES[case_id]
+    flat_ids = _ids(model, build_flat(parity_world))
+    nested_ids = _ids(model, build_nested(parity_world))
+    # Non-vacuous: the criterion must actually match something in the world, so an
+    # all-empty bug can't make the equality trivially pass.
+    assert flat_ids, f"{case_id}: flat oracle matched nothing (test data too thin)"
+    assert nested_ids == flat_ids, (
+        f"{case_id}: nested form selected {nested_ids} but flat oracle {flat_ids}"
+    )
+
+
+# ── prefill coverage gaps (#123 Phase 2d hardening) ──────────────────────────
+
+
+def test_game_bar_prefills_purchase_price_any_from_and(db):
+    """Number helper: a nested converted_price criterion repopulates the widget."""
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "purchase_filter": {
+                        "converted_price": {"value": 20, "modifier": "GREATER_THAN"}
+                    }
+                }
+            ]
+        }
+    )
+    html = str(FilterBar(filter_json))
+    assert re.search(r'name="filter-purchase-price-any"[^>]*value="20"', html)
+
+
+def test_game_bar_prefills_playevent_note_from_and(db):
+    """String helper: a nested note criterion repopulates the text input."""
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "playevent_filter": {
+                        "note": {"value": "Completed", "modifier": "INCLUDES"}
+                    }
+                }
+            ]
+        }
+    )
+    html = str(FilterBar(filter_json))
+    assert re.search(r'name="filter-playevent_note"[^>]*value="Completed"', html)
+
+
+def test_game_bar_prefills_session_emulated_true_radio(db):
+    """Relation-bool TRUE branch: an ANY element checks the 'True' radio."""
+    filter_json = _relation_bool_json(
+        "session_filter",
+        {"emulated": {"value": True, "modifier": "EQUALS"}},
+        value=True,
+    )
+    html = str(FilterBar(filter_json))
+    assert re.search(
+        r'name="filter-session-emulated"[^>]*value="true"[^>]*checked', html
+    )
+
+
+def test_game_bar_prefills_purchase_type_and_ownership_independently(db):
+    """Prefill ambiguity: two purchase_filter AND elements (type + ownership) each
+    repopulate their OWN widget — the type pill shows the type value and the
+    ownership pill the ownership value, with no cross-contamination."""
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {"purchase_filter": {"type": _set_criterion("game", "Game")}},
+                {
+                    "purchase_filter": {
+                        "ownership_type": _set_criterion("ph", "Physical")
+                    }
+                },
+            ]
+        }
+    )
+    html = str(FilterBar(filter_json))
+    include_pills = re.findall(
+        r'data-pill[^>]*?data-value="([^"]+)"[^>]*?data-search-select-type="include"',
+        html,
+    )
+    # exactly one include pill per widget — no value leaked into the other widget
+    assert include_pills.count("game") == 1
+    assert include_pills.count("ph") == 1
+
+
+def test_game_bar_prefills_refunded_false_and_infinite_true_independently(db):
+    """Two relation-bool elements set together prefill each bool independently:
+    refunded NONE → 'False' checked, infinite ANY → 'True' checked."""
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "purchase_filter": {
+                        "match": "NONE",
+                        "is_refunded": {"value": True, "modifier": "EQUALS"},
+                    }
+                },
+                {
+                    "purchase_filter": {
+                        "infinite": {"value": True, "modifier": "EQUALS"}
+                    }
+                },
+            ]
+        }
+    )
+    html = str(FilterBar(filter_json))
+    assert re.search(
+        r'name="filter-purchase-refunded"[^>]*value="false"[^>]*checked', html
+    )
+    assert re.search(
+        r'name="filter-purchase-infinite"[^>]*value="true"[^>]*checked', html
+    )

--- a/tests/test_filter_cross_entity.py
+++ b/tests/test_filter_cross_entity.py
@@ -1,0 +1,450 @@
+"""Repointed cross-entity filter widgets (#123 Phase 2d).
+
+Nine GameFilter widgets (and one PurchaseFilter widget) stopped emitting a flat
+top-level convenience key and now emit the canonical NESTED cross-entity
+sub-filter form, composed as INDEPENDENT EXISTS — each its own element of the
+parent's n-ary ``AND`` list. This module asserts:
+
+- the JSON each repointed widget emits parses + ``to_q()``-selects the right rows
+  (equivalent to the flat oracle where one exists);
+- two widgets over the SAME relation compose as independent EXISTS, not a single
+  merged relation node;
+- prefill reads those AND elements back and re-renders the widget populated.
+"""
+
+import json
+from datetime import date, datetime, timezone
+
+import pytest
+
+from common.components.filters import FilterBar, PurchaseFilterBar
+from games.filters import GameFilter, parse_game_filter, parse_purchase_filter
+from games.models import Device, Game, Platform, Purchase, Session
+
+
+def _dt(year=2024, month=6, day=1):
+    return datetime(year, month, day, 12, 0, tzinfo=timezone.utc)
+
+
+def _game_ids(filter_json: str) -> set[int]:
+    parsed = parse_game_filter(filter_json)
+    assert parsed is not None
+    return set(
+        Game.objects.filter(parsed.to_q()).distinct().values_list("id", flat=True)
+    )
+
+
+def _set_criterion(value: str, label: str) -> dict:
+    return {
+        "value": [{"id": value, "label": label}],
+        "excludes": [],
+        "modifier": "INCLUDES",
+    }
+
+
+# ── round-trip: the emitted JSON selects the right games ─────────────────────
+
+
+@pytest.fixture
+def device_world(db):
+    pc = Platform.objects.create(name="PC")
+    deck = Device.objects.create(name="SteamDeck", type=Device.HANDHELD)
+    desktop = Device.objects.create(name="Desktop", type=Device.PC)
+    on_deck = Game.objects.create(name="OnDeck", platform=pc)
+    on_desktop = Game.objects.create(name="OnDesktop", platform=pc)
+    Game.objects.create(name="NoSessions", platform=pc)
+    Session.objects.create(game=on_deck, timestamp_start=_dt(), device=deck)
+    Session.objects.create(game=on_desktop, timestamp_start=_dt(), device=desktop)
+    return {"deck": deck, "on_deck": on_deck.id, "on_desktop": on_desktop.id}
+
+
+def test_device_widget_json_selects_games(device_world):
+    """Repointed device widget emits AND→session_filter→device."""
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "session_filter": {
+                        "device": _set_criterion(
+                            str(device_world["deck"].id), "SteamDeck"
+                        )
+                    }
+                }
+            ]
+        }
+    )
+    assert _game_ids(filter_json) == {device_world["on_deck"]}
+
+
+@pytest.fixture
+def purchase_world(db):
+    pc = Platform.objects.create(name="PC")
+    game_buyer = Game.objects.create(name="GameBuyer", platform=pc)
+    dlc_buyer = Game.objects.create(name="DlcBuyer", platform=pc)
+    Game.objects.create(name="NoPurchase", platform=pc)
+
+    p1 = Purchase.objects.create(
+        date_purchased=date(2024, 1, 1), type=Purchase.GAME, converted_price=10.0
+    )
+    p1.games.set([game_buyer])
+    p2 = Purchase.objects.create(
+        date_purchased=date(2024, 1, 1),
+        type=Purchase.DLC,
+        related_game=dlc_buyer,
+        converted_price=50.0,
+    )
+    p2.games.set([dlc_buyer])
+    return {"game_buyer": game_buyer.id, "dlc_buyer": dlc_buyer.id}
+
+
+def test_purchase_type_widget_json_selects_games(purchase_world):
+    filter_json = json.dumps(
+        {"AND": [{"purchase_filter": {"type": _set_criterion("game", "Game")}}]}
+    )
+    assert _game_ids(filter_json) == {purchase_world["game_buyer"]}
+
+
+def test_purchase_price_any_widget_json_selects_games(purchase_world):
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "purchase_filter": {
+                        "converted_price": {
+                            "value": 20,
+                            "modifier": "GREATER_THAN",
+                        }
+                    }
+                }
+            ]
+        }
+    )
+    assert _game_ids(filter_json) == {purchase_world["dlc_buyer"]}  # 50 > 20
+
+
+def test_playevent_note_widget_json_selects_games(db):
+    from games.models import PlayEvent
+
+    pc = Platform.objects.create(name="PC")
+    finished = Game.objects.create(name="Finished", platform=pc)
+    started = Game.objects.create(name="Started", platform=pc)
+    PlayEvent.objects.create(game=finished, note="Completed the game")
+    PlayEvent.objects.create(game=started, note="Just started")
+
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "playevent_filter": {
+                        "note": {"value": "Completed", "modifier": "INCLUDES"}
+                    }
+                }
+            ]
+        }
+    )
+    assert _game_ids(filter_json) == {finished.id}
+
+
+def test_game_finished_widget_json_selects_games(db):
+    from games.models import PlayEvent
+
+    pc = Platform.objects.create(name="PC")
+    in_range = Game.objects.create(name="InRange", platform=pc)
+    out_range = Game.objects.create(name="OutRange", platform=pc)
+    PlayEvent.objects.create(game=in_range, ended=date(2024, 6, 15))
+    PlayEvent.objects.create(game=out_range, ended=date(2023, 1, 1))
+
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "playevent_filter": {
+                        "ended": {
+                            "value": "2024-01-01",
+                            "value2": "2024-12-31",
+                            "modifier": "BETWEEN",
+                        }
+                    }
+                }
+            ]
+        }
+    )
+    assert _game_ids(filter_json) == {in_range.id}
+
+
+# ── relation-bool: ANY (True) vs NONE (False) ────────────────────────────────
+
+
+@pytest.fixture
+def emulated_world(db):
+    pc = Platform.objects.create(name="PC")
+    emulated = Game.objects.create(name="Emulated", platform=pc)
+    native = Game.objects.create(name="Native", platform=pc)
+    no_sessions = Game.objects.create(name="NoSessions", platform=pc)
+    Session.objects.create(game=emulated, timestamp_start=_dt(), emulated=True)
+    Session.objects.create(game=native, timestamp_start=_dt(), emulated=False)
+    return {
+        "emulated": emulated.id,
+        "native": native.id,
+        "no_sessions": no_sessions.id,
+    }
+
+
+def _relation_bool_json(relation_field: str, child: dict, *, value: bool) -> str:
+    relation: dict = dict(child)
+    if not value:
+        relation = {"match": "NONE", **child}
+    return json.dumps({"AND": [{relation_field: relation}]})
+
+
+def test_session_emulated_true_matches_any(emulated_world):
+    filter_json = _relation_bool_json(
+        "session_filter",
+        {"emulated": {"value": True, "modifier": "EQUALS"}},
+        value=True,
+    )
+    assert _game_ids(filter_json) == {emulated_world["emulated"]}
+
+
+def test_session_emulated_false_matches_none(emulated_world):
+    """False → NONE: games with no emulated session, including zero-session games.
+
+    Matches the flat ``session_emulated=False`` oracle."""
+    filter_json = _relation_bool_json(
+        "session_filter",
+        {"emulated": {"value": True, "modifier": "EQUALS"}},
+        value=False,
+    )
+    from common.criteria import BoolCriterion
+
+    flat = GameFilter(session_emulated=BoolCriterion(value=False))
+    flat_ids = set(
+        Game.objects.filter(flat.to_q()).distinct().values_list("id", flat=True)
+    )
+    assert _game_ids(filter_json) == flat_ids
+    assert _game_ids(filter_json) == {
+        emulated_world["native"],
+        emulated_world["no_sessions"],
+    }
+
+
+def test_purchase_refunded_false_matches_none(db):
+    pc = Platform.objects.create(name="PC")
+    refunded = Game.objects.create(name="Refunded", platform=pc)
+    kept = Game.objects.create(name="Kept", platform=pc)
+    none = Game.objects.create(name="NoPurchase", platform=pc)
+    p1 = Purchase.objects.create(
+        date_purchased=date(2024, 1, 1), date_refunded=date(2024, 2, 1)
+    )
+    p1.games.set([refunded])
+    p2 = Purchase.objects.create(date_purchased=date(2024, 1, 1))
+    p2.games.set([kept])
+
+    filter_json = _relation_bool_json(
+        "purchase_filter",
+        {"is_refunded": {"value": True, "modifier": "EQUALS"}},
+        value=False,
+    )
+    assert _game_ids(filter_json) == {kept.id, none.id}
+
+
+def test_purchase_infinite_true_matches_any(db):
+    pc = Platform.objects.create(name="PC")
+    infinite = Game.objects.create(name="Infinite", platform=pc)
+    finite = Game.objects.create(name="Finite", platform=pc)
+    p1 = Purchase.objects.create(date_purchased=date(2024, 1, 1), infinite=True)
+    p1.games.set([infinite])
+    p2 = Purchase.objects.create(date_purchased=date(2024, 1, 1), infinite=False)
+    p2.games.set([finite])
+
+    filter_json = _relation_bool_json(
+        "purchase_filter",
+        {"infinite": {"value": True, "modifier": "EQUALS"}},
+        value=True,
+    )
+    assert _game_ids(filter_json) == {infinite.id}
+
+
+# ── two widgets over one relation = independent EXISTS ────────────────────────
+
+
+@pytest.fixture
+def two_purchase_world(db):
+    """A game whose two qualifying purchases are *distinct* rows: a type=game
+    purchase (digital ownership) and a separate ownership=physical purchase
+    (dlc type). Only independent EXISTS matches it; a merged single-node filter
+    (one purchase must be BOTH) does not."""
+    pc = Platform.objects.create(name="PC")
+    split = Game.objects.create(name="Split", platform=pc)
+    combined = Game.objects.create(name="Combined", platform=pc)
+
+    game_digital = Purchase.objects.create(
+        date_purchased=date(2024, 1, 1),
+        type=Purchase.GAME,
+        ownership_type=Purchase.DIGITAL,
+    )
+    game_digital.games.set([split])
+    dlc_physical = Purchase.objects.create(
+        date_purchased=date(2024, 1, 1),
+        type=Purchase.DLC,
+        related_game=split,
+        ownership_type=Purchase.PHYSICAL,
+    )
+    dlc_physical.games.set([split])
+
+    # combined: a single purchase that is BOTH type=game AND ownership=physical.
+    both = Purchase.objects.create(
+        date_purchased=date(2024, 1, 1),
+        type=Purchase.GAME,
+        ownership_type=Purchase.PHYSICAL,
+    )
+    both.games.set([combined])
+    return {"split": split.id, "combined": combined.id}
+
+
+def test_two_widgets_same_relation_are_independent_exists(two_purchase_world):
+    """purchase_type=game AND purchase_ownership=physical as two AND elements:
+    independent EXISTS, so a game with a type=game purchase AND a SEPARATE
+    physical-ownership purchase matches."""
+    independent = json.dumps(
+        {
+            "AND": [
+                {"purchase_filter": {"type": _set_criterion("game", "Game")}},
+                {
+                    "purchase_filter": {
+                        "ownership_type": _set_criterion("ph", "Physical")
+                    }
+                },
+            ]
+        }
+    )
+    assert _game_ids(independent) == {
+        two_purchase_world["split"],
+        two_purchase_world["combined"],
+    }
+
+
+def test_merged_single_node_requires_one_matching_row(two_purchase_world):
+    """Contrast: the WRONG single merged relation node requires ONE purchase to
+    match BOTH type=game and ownership=physical, so the split game is excluded."""
+    merged = json.dumps(
+        {
+            "AND": [
+                {
+                    "purchase_filter": {
+                        "type": _set_criterion("game", "Game"),
+                        "ownership_type": _set_criterion("ph", "Physical"),
+                    }
+                }
+            ]
+        }
+    )
+    assert _game_ids(merged) == {two_purchase_world["combined"]}
+
+
+# ── purchase bar: finished → game_filter → playevent_filter → ended ──────────
+
+
+def test_purchase_finished_widget_json_selects_purchases(db):
+    from games.models import PlayEvent
+
+    pc = Platform.objects.create(name="PC")
+    finished_game = Game.objects.create(name="Finished", platform=pc)
+    other_game = Game.objects.create(name="Other", platform=pc)
+    PlayEvent.objects.create(game=finished_game, ended=date(2024, 6, 15))
+
+    bought_finished = Purchase.objects.create(date_purchased=date(2024, 1, 1))
+    bought_finished.games.set([finished_game])
+    bought_other = Purchase.objects.create(date_purchased=date(2024, 1, 1))
+    bought_other.games.set([other_game])
+
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "game_filter": {
+                        "playevent_filter": {
+                            "ended": {
+                                "value": "2024-01-01",
+                                "value2": "2024-12-31",
+                                "modifier": "BETWEEN",
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    )
+    parsed = parse_purchase_filter(filter_json)
+    assert parsed is not None
+    purchase_ids = set(
+        Purchase.objects.filter(parsed.to_q()).distinct().values_list("id", flat=True)
+    )
+    assert purchase_ids == {bought_finished.id}
+
+
+# ── prefill: the bar reads the AND elements back and repopulates widgets ──────
+
+
+def test_game_bar_prefills_device_from_and(db):
+    deck = Device.objects.create(name="SteamDeck", type=Device.HANDHELD)
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "session_filter": {
+                        "device": _set_criterion(str(deck.id), "SteamDeck")
+                    }
+                }
+            ]
+        }
+    )
+    html = str(FilterBar(filter_json))
+    # the included pill renders the device label
+    assert "SteamDeck" in html
+
+
+def test_game_bar_prefills_purchase_type_from_and(db):
+    filter_json = json.dumps(
+        {"AND": [{"purchase_filter": {"type": _set_criterion("game", "Game")}}]}
+    )
+    html = str(FilterBar(filter_json))
+    # the included value pill carries the selected enum value
+    assert 'data-value="game"' in html
+
+
+def test_game_bar_prefills_session_emulated_false_radio(db):
+    """A relation-bool NONE element prefills the 'False' radio as checked."""
+    filter_json = _relation_bool_json(
+        "session_filter",
+        {"emulated": {"value": True, "modifier": "EQUALS"}},
+        value=False,
+    )
+    html = str(FilterBar(filter_json))
+    # locate the emulated widget's radio group and confirm a checked False radio
+    assert 'value="false"' in html
+    # the emulated radio group uses name filter-session-emulated
+    assert "filter-session-emulated" in html
+
+
+def test_purchase_bar_prefills_finished_from_and(db):
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "game_filter": {
+                        "playevent_filter": {
+                            "ended": {
+                                "value": "2024-01-01",
+                                "value2": "2024-12-31",
+                                "modifier": "BETWEEN",
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    )
+    html = str(PurchaseFilterBar(filter_json))
+    assert "2024-01-01" in html
+    assert "2024-12-31" in html

--- a/tests/test_filter_paths.py
+++ b/tests/test_filter_paths.py
@@ -26,8 +26,11 @@ from common.components.filters import (
 from common.criteria import (
     _CRITERION_KINDS,
     _CRITERION_TYPES,
+    BoolCriterion,
     OperatorFilter,
     _Criterion,
+    _criterion_class_for,
+    _filter_class_for,
     criterion_kind,
     resolve_path_kind,
 )
@@ -46,13 +49,16 @@ class WidgetDescriptor(NamedTuple):
 
     path: list[str]
     kind: str
+    compose: str | None
+    relation_child: dict | None
 
 
 class _FilterWidgetCollector(HTMLParser):
-    """Collect ``(path, kind)`` from every ``[data-filter-widget]`` start tag.
+    """Collect every ``[data-filter-widget]`` start tag's contract attributes.
 
-    Pairs ``data-path``/``data-kind`` within a single element by reading the
-    start tag's own attribute list — no regex pairing across the document.
+    Pairs ``data-path``/``data-kind``/``data-compose``/``data-relation-child``
+    within a single element by reading the start tag's own attribute list — no
+    regex pairing across the document.
     """
 
     def __init__(self) -> None:
@@ -67,7 +73,15 @@ class _FilterWidgetCollector(HTMLParser):
         kind = attributes.get("data-kind")
         assert raw_path is not None, f"<{tag}> has data-filter-widget but no data-path"
         assert kind is not None, f"<{tag}> has data-filter-widget but no data-kind"
-        self.widgets.append(WidgetDescriptor(json.loads(raw_path), kind))
+        raw_child = attributes.get("data-relation-child")
+        self.widgets.append(
+            WidgetDescriptor(
+                json.loads(raw_path),
+                kind,
+                attributes.get("data-compose"),
+                json.loads(raw_child) if raw_child else None,
+            )
+        )
 
 
 def _collect_widgets(html: str) -> list[WidgetDescriptor]:
@@ -100,9 +114,44 @@ _BAR_CASES = [
 ]
 
 
+def _resolve_subfilter(
+    filter_cls: type[OperatorFilter], path: list[str]
+) -> type[OperatorFilter]:
+    """Walk a path of sub-filter segments, returning the sub-filter class it ends at."""
+    current = filter_cls
+    for segment in path:
+        sub_filter_cls = _filter_class_for(current, segment)
+        assert sub_filter_cls is not None, (
+            f"{current.__name__} has no sub-filter field {segment!r} "
+            f"(resolving relation path {path})"
+        )
+        current = sub_filter_cls
+    return current
+
+
+def _assert_relation_bool_resolves(
+    filter_cls: type[OperatorFilter], widget: WidgetDescriptor
+) -> None:
+    """A relation-bool widget's path must resolve to a sub-filter, and every
+    fixed child key must be a ``bool`` criterion on that sub-filter."""
+    sub_filter_cls = _resolve_subfilter(filter_cls, widget.path)
+    assert widget.relation_child, (
+        f"relation-bool widget {widget.path} has no data-relation-child"
+    )
+    for child_key in widget.relation_child:
+        criterion_cls = _criterion_class_for(sub_filter_cls, child_key)
+        assert criterion_cls is BoolCriterion, (
+            f"relation-bool widget {widget.path} child {child_key!r} resolves to "
+            f"{criterion_cls} on {sub_filter_cls.__name__}, expected BoolCriterion"
+        )
+
+
 @pytest.mark.parametrize("case", _BAR_CASES, ids=lambda case: case.name)
 def test_every_widget_path_resolves_to_its_kind(case: _BarCase) -> None:
-    """Every rendered widget's path resolves to a criterion whose kind matches."""
+    """Every rendered widget's path resolves to a criterion whose kind matches.
+
+    Relation-bool widgets resolve their path to a *sub-filter* (not a leaf
+    criterion) and their fixed child key(s) to a ``bool`` criterion on it."""
     html = str(case.bar_factory(""))
     widgets = _collect_widgets(html)
     assert len(widgets) == case.widget_count, (
@@ -110,6 +159,9 @@ def test_every_widget_path_resolves_to_its_kind(case: _BarCase) -> None:
         f"expected {case.widget_count} (a forgotten path= silently drops a widget)"
     )
     for widget in widgets:
+        if widget.kind == "relation-bool":
+            _assert_relation_bool_resolves(case.filter_cls, widget)
+            continue
         resolved = resolve_path_kind(case.filter_cls, widget.path)
         assert resolved == widget.kind, (
             f"{case.name} widget {widget.path} declares kind {widget.kind!r} "
@@ -119,12 +171,19 @@ def test_every_widget_path_resolves_to_its_kind(case: _BarCase) -> None:
 
 @pytest.mark.parametrize("case", _BAR_CASES, ids=lambda case: case.name)
 def test_no_widget_path_is_a_prefix_of_another(case: _BarCase) -> None:
-    """No declared path may be a strict prefix of another within a bar.
+    """No top-level (setPath) widget path may be a strict prefix of another.
 
-    A leaf/branch collision (one widget targeting a sub-filter another widget
-    steps through) would make the contract ambiguous; forbid it up front."""
+    A leaf/branch collision among top-level widgets (one targeting a sub-filter
+    another steps through) would make the ``setPath`` write ambiguous; forbid it.
+    Cross-entity widgets (``data-compose="and"`` / relation-bool) are excluded:
+    they each build their own AND element (independent EXISTS), so several
+    sharing a relation prefix is intended, not a collision."""
     html = str(case.bar_factory(""))
-    paths = [widget.path for widget in _collect_widgets(html)]
+    paths = [
+        widget.path
+        for widget in _collect_widgets(html)
+        if widget.compose is None and widget.kind != "relation-bool"
+    ]
     for outer in paths:
         for inner in paths:
             if outer is inner:

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -273,15 +273,25 @@ function readRelationBoolWidget(
     'input[type="radio"]:checked',
   );
   if (!checked) return null;
-  let child: Record<string, unknown> = {};
+  // The child criterion is mandatory: an empty relation sub-filter would change
+  // to_q semantics to "has ANY related row" (or, for the False radio, "has NO
+  // related row"), not the intended "has a row matching the child". Bail rather
+  // than emit a meaning-altering empty relation.
   const childRaw = widget.getAttribute("data-relation-child");
-  if (childRaw) {
-    try {
-      child = JSON.parse(childRaw);
-    } catch {
-      console.warn("filter-bar: malformed data-relation-child", childRaw);
-      return null;
-    }
+  if (!childRaw) {
+    console.warn("filter-bar: relation-bool widget missing data-relation-child", widget);
+    return null;
+  }
+  let child: Record<string, unknown>;
+  try {
+    child = JSON.parse(childRaw);
+  } catch {
+    console.warn("filter-bar: malformed data-relation-child", childRaw);
+    return null;
+  }
+  if (!child || typeof child !== "object" || Object.keys(child).length === 0) {
+    console.warn("filter-bar: empty data-relation-child", childRaw);
+    return null;
   }
   const relationField = path[0];
   // true → match ANY (omit `match`); false → match NONE.

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -101,6 +101,35 @@ function setPath(
   node[path[path.length - 1]] = leaf;
 }
 
+// Fold a key chain into a fresh nested object terminating in `leaf` —
+// nest(["session_filter", "device"], leaf) → {session_filter: {device: leaf}}.
+// Unlike setPath this never mutates a shared object: each cross-entity widget
+// builds its own standalone sub-filter element so several widgets targeting the
+// same relation compose as independent EXISTS (their own AND elements) rather
+// than merging into one shared relation node.
+function nest(path: string[], leaf: unknown): Record<string, unknown> {
+  const root: Record<string, unknown> = {};
+  let node = root;
+  for (let index = 0; index < path.length - 1; index++) {
+    const child: Record<string, unknown> = {};
+    node[path[index]] = child;
+    node = child;
+  }
+  node[path[path.length - 1]] = leaf;
+  return root;
+}
+
+// Append a sub-filter element to the parent filter's n-ary AND list, creating
+// the list on first use. Only ever called with a real selection, so an empty AND
+// element (which would change query semantics) is never appended.
+function appendAnd(
+  filter: Record<string, unknown>,
+  element: Record<string, unknown>,
+): void {
+  if (!Array.isArray(filter.AND)) filter.AND = [];
+  (filter.AND as unknown[]).push(element);
+}
+
 // Per-kind readers: each is scoped to a single widget element and returns a
 // criterion object, or null to omit the field entirely. The value/modifier
 // logic is a verbatim port of the former hardcoded field loops; only the
@@ -210,11 +239,55 @@ function buildFilterJSON(form: HTMLElement): Record<string, unknown> {
   form.querySelectorAll<HTMLElement>("[data-filter-widget]").forEach((widget) => {
     const path = parseJSONAttr<string>(widget, "data-path");
     if (path.length === 0) return;
-    const result = readWidget(widget, widget.getAttribute("data-kind"));
-    if (result !== null) setPath(filter, path, result);
+    const kind = widget.getAttribute("data-kind");
+
+    // Relation-bool: a boolean radio toggling a whole cross-entity sub-filter
+    // (ANY vs NONE) over a fixed child criterion. data-path is the relation chain
+    // (single segment, no leaf); data-relation-child is the fixed child.
+    if (kind === "relation-bool") {
+      const element = readRelationBoolWidget(widget, path);
+      if (element !== null) appendAnd(filter, element);
+      return;
+    }
+
+    const result = readWidget(widget, kind);
+    if (result === null) return;
+    // Cross-entity leaf (data-compose="and"): nest the leaf under its relation
+    // chain and append it as its own independent EXISTS element of AND, rather
+    // than merging it into a shared top-level relation node.
+    if (widget.getAttribute("data-compose") === "and") {
+      appendAnd(filter, nest(path, result));
+    } else {
+      setPath(filter, path, result);
+    }
   });
 
   return filter;
+}
+
+function readRelationBoolWidget(
+  widget: HTMLElement,
+  path: string[],
+): Record<string, unknown> | null {
+  const checked = widget.querySelector<HTMLInputElement>(
+    'input[type="radio"]:checked',
+  );
+  if (!checked) return null;
+  let child: Record<string, unknown> = {};
+  const childRaw = widget.getAttribute("data-relation-child");
+  if (childRaw) {
+    try {
+      child = JSON.parse(childRaw);
+    } catch {
+      console.warn("filter-bar: malformed data-relation-child", childRaw);
+      return null;
+    }
+  }
+  const relationField = path[0];
+  // true → match ANY (omit `match`); false → match NONE.
+  const relationNode: Record<string, unknown> =
+    checked.value === "false" ? { match: "NONE", ...child } : { ...child };
+  return { [relationField]: relationNode };
 }
 
 function injectSearchInput(form: HTMLElement): void {


### PR DESCRIPTION
## What & why

Nine `GameFilter` widgets and one `PurchaseFilter` widget were FLAT cross-entity convenience fields, each emitting a top-level key (e.g. `device`, `purchase_type`). This slice repoints them to the canonical **nested cross-entity sub-filter** form.

Because several widgets target the **same relation** (e.g. `purchase_type`, `purchase_ownership_type`, `purchase_price_any` all hit `purchase_filter`), they must compose as **independent EXISTS** — each becomes its own element of the parent's n-ary `AND` list, NOT merged into one shared relation node. Merging would mean "one related row matching all criteria", a strictly smaller (different) result set.

The flat Python filter fields **stay** for now (deleted in Phase 3); the bar just stops emitting them.

## AND-composition (independent EXISTS)

A cross-entity leaf widget carries `data-compose="and"` and a multi-segment `data-path` (the relation chain to the leaf). The serializer folds the path into a fresh nested object and **appends** it to `filter.AND`:

- `["session_filter","device"]` + leaf → `{"AND":[{"session_filter":{"device": leaf}}]}`
- Two widgets over `purchase_filter` → two separate `{"purchase_filter":{…}}` AND elements → independent EXISTS (a game with a type-X purchase **and a separate** ownership-Y purchase matches; the wrong single-node merge would require one purchase to be both).

## relation-bool → match mapping

The three bool widgets become `data-kind="relation-bool"`: `data-path` is the relation chain (no leaf) and `data-relation-child` is the fixed child criterion (e.g. `{"emulated":{"value":true,"modifier":"EQUALS"}}`). The radio toggles the quantifier:

- **True** → match ANY (omit `match`) — game has a related row with the flag.
- **False** → `match:"NONE"` — game has no such related row (includes zero-row parents).

This exactly reproduces the old flat bool semantics (guarded by the kept `test_nested_matches_flat_session_emulated` / `test_nested_matches_flat_purchase_refunded`).

## Prefill from AND

The bar now reads cross-entity criteria back out of `existing["AND"]`:

- `_cross_entity_criterion(existing, path)` scans AND for the element whose nested chain contains the leaf, feeding the existing set/number/range/string readers (refactored to `*_from_field`/`_from_raw` cores).
- `_cross_entity_bool(existing, relation_field, child_key)` returns True (ANY) / False (NONE) / None (absent).

Each widget's prefill is matched to its serialized `data-path` — single source of truth.

## Validation & tests

- `tests/test_filter_paths.py`: non-bool paths validate via existing `resolve_path_kind` (it already walks sub-filters); relation-bool gets dedicated validation (path → sub-filter, child key → bool criterion). The no-prefix rule now applies only to top-level setPath widgets (composed widgets intentionally share relation prefixes). Per-bar widget counts unchanged (23/8/14/1/2/4).
- `tests/test_filter_cross_entity.py` (new): round-trip `to_q()` selection for every repointed widget; two-on-one-relation independent-EXISTS vs the wrong merged single node; prefill-from-AND re-render.
- `e2e/test_cross_entity_filter_e2e.py` (new): fill `purchase_type` (set) and `session_emulated`=No on the games bar in real Chromium, assert the `AND` shape, reload the URL, assert the widget prefills.
- `e2e/test_boolean_filter_e2e.py` and `tests/test_filter_bars.py` updated for the new nested form.

## Result-set equivalence

All repointed widgets produce result sets identical to the old flat fields **for every modifier the widget can actually emit**. One theoretical divergence: a date `IS_NULL`/`NOT_NULL` on `finished` would differ (the old flat `playevents__ended__isnull` reverse-join also matches zero-playevent games via the LEFT JOIN; the nested form does not) — but the DateRangePicker only ever emits BETWEEN/GREATER_THAN/LESS_THAN, so this is unreachable in practice.

## Verification

- `pytest tests/ --ignore=e2e` — 764 passed
- `mypy common/ games/` — clean; `ruff check` + format — clean; `make ts`/`ts-check` — clean
- new + related filter e2e — green. (12 pre-existing e2e failures on this environment are CSS/Tailwind-build related and reproduce identically on clean `origin/main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)