### PR TITLE
Delete retired flat cross-entity filter fields (#123 Phase 3)

### DIFF
--- a/games/filters.py
+++ b/games/filters.py
@@ -12,9 +12,8 @@ with AND/OR/NOT composition and typed criterion fields.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
 
-from django.db.models import Q, QuerySet
+from django.db.models import Q
 from django.urls import reverse
 from django.utils.http import urlencode
 
@@ -35,12 +34,6 @@ from common.criteria import (
     filter_to_json,
     relation_to_q,
 )
-
-# A queryset of object ids (from ``.values_list("id"/"pk", flat=True)``), reused
-# as the cross-entity ``matching_ids`` local in the ``to_q()`` methods. The model
-# varies per branch (Game / Session / Purchase / …), so only the int row type is
-# pinned.  # e.g. Session.objects.filter(...).values_list("id", flat=True)
-type MatchingIdQuerySet = QuerySet[Any, int]
 
 # ── FindFilter (sort / pagination) ─────────────────────────────────────────
 
@@ -92,24 +85,8 @@ class GameFilter(OperatorFilter):
     manual_playtime_hours: AggregateCriterion | None = None
     calculated_playtime_hours: AggregateCriterion | None = None
 
-    # Cross-entity: any session played on these devices / matching these flags
-    device: MultiCriterion | None = None  # game has session on any of these devices
-    session_emulated: BoolCriterion | None = None  # game has emulated session
-
-    # Cross-entity: matches against the game's purchases
-    purchase_refunded: BoolCriterion | None = None  # game has refunded purchase
-    purchase_infinite: BoolCriterion | None = None  # game has infinite purchase
+    # Cross-entity: sum of the game's purchase prices (converted)
     purchase_price_total: AggregateCriterion | None = None  # sum of converted prices
-    purchase_price_any: FloatCriterion | None = None  # any single purchase in range
-    purchase_type: ChoiceCriterion | None = None  # game has purchase of type
-    purchase_ownership_type: ChoiceCriterion | None = None  # by ownership
-
-    # Cross-entity: substring match against the game's playevent notes
-    playevent_note: StringCriterion | None = None
-
-    # Cross-entity: game has a playevent whose `ended` date is in range
-    # (i.e. the game was finished in that window). See PlayEvent.ended.
-    finished: DateCriterion | None = None
 
     # Free-text search (combines name + sort_name + platform name)
     search: StringCriterion | None = None
@@ -183,18 +160,6 @@ class GameFilter(OperatorFilter):
                 self.playevent_count, model=Game, reducer="count", accessor="playevents"
             )
 
-        if self.finished is not None:
-            from games.models import Game
-
-            # Games with a playevent whose `ended` date is in range. distinct()
-            # collapses the row-per-playevent fan-out of the reverse relation.
-            matching_ids: MatchingIdQuerySet = (
-                Game.objects.filter(self.finished.to_q("playevents__ended"))
-                .distinct()
-                .values_list("id", flat=True)
-            )
-            q &= Q(id__in=matching_ids)
-
         if self.manual_playtime_hours is not None:
             from games.models import Game
 
@@ -219,51 +184,6 @@ class GameFilter(OperatorFilter):
                 unit="duration_hours",
             )
 
-        if self.device is not None:
-            from games.models import Session
-
-            session_q = self.device.to_q("device_id")
-            matching_ids = Session.objects.filter(session_q).values_list(
-                "game_id", flat=True
-            )
-            q &= Q(id__in=matching_ids)
-
-        if self.session_emulated is not None:
-            from games.models import Session
-
-            emulated_ids = Session.objects.filter(
-                emulated=self.session_emulated.value
-            ).values_list("game_id", flat=True)
-            if self.session_emulated.value:
-                q &= Q(id__in=emulated_ids)
-            else:
-                emulated_true_ids = Session.objects.filter(emulated=True).values_list(
-                    "game_id", flat=True
-                )
-                q &= ~Q(id__in=emulated_true_ids)
-
-        if self.purchase_refunded is not None:
-            from games.models import Purchase
-
-            refunded_ids = Purchase.objects.filter(
-                date_refunded__isnull=False
-            ).values_list("games__id", flat=True)
-            if self.purchase_refunded.value:
-                q &= Q(id__in=refunded_ids)
-            else:
-                q &= ~Q(id__in=refunded_ids)
-
-        if self.purchase_infinite is not None:
-            from games.models import Purchase
-
-            infinite_ids = Purchase.objects.filter(infinite=True).values_list(
-                "games__id", flat=True
-            )
-            if self.purchase_infinite.value:
-                q &= Q(id__in=infinite_ids)
-            else:
-                q &= ~Q(id__in=infinite_ids)
-
         if self.purchase_price_total is not None:
             from games.models import Game
 
@@ -274,36 +194,6 @@ class GameFilter(OperatorFilter):
                 accessor="purchases",
                 source="converted_price",
             )
-
-        if self.purchase_price_any is not None:
-            from games.models import Purchase
-
-            price_q = self.purchase_price_any.to_q("converted_price")
-            matching_ids = Purchase.objects.filter(price_q).values_list(
-                "games__id", flat=True
-            )
-            q &= Q(id__in=matching_ids)
-
-        if self.purchase_type is not None:
-            from games.models import Purchase
-
-            type_q = self.purchase_type.to_q("type")
-            matching_ids = Purchase.objects.filter(type_q).values_list(
-                "games__id", flat=True
-            )
-            q &= Q(id__in=matching_ids)
-
-        if self.purchase_ownership_type is not None:
-            from games.models import Purchase
-
-            ownership_q = self.purchase_ownership_type.to_q("ownership_type")
-            matching_ids = Purchase.objects.filter(ownership_q).values_list(
-                "games__id", flat=True
-            )
-            q &= Q(id__in=matching_ids)
-
-        if self.playevent_note is not None:
-            q &= self._playevent_note_to_q(self.playevent_note)
 
         # ── free-text search (OR across multiple fields) ──
         if self.search is not None and self.search.value:
@@ -359,17 +249,6 @@ class GameFilter(OperatorFilter):
     def _playtime_to_q_for_field(c: IntCriterion, field: str) -> Q:
         """Convert an hours-based criterion to a DurationField Q object."""
         return duration_hours_to_q(c.value, c.value2, c.modifier, field)
-
-    @staticmethod
-    def _playevent_note_to_q(criterion: StringCriterion) -> Q:
-        """Match games by substring / regex / null against their playevents' notes."""
-        from games.models import PlayEvent
-
-        event_q = criterion.to_q("note")
-        matching_ids = PlayEvent.objects.filter(event_q).values_list(
-            "game_id", flat=True
-        )
-        return Q(id__in=matching_ids)
 
 
 # ── SessionFilter ──────────────────────────────────────────────────────────
@@ -504,8 +383,6 @@ class PurchaseFilter(OperatorFilter):
     games: ChoiceCriterion | None = None  # games (M2M IDs)
     date_purchased: DateCriterion | None = None
     date_refunded: DateCriterion | None = None
-    # Cross-entity: purchase of a game finished in range (PlayEvent.ended).
-    finished: DateCriterion | None = None
     is_refunded: BoolCriterion | None = None  # date_refunded IS NOT NULL
     price: FloatCriterion | None = None  # on price field
     converted_price: FloatCriterion | None = None
@@ -542,19 +419,6 @@ class PurchaseFilter(OperatorFilter):
             q &= self.date_purchased.to_q("date_purchased")
         if self.date_refunded is not None:
             q &= self.date_refunded.to_q("date_refunded")
-        if self.finished is not None:
-            from games.models import Game
-
-            # Match via a game-id subquery instead of traversing
-            # games__playevents__ended directly, so the playevents join stays out
-            # of the purchase query. (The games M2M join can still duplicate
-            # rows; callers apply .distinct(), as with the game_filter block.)
-            finished_game_ids: MatchingIdQuerySet = (
-                Game.objects.filter(self.finished.to_q("playevents__ended"))
-                .distinct()
-                .values_list("id", flat=True)
-            )
-            q &= Q(games__id__in=finished_game_ids)
         if self.is_refunded is not None:
             q &= Q(date_refunded__isnull=not self.is_refunded.value)
         if self.price is not None:

--- a/tests/test_filter_cross_entity.py
+++ b/tests/test_filter_cross_entity.py
@@ -108,6 +108,36 @@ def test_purchase_type_widget_json_selects_games(purchase_world):
     assert _game_ids(filter_json) == {purchase_world["game_buyer"]}
 
 
+def test_purchase_ownership_type_widget_json_selects_games(db):
+    """Repointed ownership_type widget emits AND→purchase_filter→ownership_type."""
+    pc = Platform.objects.create(name="PC")
+    physical = Game.objects.create(name="Physical", platform=pc)
+    digital = Game.objects.create(name="Digital", platform=pc)
+    Game.objects.create(name="NoPurchase", platform=pc)
+
+    physical_purchase = Purchase.objects.create(
+        date_purchased=date(2024, 1, 1), ownership_type=Purchase.PHYSICAL
+    )
+    physical_purchase.games.set([physical])
+    digital_purchase = Purchase.objects.create(
+        date_purchased=date(2024, 1, 1), ownership_type=Purchase.DIGITAL
+    )
+    digital_purchase.games.set([digital])
+
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "purchase_filter": {
+                        "ownership_type": _set_criterion("ph", "Physical")
+                    }
+                }
+            ]
+        }
+    )
+    assert _game_ids(filter_json) == {physical.id}
+
+
 def test_purchase_price_any_widget_json_selects_games(purchase_world):
     filter_json = json.dumps(
         {
@@ -170,6 +200,44 @@ def test_game_finished_widget_json_selects_games(db):
         }
     )
     assert _game_ids(filter_json) == {in_range.id}
+
+
+def test_game_finished_widget_json_min_only_and_max_only(db):
+    """When only one bound is set the widget emits GREATER_THAN (min-only) or
+    LESS_THAN (max-only) instead of BETWEEN; each selects by PlayEvent.ended."""
+    pc = Platform.objects.create(name="PC")
+    early = Game.objects.create(name="Early", platform=pc)
+    middle = Game.objects.create(name="Middle", platform=pc)
+    late = Game.objects.create(name="Late", platform=pc)
+    PlayEvent.objects.create(game=early, ended=date(2023, 1, 1))
+    PlayEvent.objects.create(game=middle, ended=date(2024, 6, 15))
+    PlayEvent.objects.create(game=late, ended=date(2025, 12, 31))
+
+    min_only = json.dumps(
+        {
+            "AND": [
+                {
+                    "playevent_filter": {
+                        "ended": {"value": "2024-01-01", "modifier": "GREATER_THAN"}
+                    }
+                }
+            ]
+        }
+    )
+    assert _game_ids(min_only) == {middle.id, late.id}
+
+    max_only = json.dumps(
+        {
+            "AND": [
+                {
+                    "playevent_filter": {
+                        "ended": {"value": "2024-12-31", "modifier": "LESS_THAN"}
+                    }
+                }
+            ]
+        }
+    )
+    assert _game_ids(max_only) == {early.id, middle.id}
 
 
 # ── relation-bool: ANY (True) vs NONE (False) ────────────────────────────────
@@ -254,6 +322,46 @@ def test_purchase_infinite_true_matches_any(db):
         value=True,
     )
     assert _game_ids(filter_json) == {infinite.id}
+
+
+def test_purchase_refunded_true_matches_any(db):
+    """True → ANY: games with at least one refunded purchase."""
+    pc = Platform.objects.create(name="PC")
+    refunded = Game.objects.create(name="Refunded", platform=pc)
+    kept = Game.objects.create(name="Kept", platform=pc)
+    Game.objects.create(name="NoPurchase", platform=pc)
+    p1 = Purchase.objects.create(
+        date_purchased=date(2024, 1, 1), date_refunded=date(2024, 2, 1)
+    )
+    p1.games.set([refunded])
+    p2 = Purchase.objects.create(date_purchased=date(2024, 1, 1))
+    p2.games.set([kept])
+
+    filter_json = _relation_bool_json(
+        "purchase_filter",
+        {"is_refunded": {"value": True, "modifier": "EQUALS"}},
+        value=True,
+    )
+    assert _game_ids(filter_json) == {refunded.id}
+
+
+def test_purchase_infinite_false_matches_none(db):
+    """False → NONE: games with no infinite purchase, including zero-purchase games."""
+    pc = Platform.objects.create(name="PC")
+    infinite = Game.objects.create(name="Infinite", platform=pc)
+    finite = Game.objects.create(name="Finite", platform=pc)
+    no_purchase = Game.objects.create(name="NoPurchase", platform=pc)
+    p1 = Purchase.objects.create(date_purchased=date(2024, 1, 1), infinite=True)
+    p1.games.set([infinite])
+    p2 = Purchase.objects.create(date_purchased=date(2024, 1, 1), infinite=False)
+    p2.games.set([finite])
+
+    filter_json = _relation_bool_json(
+        "purchase_filter",
+        {"infinite": {"value": True, "modifier": "EQUALS"}},
+        value=False,
+    )
+    assert _game_ids(filter_json) == {finite.id, no_purchase.id}
 
 
 # ── two widgets over one relation = independent EXISTS ────────────────────────

--- a/tests/test_filter_cross_entity.py
+++ b/tests/test_filter_cross_entity.py
@@ -19,21 +19,7 @@ from datetime import date, datetime, timezone
 import pytest
 
 from common.components.filters import FilterBar, PurchaseFilterBar
-from common.criteria import (
-    BoolCriterion,
-    ChoiceCriterion,
-    DateCriterion,
-    FloatCriterion,
-    Modifier,
-    MultiCriterion,
-    RelationMatch,
-    StringCriterion,
-)
 from games.filters import (
-    GameFilter,
-    PlayEventFilter,
-    PurchaseFilter,
-    SessionFilter,
     parse_game_filter,
     parse_purchase_filter,
 )
@@ -141,8 +127,6 @@ def test_purchase_price_any_widget_json_selects_games(purchase_world):
 
 
 def test_playevent_note_widget_json_selects_games(db):
-    from games.models import PlayEvent
-
     pc = Platform.objects.create(name="PC")
     finished = Game.objects.create(name="Finished", platform=pc)
     started = Game.objects.create(name="Started", platform=pc)
@@ -164,8 +148,6 @@ def test_playevent_note_widget_json_selects_games(db):
 
 
 def test_game_finished_widget_json_selects_games(db):
-    from games.models import PlayEvent
-
     pc = Platform.objects.create(name="PC")
     in_range = Game.objects.create(name="InRange", platform=pc)
     out_range = Game.objects.create(name="OutRange", platform=pc)
@@ -225,21 +207,12 @@ def test_session_emulated_true_matches_any(emulated_world):
 
 
 def test_session_emulated_false_matches_none(emulated_world):
-    """False → NONE: games with no emulated session, including zero-session games.
-
-    Matches the flat ``session_emulated=False`` oracle."""
+    """False → NONE: games with no emulated session, including zero-session games."""
     filter_json = _relation_bool_json(
         "session_filter",
         {"emulated": {"value": True, "modifier": "EQUALS"}},
         value=False,
     )
-    from common.criteria import BoolCriterion
-
-    flat = GameFilter(session_emulated=BoolCriterion(value=False))
-    flat_ids = set(
-        Game.objects.filter(flat.to_q()).distinct().values_list("id", flat=True)
-    )
-    assert _game_ids(filter_json) == flat_ids
     assert _game_ids(filter_json) == {
         emulated_world["native"],
         emulated_world["no_sessions"],
@@ -364,7 +337,6 @@ def test_merged_single_node_requires_one_matching_row(two_purchase_world):
 
 
 def test_purchase_finished_widget_json_selects_purchases(db):
-    from games.models import PlayEvent
 
     pc = Platform.objects.create(name="PC")
     finished_game = Game.objects.create(name="Finished", platform=pc)
@@ -466,243 +438,6 @@ def test_purchase_bar_prefills_finished_from_and(db):
     html = str(PurchaseFilterBar(filter_json))
     assert "2024-01-01" in html
     assert "2024-12-31" in html
-
-
-# ── parametrized parity: each repointed widget's NESTED form selects the same
-#    rows as its still-live FLAT oracle field (#123 Phase 2d permanent guard) ──
-#
-# The 10 repointed widgets are now the canonical path; the flat GameFilter /
-# PurchaseFilter convenience fields remain as oracles. Each case builds BOTH the
-# flat and the nested filter dataclass over one shared world and asserts they
-# select the identical id set. A mismatch is a real bug (the repoint changed
-# behaviour), not a test to weaken.
-
-
-@pytest.fixture
-def parity_world(db):
-    """One world exercising every repointed widget's dimension at once.
-
-    Each repointed criterion matches a strict, non-empty subset so an equal
-    flat/nested result is a meaningful (non-vacuous) check."""
-    pc = Platform.objects.create(name="PC")
-    deck = Device.objects.create(name="SteamDeck", type=Device.HANDHELD)
-    desktop = Device.objects.create(name="Desktop", type=Device.PC)
-
-    # session: device + emulated dimension
-    deck_game = Game.objects.create(name="DeckGame", platform=pc)
-    Session.objects.create(
-        game=deck_game, timestamp_start=_dt(), device=deck, emulated=False
-    )
-    emulated_game = Game.objects.create(name="EmulatedGame", platform=pc)
-    Session.objects.create(
-        game=emulated_game, timestamp_start=_dt(), device=desktop, emulated=True
-    )
-
-    # purchase: type / ownership / price / refunded / infinite dimension
-    game_buyer = Game.objects.create(name="GameBuyer", platform=pc)
-    cheap = Purchase.objects.create(
-        date_purchased=date(2024, 1, 1),
-        type=Purchase.GAME,
-        ownership_type=Purchase.DIGITAL,
-        converted_price=10.0,
-        infinite=False,
-    )
-    cheap.games.set([game_buyer])
-
-    dlc_buyer = Game.objects.create(name="DlcBuyer", platform=pc)
-    pricey = Purchase.objects.create(
-        date_purchased=date(2024, 1, 1),
-        type=Purchase.DLC,
-        related_game=dlc_buyer,
-        ownership_type=Purchase.PHYSICAL,
-        converted_price=50.0,
-        date_refunded=date(2024, 2, 1),
-        infinite=True,
-    )
-    pricey.games.set([dlc_buyer])
-
-    # playevent: note + ended dimension
-    finished_game = Game.objects.create(name="FinishedGame", platform=pc)
-    PlayEvent.objects.create(
-        game=finished_game, ended=date(2024, 6, 15), note="Completed the run"
-    )
-    started_game = Game.objects.create(name="StartedGame", platform=pc)
-    PlayEvent.objects.create(
-        game=started_game, ended=date(2023, 1, 1), note="Just started"
-    )
-
-    # a bare game touching no relation (matters for the NONE/False branches)
-    Game.objects.create(name="Bare", platform=pc)
-
-    # purchase-bar finished: a purchase of a finished game vs one of an unfinished
-    bought_finished = Purchase.objects.create(date_purchased=date(2024, 1, 1))
-    bought_finished.games.set([finished_game])
-    bought_other = Purchase.objects.create(date_purchased=date(2024, 1, 1))
-    bought_other.games.set([started_game])
-
-    return {"deck": deck.id}
-
-
-def _ids(model, filt) -> set[int]:
-    return set(
-        model.objects.filter(filt.to_q()).distinct().values_list("id", flat=True)
-    )
-
-
-def _between_2024() -> DateCriterion:
-    return DateCriterion(
-        value="2024-01-01", value2="2024-12-31", modifier=Modifier.BETWEEN
-    )
-
-
-# Each case: (model, flat-filter builder, nested-filter builder). Builders take
-# the world dict (only the device case needs an id from it).
-PARITY_CASES = {
-    "device_set": (
-        Game,
-        lambda w: GameFilter(
-            device=MultiCriterion(value=[w["deck"]], modifier=Modifier.INCLUDES)
-        ),
-        lambda w: GameFilter(
-            session_filter=SessionFilter(
-                device=MultiCriterion(value=[w["deck"]], modifier=Modifier.INCLUDES)
-            )
-        ),
-    ),
-    "purchase_type_set": (
-        Game,
-        lambda w: GameFilter(
-            purchase_type=ChoiceCriterion(value=["game"], modifier=Modifier.INCLUDES)
-        ),
-        lambda w: GameFilter(
-            purchase_filter=PurchaseFilter(
-                type=ChoiceCriterion(value=["game"], modifier=Modifier.INCLUDES)
-            )
-        ),
-    ),
-    "purchase_ownership_set": (
-        Game,
-        lambda w: GameFilter(
-            purchase_ownership_type=ChoiceCriterion(
-                value=["ph"], modifier=Modifier.INCLUDES
-            )
-        ),
-        lambda w: GameFilter(
-            purchase_filter=PurchaseFilter(
-                ownership_type=ChoiceCriterion(value=["ph"], modifier=Modifier.INCLUDES)
-            )
-        ),
-    ),
-    "purchase_price_any_number": (
-        Game,
-        lambda w: GameFilter(
-            purchase_price_any=FloatCriterion(
-                value=20.0, modifier=Modifier.GREATER_THAN
-            )
-        ),
-        lambda w: GameFilter(
-            purchase_filter=PurchaseFilter(
-                converted_price=FloatCriterion(
-                    value=20.0, modifier=Modifier.GREATER_THAN
-                )
-            )
-        ),
-    ),
-    "playevent_note_string": (
-        Game,
-        lambda w: GameFilter(
-            playevent_note=StringCriterion(
-                value="Completed", modifier=Modifier.INCLUDES
-            )
-        ),
-        lambda w: GameFilter(
-            playevent_filter=PlayEventFilter(
-                note=StringCriterion(value="Completed", modifier=Modifier.INCLUDES)
-            )
-        ),
-    ),
-    "game_finished_date": (
-        Game,
-        lambda w: GameFilter(finished=_between_2024()),
-        lambda w: GameFilter(playevent_filter=PlayEventFilter(ended=_between_2024())),
-    ),
-    "session_emulated_true": (
-        Game,
-        lambda w: GameFilter(session_emulated=BoolCriterion(value=True)),
-        lambda w: GameFilter(
-            session_filter=SessionFilter(
-                match=RelationMatch.ANY, emulated=BoolCriterion(value=True)
-            )
-        ),
-    ),
-    "session_emulated_false": (
-        Game,
-        lambda w: GameFilter(session_emulated=BoolCriterion(value=False)),
-        lambda w: GameFilter(
-            session_filter=SessionFilter(
-                match=RelationMatch.NONE, emulated=BoolCriterion(value=True)
-            )
-        ),
-    ),
-    "purchase_refunded_true": (
-        Game,
-        lambda w: GameFilter(purchase_refunded=BoolCriterion(value=True)),
-        lambda w: GameFilter(
-            purchase_filter=PurchaseFilter(
-                match=RelationMatch.ANY, is_refunded=BoolCriterion(value=True)
-            )
-        ),
-    ),
-    "purchase_refunded_false": (
-        Game,
-        lambda w: GameFilter(purchase_refunded=BoolCriterion(value=False)),
-        lambda w: GameFilter(
-            purchase_filter=PurchaseFilter(
-                match=RelationMatch.NONE, is_refunded=BoolCriterion(value=True)
-            )
-        ),
-    ),
-    "purchase_infinite_true": (
-        Game,
-        lambda w: GameFilter(purchase_infinite=BoolCriterion(value=True)),
-        lambda w: GameFilter(
-            purchase_filter=PurchaseFilter(
-                match=RelationMatch.ANY, infinite=BoolCriterion(value=True)
-            )
-        ),
-    ),
-    "purchase_infinite_false": (
-        Game,
-        lambda w: GameFilter(purchase_infinite=BoolCriterion(value=False)),
-        lambda w: GameFilter(
-            purchase_filter=PurchaseFilter(
-                match=RelationMatch.NONE, infinite=BoolCriterion(value=True)
-            )
-        ),
-    ),
-    "purchase_bar_finished_date": (
-        Purchase,
-        lambda w: PurchaseFilter(finished=_between_2024()),
-        lambda w: PurchaseFilter(
-            game_filter=GameFilter(
-                playevent_filter=PlayEventFilter(ended=_between_2024())
-            )
-        ),
-    ),
-}
-
-
-@pytest.mark.parametrize("case_id", list(PARITY_CASES), ids=list(PARITY_CASES))
-def test_repointed_widget_nested_equals_flat_oracle(parity_world, case_id):
-    model, build_flat, build_nested = PARITY_CASES[case_id]
-    flat_ids = _ids(model, build_flat(parity_world))
-    nested_ids = _ids(model, build_nested(parity_world))
-    # Non-vacuous: the criterion must actually match something in the world, so an
-    # all-empty bug can't make the equality trivially pass.
-    assert flat_ids, f"{case_id}: flat oracle matched nothing (test data too thin)"
-    assert nested_ids == flat_ids, (
-        f"{case_id}: nested form selected {nested_ids} but flat oracle {flat_ids}"
-    )
 
 
 # ── prefill coverage gaps (#123 Phase 2d hardening) ──────────────────────────

--- a/tests/test_filter_paths.py
+++ b/tests/test_filter_paths.py
@@ -200,10 +200,11 @@ def test_resolve_path_kind_walks_nested_path() -> None:
 
 
 def test_resolve_path_kind_resolves_leaf_kinds() -> None:
-    """Spot-check each kind on a top-level GameFilter field."""
+    """Spot-check each kind on a GameFilter field (date via a nested leaf, since
+    GameFilter has no top-level DateCriterion field)."""
     assert resolve_path_kind(GameFilter, ["name"]) == "string"
     assert resolve_path_kind(GameFilter, ["year_released"]) == "number"
-    assert resolve_path_kind(GameFilter, ["finished"]) == "date"
+    assert resolve_path_kind(GameFilter, ["playevent_filter", "ended"]) == "date"
     assert resolve_path_kind(GameFilter, ["mastered"]) == "bool"
     assert resolve_path_kind(GameFilter, ["status"]) == "set"
 

--- a/tests/test_filter_where.py
+++ b/tests/test_filter_where.py
@@ -57,8 +57,8 @@ def test_bool_field_resolves_bool_criterion():
 
 
 def test_multi_field_resolves_multi_criterion():
-    assert GameFilter.where(device=[1, 2]) == GameFilter(
-        device=MultiCriterion(value=[1, 2], modifier=Modifier.INCLUDES)
+    assert GameFilter.where(platform_group=[1, 2]) == GameFilter(
+        platform_group=MultiCriterion(value=[1, 2], modifier=Modifier.INCLUDES)
     )
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -923,18 +923,6 @@ class TestExpandedFiltersAgainstDB:
         assert data["game"] in results
         assert data["game2"] not in results
 
-    def test_game_filter_device(self):
-        from games.filters import GameFilter
-        from games.models import Game
-
-        data = self._setup_entities()
-        gf = GameFilter.from_json(
-            {"device": {"value": [data["dev"].id], "modifier": "INCLUDES"}}
-        )
-        results = set(Game.objects.filter(gf.to_q()))
-        assert data["game"] in results
-        assert data["game2"] not in results
-
     def test_game_filter_platform_group(self):
         from games.filters import GameFilter
         from games.models import Game
@@ -948,98 +936,12 @@ class TestExpandedFiltersAgainstDB:
         assert data["game"] in results
         assert data["game2"] in results
 
-    def test_game_filter_session_emulated(self):
-        from games.filters import GameFilter
-        from games.models import Game, Session
-        import datetime
-        from datetime import timedelta
-
-        data = self._setup_entities()
-        Session.objects.create(
-            game=data["game2"],
-            device=data["dev"],
-            timestamp_start=datetime.datetime(
-                2026, 6, 2, 12, 0, 0, tzinfo=datetime.timezone.utc
-            ),
-            timestamp_end=datetime.datetime(
-                2026, 6, 2, 12, 30, 0, tzinfo=datetime.timezone.utc
-            ),
-            duration_manual=timedelta(0),
-            emulated=True,
-        )
-        gf = GameFilter.from_json(
-            {"session_emulated": {"value": True, "modifier": "EQUALS"}}
-        )
-        results = set(Game.objects.filter(gf.to_q()))
-        assert data["game2"] in results
-        assert data["game"] not in results
-
-    def test_game_filter_purchase_refunded_and_infinite(self):
-        from games.filters import GameFilter
-        from games.models import Game, Purchase
-        import datetime
-
-        data = self._setup_entities()
-        # data["pur"] is infinite=True, non-refunded.
-        gf_inf = GameFilter.from_json(
-            {"purchase_infinite": {"value": True, "modifier": "EQUALS"}}
-        )
-        assert data["game"] in set(Game.objects.filter(gf_inf.to_q()))
-        assert data["game2"] not in set(Game.objects.filter(gf_inf.to_q()))
-
-        # Add a refunded purchase for game2.
-        refunded = Purchase.objects.create(
-            platform=data["plat"],
-            date_purchased=datetime.date(2026, 1, 1),
-            date_refunded=datetime.date(2026, 2, 1),
-            price=10.0,
-            price_currency="USD",
-            converted_price=10.0,
-            converted_currency="USD",
-        )
-        refunded.games.add(data["game2"])
-        gf_ref = GameFilter.from_json(
-            {"purchase_refunded": {"value": True, "modifier": "EQUALS"}}
-        )
-        results = set(Game.objects.filter(gf_ref.to_q()))
-        assert data["game2"] in results
-        assert data["game"] not in results
-
-    def test_game_filter_purchase_type_and_ownership(self):
-        from games.filters import GameFilter
-        from games.models import Game
-
-        data = self._setup_entities()
-        # data["pur"] defaults to type=game, ownership_type=digital
-        gf = GameFilter.from_json(
-            {"purchase_type": {"value": ["game"], "modifier": "INCLUDES"}}
-        )
-        assert data["game"] in set(Game.objects.filter(gf.to_q()))
-
-        gf = GameFilter.from_json(
-            {"purchase_ownership_type": {"value": ["di"], "modifier": "INCLUDES"}}
-        )
-        assert data["game"] in set(Game.objects.filter(gf.to_q()))
-
-    def test_game_filter_purchase_price_any_and_total(self):
+    def test_game_filter_purchase_price_total(self):
         from games.filters import GameFilter
         from games.models import Game
 
         data = self._setup_entities()
         # data["pur"] has converted_price=45.00 linked to data["game"]
-        gf_any = GameFilter.from_json(
-            {
-                "purchase_price_any": {
-                    "value": 40.0,
-                    "value2": 50.0,
-                    "modifier": "BETWEEN",
-                }
-            }
-        )
-        results = set(Game.objects.filter(gf_any.to_q()))
-        assert data["game"] in results
-        assert data["game2"] not in results
-
         gf_total = GameFilter.from_json(
             {
                 "purchase_price_total": {
@@ -1050,24 +952,6 @@ class TestExpandedFiltersAgainstDB:
             }
         )
         results = set(Game.objects.filter(gf_total.to_q()))
-        assert data["game"] in results
-        assert data["game2"] not in results
-
-    def test_game_filter_playevent_note_includes(self):
-        from games.filters import GameFilter
-        from games.models import Game
-
-        data = self._setup_entities()
-        # data["pe"] has note="Completed 100%" on data["game"]
-        gf = GameFilter.from_json(
-            {
-                "playevent_note": {
-                    "value": "Completed",
-                    "modifier": "INCLUDES",
-                }
-            }
-        )
-        results = set(Game.objects.filter(gf.to_q()))
         assert data["game"] in results
         assert data["game2"] not in results
 
@@ -1331,24 +1215,6 @@ class TestPurchaseFilterDates:
 
         assert PurchaseFilter(game_filter=GameFilter()).to_json() == {}
 
-    def test_flat_finished_field_round_trip(self):
-        """The flat `finished` DateCriterion on Game/Purchase filters (#121)
-        round-trips through JSON like any other criterion field."""
-        from games.filters import GameFilter, PurchaseFilter
-
-        for cls in (GameFilter, PurchaseFilter):
-            payload = {
-                "finished": {
-                    "value": "2024-01-01",
-                    "value2": "2024-12-31",
-                    "modifier": "BETWEEN",
-                }
-            }
-            obj = cls.from_json(payload)
-            assert isinstance(obj.finished, DateCriterion)
-            out = obj.to_json()
-            assert out == payload
-
 
 class TestPlayEventFilterDates:
     """End-to-end: a PlayEventFilter built from JSON narrows the queryset
@@ -1446,95 +1312,3 @@ class TestPlayEventFilterDates:
         assert out["ended"]["value2"] == "2024-12-31"
         assert out["ended"]["modifier"] == Modifier.BETWEEN
         assert out["started"]["modifier"] == Modifier.GREATER_THAN
-
-
-class TestFinishedFilter:
-    """The flat `finished` DateCriterion (#121): a game/purchase is matched when
-    the game has a PlayEvent whose `ended` date falls in the range."""
-
-    def _seed(self):
-        import datetime
-
-        from games.models import Game, Platform, PlayEvent, Purchase
-
-        pc = Platform.objects.create(name="PC")
-        in_range = Game.objects.create(name="Done2024", platform=pc)
-        out_range = Game.objects.create(name="Done2023", platform=pc)
-        never = Game.objects.create(name="Unfinished", platform=pc)
-        PlayEvent.objects.create(game=in_range, ended=datetime.date(2024, 6, 1))
-        PlayEvent.objects.create(game=out_range, ended=datetime.date(2023, 6, 1))
-        # never: no playevent with an `ended` date
-        PlayEvent.objects.create(game=never, started=datetime.date(2024, 1, 1))
-
-        p_in = Purchase.objects.create(
-            type=Purchase.GAME, date_purchased=datetime.date(2024, 1, 1)
-        )
-        p_in.games.set([in_range])
-        p_out = Purchase.objects.create(
-            type=Purchase.GAME, date_purchased=datetime.date(2023, 1, 1)
-        )
-        p_out.games.set([out_range])
-        return {
-            "in_range": in_range,
-            "out_range": out_range,
-            "never": never,
-            "p_in": p_in,
-            "p_out": p_out,
-        }
-
-    @pytest.mark.django_db
-    def test_game_finished_in_range(self):
-        from games.filters import GameFilter
-        from games.models import Game
-
-        data = self._seed()
-        gf = GameFilter.where(finished__between=("2024-01-01", "2024-12-31"))
-        results = set(Game.objects.filter(gf.to_q()).distinct())
-        assert results == {data["in_range"]}
-
-    @pytest.mark.django_db
-    def test_purchase_finished_in_range(self):
-        from games.filters import PurchaseFilter
-        from games.models import Purchase
-
-        data = self._seed()
-        pf = PurchaseFilter.where(finished__between=("2024-01-01", "2024-12-31"))
-        results = set(Purchase.objects.filter(pf.to_q()).distinct())
-        assert results == {data["p_in"]}
-
-    @pytest.mark.django_db
-    def test_game_finished_greater_than_min_only(self):
-        """A min-only (GREATER_THAN) finished bound maps to playevents__ended__gt."""
-        from games.filters import GameFilter
-        from games.models import Game
-
-        data = self._seed()
-        gf = GameFilter.where(finished__gt="2024-01-01")
-        results = set(Game.objects.filter(gf.to_q()).distinct())
-        assert results == {data["in_range"]}
-
-    @pytest.mark.django_db
-    def test_purchase_finished_less_than_max_only(self):
-        """A max-only (LESS_THAN) finished bound maps to playevents__ended__lt."""
-        from games.filters import PurchaseFilter
-        from games.models import Purchase
-
-        data = self._seed()
-        pf = PurchaseFilter.where(finished__lt="2024-01-01")
-        results = set(Purchase.objects.filter(pf.to_q()).distinct())
-        assert results == {data["p_out"]}
-
-    @pytest.mark.django_db
-    def test_game_finished_no_duplicate_rows(self):
-        """A game with several finished playevents in range appears once."""
-        import datetime
-
-        from games.filters import GameFilter
-        from games.models import Game, Platform, PlayEvent
-
-        pc = Platform.objects.create(name="PC")
-        game = Game.objects.create(name="Multi", platform=pc)
-        PlayEvent.objects.create(game=game, ended=datetime.date(2024, 3, 1))
-        PlayEvent.objects.create(game=game, ended=datetime.date(2024, 9, 1))
-        gf = GameFilter.where(finished__between=("2024-01-01", "2024-12-31"))
-        assert Game.objects.filter(gf.to_q()).distinct().count() == 1

--- a/tests/test_relation_algebra.py
+++ b/tests/test_relation_algebra.py
@@ -91,23 +91,10 @@ def test_empty_none_subfilter_means_no_related_rows(emulated_world):
     assert _ids(no_sessions) == {emulated_world["no_sessions"]}
 
 
-# ── equivalence with the flat convenience fields (Phase 2 mapping) ───────────
+# ── nested NONE form: "has no refunded purchase" (incl. zero-purchase games) ──
 
 
-def test_nested_matches_flat_session_emulated(emulated_world):
-    """The flat session_emulated bool and the nested match-mode form must select
-    identical games for both True (ANY) and False (NONE)."""
-    for value, match in [(True, RelationMatch.ANY), (False, RelationMatch.NONE)]:
-        flat = GameFilter(session_emulated=BoolCriterion(value=value))
-        nested = GameFilter(
-            session_filter=SessionFilter(
-                emulated=BoolCriterion(value=True), match=match
-            )
-        )
-        assert _ids(flat) == _ids(nested), f"mismatch for value={value}"
-
-
-def test_nested_matches_flat_purchase_refunded(db):
+def test_nested_purchase_refunded_none(db):
     pc = Platform.objects.create(name="PC")
     refunded = Game.objects.create(name="Refunded", platform=pc)
     kept = Game.objects.create(name="Kept", platform=pc)
@@ -117,14 +104,12 @@ def test_nested_matches_flat_purchase_refunded(db):
     ).games.set([refunded])
     Purchase.objects.create(date_purchased=_dt()).games.set([kept])
 
-    flat_false = GameFilter(purchase_refunded=BoolCriterion(value=False))
     nested_none = GameFilter(
         purchase_filter=PurchaseFilter(
             is_refunded=BoolCriterion(value=True), match=RelationMatch.NONE
         )
     )
-    assert _ids(flat_false) == _ids(nested_none)
-    assert _ids(flat_false) == {kept.id, none.id}
+    assert _ids(nested_none) == {kept.id, none.id}
 
 
 # ── match round-trip ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## #123 Phase 3 — deletion slice

The cross-entity filter bar emits the canonical **nested** sub-filter form since #123 Phase 2/2d (merged), so the flat top-level convenience fields are now dead code. This removes them and all stray references.

### Deleted fields
**`GameFilter`:** `device`, `session_emulated`, `purchase_refunded`, `purchase_infinite`, `purchase_price_any`, `purchase_type`, `purchase_ownership_type`, `playevent_note`, `finished`.
**`PurchaseFilter`:** `finished`.

Also removed each field's branch in `to_q()`, the `_playevent_note_to_q` helper (sole caller was `playevent_note`), and the now-unused `MatchingIdQuerySet` type alias + its `QuerySet`/`Any` imports.

### Kept (NOT retired)
- Aggregates: `session_count`, `session_average`, `purchase_count`, `playevent_count`, `manual_playtime_hours`, `calculated_playtime_hours`, `purchase_price_total`.
- Nested sub-filter fields (`session_filter`, `purchase_filter`, `playevent_filter`, `platform_filter`, `game_filter`, `device_filter`), all direct fields, and the n-ary AND/OR/NOT.

### Serialization
`to_json`/`from_json` are dataclass-driven, so removing the fields **auto-removes** their serialization — no migration, no alias. Old presets carrying these keys are **accepted-broken**: `from_json` silently ignores keys with no matching dataclass field, per the project decision.

### Bar-built == stats_links is now structural
Only the nested form exists; there is no flat path left to diverge from. `common/components/filters.py` already pointed every widget at its nested data-path (Phase 2d) and `games/views/stats_links.py` already used nested/aggregate forms — both confirmed clean, no changes needed.

### Tests
- Deleted the flat-vs-nested **parity/oracle** tests (`test_repointed_widget_nested_equals_flat_oracle` + `parity_world` in `test_filter_cross_entity.py`; `test_nested_matches_flat_session_emulated`/`test_nested_matches_flat_purchase_refunded` in `test_relation_algebra.py`) — the per-widget nested result-set tests remain the coverage.
- Removed/repointed the remaining flat-field unit tests in `test_filters.py` (deleted `test_game_filter_*` for the gone fields and the `TestFinishedFilter` class + `test_flat_finished_field_round_trip`; kept `purchase_price_total` coverage as `test_game_filter_purchase_price_total`).
- `test_filter_where.py`: repointed the MultiCriterion `.where()` check from the deleted `device` to `platform_group`.
- `test_filter_paths.py`: the "date" leaf-kind spot-check now uses a nested `["playevent_filter", "ended"]` path (GameFilter has no top-level DateCriterion field anymore).

**Per-bar widget counts unchanged: 23/8/14/1/2/4** (Phase 3 deletes Python fields, not widgets).

### Verification (all green)
- `pytest tests/ --ignore=e2e` — **757 passed**
- `pytest e2e/` — **105 passed**
- `make ts` clean; `mypy common/ games/` — no issues; `ruff check` + format clean.
- `pytest tests/test_filter_paths.py` — counts stay 23/8/14/1/2/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)