### PR TITLE
Fix cross-entity prefill from top-level ?filter= (#137)

### DIFF
--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -186,12 +186,16 @@ def _deep_get(value: dict, keys: FilterWidgetPath) -> object:
 
 
 def _cross_entity_criterion(existing: dict, path: FilterWidgetPath) -> dict:
-    """Find the leaf criterion a composed widget at ``path`` serialized into AND.
+    """Find the leaf criterion a composed widget at ``path`` serialized into.
 
-    Scans ``existing["AND"]`` for the element whose nested chain ``path[:-1]``
-    contains ``path[-1]`` as a dict (the leaf criterion), returning that dict (or
-    ``{}`` when no element matches). Example: ``["session_filter", "device"]``
-    finds ``{"session_filter": {"device": {...}}}`` and returns the inner dict.
+    Two producers write the cross-entity sub-filter, in different shapes (#137):
+    the bar wraps it in an ``AND`` element (``{"AND": [{"session_filter":
+    {"device": {...}}}]}``), while stats-links / ``filter_url`` emit it
+    TOP-LEVEL (``{"session_filter": {"device": {...}}}``). Both are valid for
+    ``to_q``, so prefill reads BOTH: first the ``existing["AND"]`` scan, then the
+    top-level nested ``path``. Returns the first leaf criterion dict found (AND
+    takes precedence when both are present), or ``{}`` when neither matches.
+    Example: ``["session_filter", "device"]`` returns the inner ``device`` dict.
     """
     for element in existing.get("AND", []) or []:
         if not isinstance(element, dict):
@@ -199,17 +203,23 @@ def _cross_entity_criterion(existing: dict, path: FilterWidgetPath) -> dict:
         parent = _deep_get(element, path[:-1])
         if isinstance(parent, dict) and isinstance(parent.get(path[-1]), dict):
             return parent[path[-1]]
+    top_level = _deep_get(existing, path)
+    if isinstance(top_level, dict):
+        return top_level
     return {}
 
 
 def _cross_entity_bool(
     existing: dict, relation_field: str, child_key: str
 ) -> bool | None:
-    """Read a relation-bool widget's tri-state from the AND list.
+    """Read a relation-bool widget's tri-state from either producer's shape.
 
-    Returns True when an AND element's ``[relation_field][child_key]`` exists and
-    its relation is matched ANY (no ``match`` / not NONE), False when that element
-    sets ``match: "NONE"``, and None when no such element is present.
+    Like ``_cross_entity_criterion``, the relation node can arrive wrapped in an
+    ``AND`` element (bar) or TOP-LEVEL (stats-links / ``filter_url``) (#137), so
+    both are read: first the ``existing["AND"]`` scan, then the top-level
+    ``existing[relation_field]``. Returns True when a matching relation exists and
+    is matched ANY (no ``match`` / not NONE), False when it sets ``match:
+    "NONE"``, and None when no such relation is present (AND takes precedence).
     """
     for element in existing.get("AND", []) or []:
         if not isinstance(element, dict):
@@ -217,6 +227,9 @@ def _cross_entity_bool(
         relation = element.get(relation_field)
         if isinstance(relation, dict) and child_key in relation:
             return relation.get("match") != "NONE"
+    top_level = existing.get(relation_field)
+    if isinstance(top_level, dict) and child_key in top_level:
+        return top_level.get("match") != "NONE"
     return None
 
 

--- a/tests/test_filter_cross_entity.py
+++ b/tests/test_filter_cross_entity.py
@@ -651,3 +651,52 @@ def test_game_bar_prefills_refunded_false_and_infinite_true_independently(db):
     assert re.search(
         r'name="filter-purchase-infinite"[^>]*value="true"[^>]*checked', html
     )
+
+
+# ── prefill: TOP-LEVEL cross-entity shape (stats-link / filter_url) (#137) ────
+# stats_links / filter_url emit cross-entity sub-filters TOP-LEVEL (no AND
+# wrapper), e.g. {"session_filter": {"device": {...}}}. to_q honours that shape,
+# but prefill historically scanned only existing["AND"], so the matching bar
+# widget rendered BLANK — re-applying the bar silently dropped the constraint.
+# These assert the dual-read prefill repopulates the widget from the top level.
+
+
+def test_game_bar_prefills_device_from_top_level(db):
+    """Top-level (no AND) session_filter→device prefills the device pill."""
+    deck = Device.objects.create(name="SteamDeck", type=Device.HANDHELD)
+    filter_json = json.dumps(
+        {"session_filter": {"device": _set_criterion(str(deck.id), "SteamDeck")}}
+    )
+    html = str(FilterBar(filter_json))
+    assert "SteamDeck" in html
+
+
+def test_purchase_bar_prefills_finished_from_top_level(db):
+    """Top-level game_filter→playevent_filter→ended prefills the date widget."""
+    filter_json = json.dumps(
+        {
+            "game_filter": {
+                "playevent_filter": {
+                    "ended": {
+                        "value": "2024-01-01",
+                        "value2": "2024-12-31",
+                        "modifier": "BETWEEN",
+                    }
+                }
+            }
+        }
+    )
+    html = str(PurchaseFilterBar(filter_json))
+    assert "2024-01-01" in html
+    assert "2024-12-31" in html
+
+
+def test_game_bar_prefills_session_emulated_true_radio_from_top_level(db):
+    """Top-level (no AND) relation-bool checks the 'True' radio."""
+    filter_json = json.dumps(
+        {"session_filter": {"emulated": {"value": True, "modifier": "EQUALS"}}}
+    )
+    html = str(FilterBar(filter_json))
+    assert re.search(
+        r'name="filter-session-emulated"[^>]*value="true"[^>]*checked', html
+    )


### PR DESCRIPTION
## Problem

Two producers write the `?filter=` JSON's cross-entity sub-filters in **different shapes**:

- The **filter bar serializer** wraps them in `AND`:
  `{"AND":[{"purchase_filter":{"type":...}}]}`
- **`games/views/stats_links.py` / `filter_url`** emit them **TOP-LEVEL**:
  `{"game_filter":{"playevent_filter":{"ended":...}}}` (also `{"session_filter":{...}}`, etc.)

Both shapes are valid for `to_q`, so the list filters correctly in both cases. But the bar's prefill helpers `_cross_entity_criterion` and `_cross_entity_bool` (in `common/components/filters.py`) scanned **only** `existing["AND"]`. So clicking a stats link landed the user on a correctly-filtered list with the matching bar widget rendered **blank** — and if they opened the bar and hit Apply, the cross-entity constraint was **silently dropped** (re-serialized from an empty widget).

## Fix

Both helpers now perform a **dual read**, robust to either producer:

1. the existing `existing["AND"]`-element scan, then
2. the **top-level** nested path (`existing` itself, walking `path` / `relation_field`).

The first match wins, with the AND scan taking precedence (bar-built shape) when both are somehow present; in practice only one producer is present. The localized dual-read was chosen over canonicalizing top-level sub-filters into `AND` in `_FilterBarBase.__init__` because it is lower-risk and sufficient — `to_q`/serialization are untouched; only prefill **reading** changed.

## Tests

`tests/test_filter_cross_entity.py` gains regression tests proving a TOP-LEVEL (no-`AND`) cross-entity filter prefills the widget:

- games-bar device pill from top-level `session_filter→device`
- purchase-bar `finished` date widget from top-level `game_filter→playevent_filter→ended`
- games-bar relation-bool `emulated` True radio from top-level `session_filter→emulated`

The existing AND-shape prefill tests stay green — both shapes work.

## Verification

- `uv run --with pytest-django pytest tests/ --ignore=e2e -q` → 764 passed
- `uv run mypy common/ games/` → clean; `uv run ruff check` + `ruff format` → clean

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)