### PR TITLE
Remove dead AggregateCriterion.scope field (#139)

### DIFF
--- a/common/criteria.py
+++ b/common/criteria.py
@@ -406,17 +406,12 @@ class AggregateCriterion(_Criterion):
 
     The reducer, relation accessor, source field, and unit are *static config*
     supplied by the filter at query time (see ``aggregate_to_q``); the instance
-    carries only the user's comparison value(s)/modifier and an optional
-    ``scope`` sub-filter restricting which related rows are aggregated.
+    carries only the user's comparison value(s)/modifier.
     """
 
     value: int | float = 0
     value2: int | float | None = None
     modifier: Modifier = Modifier.EQUALS
-    # Restricts which related rows are aggregated. Always None today; honouring it
-    # needs both the path serializer (to populate it) AND aggregate_to_q (to apply
-    # it as the annotate ``filter=``) — neither is wired yet.
-    scope: "OperatorFilter | None" = None
 
     def to_q(self, field_name: str) -> Q:
         # Unlike sibling criteria, an aggregate is not self-contained: its meaning


### PR DESCRIPTION
Removes the dead `scope` field from `AggregateCriterion` in `common/criteria.py`.

The field was never set or read: `aggregate_to_q` ignores it, nothing assigns `scope=`, and `_Criterion.from_json` would copy a JSON `scope` as a raw dict rather than deserialize it to an `OperatorFilter` (so it was mis-typed if ever populated). It was Phase-1 forward-scaffolding for scoped aggregates that never got wired. Removed the field, its inline comment, and the docstring paragraph describing it.

## Verification
- `uv run --with pytest-django pytest tests/ --ignore=e2e -q` — 761 passed, 56 subtests passed
- `uv run mypy common/ games/` — Success: no issues found in 72 source files
- `uv run ruff check common/ tests/` — All checks passed; `ruff format` left the file unchanged

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)