### PR TITLE
Drop SessionFilter.duration_hours legacy alias (#140)

### DIFF
--- a/games/filters.py
+++ b/games/filters.py
@@ -266,7 +266,6 @@ class SessionFilter(OperatorFilter):
     device: MultiCriterion | None = None  # filters on device_id
     emulated: BoolCriterion | None = None
     note: StringCriterion | None = None
-    duration_hours: IntCriterion | None = None  # on duration_total (legacy alias)
     duration_total_hours: IntCriterion | None = None
     duration_manual_hours: IntCriterion | None = None
     duration_calculated_hours: IntCriterion | None = None
@@ -302,8 +301,6 @@ class SessionFilter(OperatorFilter):
             q &= self.emulated.to_q("emulated")
         if self.note is not None:
             q &= self.note.to_q("note")
-        if self.duration_hours is not None:
-            q &= self._duration_to_q(self.duration_hours, "duration_total")
         if self.duration_total_hours is not None:
             q &= self._duration_to_q(self.duration_total_hours, "duration_total")
         if self.duration_manual_hours is not None:


### PR DESCRIPTION
Removes the pre-refactor legacy alias `duration_hours` from `SessionFilter` in `games/filters.py`.

It duplicated `duration_total_hours` (both map to the `duration_total` column) and no filter-bar widget emits it — it was reachable only via `where()` or stale saved presets. Deletes both the field declaration and its branch in `SessionFilter.to_q()`.

The `unit="duration_hours"` `DurationUnit` literal in `common/criteria.py` and `games/filters.py` is unrelated (a criterion unit, not the field) and is untouched.

## Verification
- `uv run --with pytest-django pytest tests/ --ignore=e2e -q` — 761 passed, 56 subtests passed
- `uv run mypy common/ games/` — Success, no issues
- `uv run ruff check games/ tests/` — all checks passed; format clean

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)