### PR TITLE
Sweep dead filter-component helpers (#141)

### DIFF
--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -6,7 +6,6 @@ from common.components.core import BaseComponent, Element, Node, Safe
 from common.components.custom_elements import _FilterBarElement
 from common.components.date_range_picker import DateRangePicker
 from common.components.primitives import (
-    Checkbox,
     Div,
     FilterWidgetKind,
     FilterWidgetPath,
@@ -220,14 +219,6 @@ def _cross_entity_bool(
     return None
 
 
-def _parse_bool(existing: dict, key: str) -> bool:
-    """Extract a boolean value from a filter criterion."""
-    field = existing.get(key, {})
-    if not isinstance(field, dict):
-        return False
-    return bool(field.get("value", False))
-
-
 def _parse_bool_nullable(existing: dict, key: str) -> bool | None:
     """Extract a nullable boolean value from a filter criterion."""
     if key not in existing:
@@ -250,11 +241,6 @@ def _parse_bool_nullable(existing: dict, key: str) -> bool | None:
 # Each list filter is a FilterSelect. Enum fields pre-render their small, fixed
 # option set; model-backed fields fetch from a search endpoint on demand, with
 # labels embedded in the filter JSON so pills render without a DB round-trip.
-
-# Presence modifiers drive the pinned (Any)/(None) pseudo-options. They are
-# mutually exclusive with value pills (selecting one clears the value set).
-# Must match JS PRESENCE_MODIFIERS in search_select.js.
-_PRESENCE_MODIFIERS = frozenset({"NOT_NULL", "IS_NULL"})
 
 # M2M-only modifiers surfaced as additional pseudo-options in the dropdown.
 # "any" (INCLUDES) is the implicit default when neither a presence nor an
@@ -284,20 +270,6 @@ def _modifier_options(
     return options
 
 
-def _split_modifier(modifier: str, has_m2m: bool = False) -> str:
-    """Return the modifier value to surface as the modifier pill.
-
-    Presence modifiers (NOT_NULL / IS_NULL) are always surfaced.  Non-presence
-    modifiers (INCLUDES / INCLUDES_ALL / INCLUDES_ONLY) only need a pill on M2M
-    fields — otherwise the modifier is just the implicit default.
-    """
-    if modifier in _PRESENCE_MODIFIERS or not has_m2m:
-        return modifier
-    if modifier:
-        return modifier
-    return ""
-
-
 def _enum_filter(
     field_name: str,
     options,
@@ -321,7 +293,7 @@ def _enum_filter(
     excluded = [
         (value, _find_label(options_str, value)) for value, _label in choice.excluded
     ]
-    modifier = _split_modifier(choice.modifier)
+    modifier = choice.modifier
     return FilterSelect(
         field_name=field_name,
         options=options_str,
@@ -353,7 +325,7 @@ def _model_filter(
     cross-entity widget point at a nested sub-filter leaf (defaults to the flat
     ``[field_name]``).
     """
-    modifier = _split_modifier(choice.modifier, has_m2m=bool(m2m_modifiers))
+    modifier = choice.modifier
     return FilterSelect(
         field_name=field_name,
         included=[(value, label or value) for value, label in choice.selected],
@@ -365,19 +337,6 @@ def _model_filter(
         path=path if path is not None else [field_name],
         compose=compose,
     )
-
-
-def _filter_mins_to_hrs(val) -> str:
-    if val is None or val == "" or val == 0:
-        return ""
-    try:
-        mins = int(val)
-    except (TypeError, ValueError):
-        return ""
-    if mins == 0:
-        return ""
-    hrs = mins / 60
-    return str(int(hrs)) if hrs == int(hrs) else f"{hrs:.1f}"
 
 
 def _widget_id(widget) -> str:
@@ -409,11 +368,6 @@ def _filter_field(label: str, widget) -> Node:
             widget,
         ],
     )
-
-
-def _filter_checkbox(name: str, label: str, checked: bool) -> Node:
-    """Thin adapter mapping legacy checkbox filters to the generalized Checkbox primitive."""
-    return Checkbox(name=name, label=label, checked=checked)
 
 
 def _filter_boolean_radio(

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -161,8 +161,8 @@ class FilterBarRenderingTest(TestCase):
 
     def test_game_filter_bar_preserves_excludes_modifier(self):
         """An enum field with an EXCLUDES modifier renders data-modifier correctly
-        so the JS roundtrip preserves the modifier (regression: _split_modifier
-        silently dropped non-presence modifiers when match_modes was None)."""
+        so the JS roundtrip preserves the modifier (regression: non-presence
+        modifiers were silently dropped when match_modes was None)."""
         filter_json = json.dumps(
             {
                 "status": {

--- a/tests/test_filter_helpers.py
+++ b/tests/test_filter_helpers.py
@@ -2,7 +2,7 @@
 
 from django.test import SimpleTestCase
 
-from common.components.filters import _parse_bool, _parse_range, _parse_bool_nullable
+from common.components.filters import _parse_range, _parse_bool_nullable
 
 
 class ParseRangeTest(SimpleTestCase):
@@ -38,34 +38,6 @@ class ParseRangeTest(SimpleTestCase):
             _parse_range({"field": {"value": 5, "value2": 15}}, "field"),
             ("5", "15"),
         )
-
-
-class ParseBoolTest(SimpleTestCase):
-    def test_empty_dict(self):
-        self.assertFalse(_parse_bool({}, "field"))
-
-    def test_missing_key(self):
-        self.assertFalse(_parse_bool({"other": 1}, "field"))
-
-    def test_null_value(self):
-        self.assertFalse(_parse_bool({"field": None}, "field"))
-
-    def test_non_dict_value(self):
-        """A non-dict field value is coerced to False."""
-        self.assertFalse(_parse_bool({"field": "not_a_dict"}, "field"))
-
-    def test_false_value(self):
-        self.assertFalse(_parse_bool({"field": {"value": False}}, "field"))
-
-    def test_true_value(self):
-        self.assertTrue(_parse_bool({"field": {"value": True}}, "field"))
-
-    def test_truthy_string(self):
-        """Non-empty strings are truthy — bool("yes") is True."""
-        self.assertTrue(_parse_bool({"field": {"value": "yes"}}, "field"))
-
-    def test_missing_value_in_field(self):
-        self.assertFalse(_parse_bool({"field": {}}, "field"))
 
 
 class ParseBoolNullableTest(SimpleTestCase):

--- a/ts/elements/search-select.ts
+++ b/ts/elements/search-select.ts
@@ -52,10 +52,11 @@ interface FilterPillEntry {
 
 const DEBOUNCE_MS = 100;
 
-// Must match Python common/components/filters.py:_PRESENCE_MODIFIERS.
-// These modifiers are mutually exclusive with value pills — selecting
-// one clears all value pills.  Non-presence modifiers (INCLUDES_ALL,
-// INCLUDES_ONLY) coexist with value pills.
+// Presence modifiers — the sole definition of this set (the former Python
+// _PRESENCE_MODIFIERS constant was removed with its only consumer in #141).
+// They are mutually exclusive with value pills — selecting one clears all
+// value pills.  Non-presence modifiers (INCLUDES_ALL, INCLUDES_ONLY) coexist
+// with value pills.
 const PRESENCE_MODIFIERS = ["NOT_NULL", "IS_NULL"];
 
 const initWidget = (containerElement: Element) => {


### PR DESCRIPTION
Removes pre-existing dead helpers in `common/components/filters.py`, surfaced while scrutinizing #123 (they predate it). Each name was grepped across `common/`, `games/`, `tests/`, and `e2e/` first to confirm zero remaining callers.

## Removed
- `_filter_mins_to_hrs` — no callers.
- `_parse_bool` (non-nullable) — everything uses `_parse_bool_nullable`; its only references were unit tests, removed too.
- `_filter_checkbox` — no callers; the now-sole-use `Checkbox` import in this module goes with it (other modules still import `Checkbox` directly from `primitives`).
- `_split_modifier` — reduced to an identity function (every branch returned `modifier`; the `has_m2m` param was a no-op). Inlined `choice.modifier` at its two call sites.
- `_PRESENCE_MODIFIERS` — only consumer was `_split_modifier`, so it became dead and was removed.

## Tests
- Dropped the `_parse_bool` test class in `tests/test_filter_helpers.py`.
- Updated the `test_filter_bars.py` docstring that named `_split_modifier` (the test still guards EXCLUDES-modifier rendering, which remains valid).

## Verification
- `pytest tests/ --ignore=e2e -q` → 753 passed, 56 subtests passed
- `mypy common/ games/` → clean
- `ruff check common/ tests/` → clean; touched files formatted

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)