### PR TITLE
feat(filters): surface EXCLUDES for free-text search (#142)

### DIFF
--- a/e2e/test_search_filter_e2e.py
+++ b/e2e/test_search_filter_e2e.py
@@ -1,0 +1,140 @@
+"""End-to-end Playwright tests for the injected free-text search input and its
+Exclude toggle (issue #142).
+
+Every ``*Filter.to_q`` already negates the free-text OR when
+``search.modifier == EXCLUDES``, but until now the client-injected search input
+only ever emitted ``modifier:"INCLUDES"``. The Exclude checkbox added next to the
+search box makes the EXCLUDES branch reachable from the UI. These tests assert
+both the emitted filter JSON and that an excluded term actually filters the list.
+"""
+
+import json
+import urllib.parse
+
+import pytest
+from django.http import HttpResponse
+from django.test import override_settings
+from django.urls import path, reverse
+from playwright.sync_api import Page, expect
+
+from common.components import PlatformFilterBar
+from games.models import Game
+
+
+def _bar_page(filter_json: str = "") -> str:
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>Search filter E2E</title>
+    <script src="/static/js/htmx.min.js"></script>
+    <script src="/static/js/dist/elements/search-select.js" type="module"></script>
+    <script src="/static/js/dist/elements/filter-bar.js" type="module"></script>
+</head>
+<body>
+    {PlatformFilterBar(filter_json=filter_json, preset_list_url="/p/l", preset_save_url="/p/s")}
+</body>
+</html>"""
+
+
+def empty_bar_view(request):
+    return HttpResponse(_bar_page())
+
+
+def prefilled_exclude_view(request):
+    filter_json = json.dumps({"search": {"value": "Witcher", "modifier": "EXCLUDES"}})
+    return HttpResponse(_bar_page(filter_json=filter_json))
+
+
+urlpatterns = [
+    path("test-search-filter-empty/", empty_bar_view),
+    path("test-search-filter-prefilled-exclude/", prefilled_exclude_view),
+]
+
+
+def _filter_from_url(url: str) -> dict:
+    query = urllib.parse.urlparse(url).query
+    params = urllib.parse.parse_qs(query)
+    raw = params.get("filter", [""])[0]
+    return json.loads(raw) if raw else {}
+
+
+def _submit(page: Page) -> None:
+    with page.expect_navigation():
+        page.evaluate(
+            "document.getElementById('filter-bar-form')"
+            ".dispatchEvent(new Event('submit', {cancelable: true}))"
+        )
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_search_filter_e2e")
+def test_search_defaults_to_includes(live_server, page):
+    page.goto(live_server.url + "/test-search-filter-empty/")
+
+    search_input = page.locator('input[name="filter-search"]')
+    exclude_checkbox = page.locator('input[name="filter-search-exclude"]')
+    expect(search_input).to_be_visible()
+    assert not exclude_checkbox.is_checked()
+
+    search_input.fill("Witcher")
+    _submit(page)
+    parsed = _filter_from_url(page.url)
+    assert parsed["search"] == {"value": "Witcher", "modifier": "INCLUDES"}
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_search_filter_e2e")
+def test_search_exclude_emits_excludes_modifier(live_server, page):
+    page.goto(live_server.url + "/test-search-filter-empty/")
+
+    page.locator('input[name="filter-search"]').fill("Witcher")
+    page.locator('input[name="filter-search-exclude"]').check()
+
+    _submit(page)
+    parsed = _filter_from_url(page.url)
+    assert parsed["search"] == {"value": "Witcher", "modifier": "EXCLUDES"}
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_search_filter_e2e")
+def test_search_exclude_prefills_from_filter_json(live_server, page):
+    page.goto(live_server.url + "/test-search-filter-prefilled-exclude/")
+
+    assert page.locator('input[name="filter-search"]').input_value() == "Witcher"
+    assert page.locator('input[name="filter-search-exclude"]').is_checked()
+
+
+@pytest.fixture
+def authenticated_page(live_server, page: Page, django_user_model) -> Page:
+    django_user_model.objects.create_user(username="tester", password="secret123")
+    page.goto(f"{live_server.url}{reverse('login')}")
+    page.fill('input[name="username"]', "tester")
+    page.fill('input[name="password"]', "secret123")
+    page.click('button:has-text("Login")')
+    page.wait_for_url(f"{live_server.url}/tracker**")
+    return page
+
+
+def test_excluded_search_term_filters_game_list(authenticated_page, live_server, db):
+    """An excluded search term hides matching games and keeps the rest."""
+    page = authenticated_page
+    Game.objects.create(name="The Witcher 3", sort_name="witcher 3")
+    Game.objects.create(name="Hollow Knight", sort_name="hollow knight")
+
+    page.goto(f"{live_server.url}{reverse('games:list_games')}")
+    # Reveal the collapsed filter-bar body.
+    page.locator("[data-filter-bar-toggle]").click()
+    page.locator('input[name="filter-search"]').fill("Witcher")
+    page.locator('input[name="filter-search-exclude"]').check()
+
+    with page.expect_navigation():
+        page.locator("[data-filter-bar-clear]").wait_for()
+        page.evaluate(
+            "document.getElementById('filter-bar-form')"
+            ".dispatchEvent(new Event('submit', {cancelable: true}))"
+        )
+
+    assert _filter_from_url(page.url)["search"]["modifier"] == "EXCLUDES"
+    table = page.locator("table")
+    expect(table).not_to_contain_text("The Witcher 3")
+    expect(table).to_contain_text("Hollow Knight")

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -228,7 +228,13 @@ function buildFilterJSON(form: HTMLElement): Record<string, unknown> {
 
   const searchInput = form.querySelector<HTMLInputElement>('[name="filter-search"]');
   if (searchInput && searchInput.value.trim()) {
-    setPath(filter, ["search"], { value: searchInput.value.trim(), modifier: "INCLUDES" });
+    const excludeChecked = form.querySelector<HTMLInputElement>(
+      '[name="filter-search-exclude"]',
+    )?.checked;
+    setPath(filter, ["search"], {
+      value: searchInput.value.trim(),
+      modifier: excludeChecked ? "EXCLUDES" : "INCLUDES",
+    });
   }
 
   // Serialise every search-select's state into its data-included/excluded/
@@ -302,23 +308,43 @@ function readRelationBoolWidget(
 
 function injectSearchInput(form: HTMLElement): void {
   if (form.querySelector('[name="filter-search"]')) return;
+
+  const wrapper = document.createElement("div");
+  wrapper.className = "mb-4";
+
   const input = document.createElement("input");
   input.type = "text";
   input.name = "filter-search";
   input.placeholder = "Search…";
   input.className =
-    "block w-full rounded-base border border-default-medium bg-neutral-secondary-medium text-sm text-heading p-2 mb-4 focus:ring-brand focus:border-brand";
+    "block w-full rounded-base border border-default-medium bg-neutral-secondary-medium text-sm text-heading p-2 focus:ring-brand focus:border-brand";
+
+  // Exclude toggle: surfaces the EXCLUDES modifier every *Filter.to_q already
+  // honours for free-text search (negates the OR-of-fields). Unchecked keeps the
+  // historical INCLUDES default; checked emits {value, modifier:"EXCLUDES"}.
+  const excludeLabel = document.createElement("label");
+  excludeLabel.className =
+    "flex items-center gap-2 mt-2 text-sm text-heading cursor-pointer";
+  const excludeCheckbox = document.createElement("input");
+  excludeCheckbox.type = "checkbox";
+  excludeCheckbox.name = "filter-search-exclude";
+  excludeCheckbox.className =
+    "rounded border-default-medium bg-neutral-secondary-medium text-brand focus:ring-brand";
+  excludeLabel.append(excludeCheckbox, document.createTextNode("Exclude matches"));
+
   const hidden = form.querySelector<HTMLInputElement>('[name="filter"]');
   if (hidden && hidden.parentNode) {
     try {
       const existing = JSON.parse(hidden.value || "{}");
       if (existing.search && existing.search.value) {
         input.value = existing.search.value;
+        excludeCheckbox.checked = existing.search.modifier === "EXCLUDES";
       }
     } catch {
       // ignore malformed existing filter JSON
     }
-    hidden.parentNode.insertBefore(input, hidden.nextSibling);
+    wrapper.append(input, excludeLabel);
+    hidden.parentNode.insertBefore(wrapper, hidden.nextSibling);
   }
 }
 


### PR DESCRIPTION
Closes #142

## What

`injectSearchInput` (`ts/elements/filter-bar.ts`) only ever emitted the free-text search with `modifier:"INCLUDES"`, even though every `*Filter.to_q` already negates the OR-of-fields when `search.modifier == EXCLUDES`. The EXCLUDES branch was therefore unreachable from the UI.

This adds a small **"Exclude matches"** checkbox next to the injected search input:

- `injectSearchInput` now wraps the input in a `<div>` and appends a styled checkbox (`name="filter-search-exclude"`), and prefills its checked state from existing filter JSON (`search.modifier === "EXCLUDES"`).
- `buildFilterJSON` reads the checkbox and emits `{value, modifier: "EXCLUDES"}` when checked, keeping the historical `INCLUDES` default when unchecked.

## Which option and why

I took the **UI-affordance** option (not the docs-only fallback). The change is small and self-contained — it stays entirely within the existing `injectSearchInput`/`buildFilterJSON` pattern, reuses the project's checkbox tailwind classes, and needs no Python/backend changes since `to_q` already honours EXCLUDES. No disproportionate scope, so surfacing the capability was the smaller correct option over reserving it.

## Tests

New `e2e/test_search_filter_e2e.py` (mirrors `test_string_filter_e2e.py`):
- defaults to `INCLUDES`
- excluded term emits `{"search":{"value":...,"modifier":"EXCLUDES"}}`
- checkbox prefills from existing EXCLUDES filter JSON
- excluded term actually filters the game list (real data: hides the matching game, keeps the rest)

## Verification

- `pytest tests/ --ignore=e2e -q` → 761 passed
- `make ts` clean; `uv run mypy common/ games/` → no issues; `ruff check` + format on touched files clean
- `pytest e2e/ -k search` → 12 passed (4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)