### PR TITLE
Remove redundant data-compose channel (#138)

### DIFF
--- a/common/components/date_range_picker.py
+++ b/common/components/date_range_picker.py
@@ -334,7 +334,6 @@ def DateRangePicker(
     min_value: str = "",
     max_value: str = "",
     path: FilterWidgetPath | None = None,
-    compose: bool = False,
 ) -> Node:
     """A date-range widget: segmented manual entry plus a calendar popup.
 
@@ -348,9 +347,7 @@ def DateRangePicker(
     filter serializer; non-filter callers (e.g. a standalone date picker) leave
     it None and the extra attributes are omitted."""
     widget_attributes = (
-        filter_widget_attributes(path, "date", compose=compose)
-        if path is not None
-        else []
+        filter_widget_attributes(path, "date") if path is not None else []
     )
     return _DateRangePicker(widget_attributes, class_="relative")[
         DateRangeField(

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -305,13 +305,12 @@ def _enum_filter(
     *,
     nullable,
     path: FilterWidgetPath | None = None,
-    compose: bool = False,
 ) -> Node:
     """A FilterSelect over a small, fully pre-rendered option set (enum field).
 
     Enum fields are single-valued, so no M2M modifiers (all/only are
-    meaningless); only the presence modifier is surfaced. ``path``/``compose``
-    let a cross-entity widget point at a nested sub-filter leaf (defaults to the
+    meaningless); only the presence modifier is surfaced. ``path`` lets a
+    cross-entity widget point at a nested sub-filter leaf (defaults to the
     flat ``[field_name]``).
     """
     options_str = [(str(value), label) for value, label in options]
@@ -330,7 +329,6 @@ def _enum_filter(
         modifier=modifier,
         modifier_options=_modifier_options(nullable),
         path=path if path is not None else [field_name],
-        compose=compose,
     )
 
 
@@ -342,16 +340,14 @@ def _model_filter(
     nullable,
     m2m_modifiers: list[LabeledOption] | None = None,
     path: FilterWidgetPath | None = None,
-    compose: bool = False,
 ) -> Node:
     """A FilterSelect backed by a search endpoint.
 
     Labels are embedded in the filter JSON (Stash-style), so pills render
     directly from ``choice`` with no DB round-trip. Pass ``m2m_modifiers`` for
     many-to-many fields to surface ``(All)`` / ``(Only)`` pseudo-options in the
-    dropdown alongside the presence options. ``path``/``compose`` let a
-    cross-entity widget point at a nested sub-filter leaf (defaults to the flat
-    ``[field_name]``).
+    dropdown alongside the presence options. ``path`` lets a cross-entity widget
+    point at a nested sub-filter leaf (defaults to the flat ``[field_name]``).
     """
     modifier = _split_modifier(choice.modifier, has_m2m=bool(m2m_modifiers))
     return FilterSelect(
@@ -363,7 +359,6 @@ def _model_filter(
         search_url=search_url,
         prefetch=DEFAULT_PREFETCH,
         path=path if path is not None else [field_name],
-        compose=compose,
     )
 
 
@@ -436,9 +431,9 @@ def _filter_boolean_radio(
     return Div(
         attributes=[
             ("class", "flex flex-col gap-1"),
-            # No ``compose=True``: the relation-bool serializer branch builds and
-            # appends its own AND element directly, returning before it ever reads
-            # ``data-compose`` — so emitting it would be inert and misleading.
+            # The relation-bool serializer branch builds and appends its own AND
+            # element directly from ``data-relation-child``, so the generic
+            # path-length cross-entity branch never applies here.
             *filter_widget_attributes(
                 path,
                 kind,
@@ -843,7 +838,6 @@ def _game_fields(
                         search_url="/api/devices/search",
                         nullable=False,
                         path=["session_filter", "device"],
-                        compose=True,
                     ),
                 ),
                 _filter_field(
@@ -856,7 +850,6 @@ def _game_fields(
                         purchase_type_choice,
                         nullable=False,
                         path=["purchase_filter", "type"],
-                        compose=True,
                     ),
                 ),
                 _filter_field(
@@ -867,7 +860,6 @@ def _game_fields(
                         purchase_ownership_choice,
                         nullable=False,
                         path=["purchase_filter", "ownership_type"],
-                        compose=True,
                     ),
                 ),
                 _filter_field(
@@ -878,7 +870,6 @@ def _game_fields(
                         modifier=playevent_note_modifier,
                         placeholder="e.g. Completed, Started",
                         path=["playevent_filter", "note"],
-                        compose=True,
                     ),
                 ),
                 _filter_field(
@@ -997,7 +988,6 @@ def _game_fields(
                         min_value=finished_min,
                         max_value=finished_max,
                         path=["playevent_filter", "ended"],
-                        compose=True,
                     ),
                 ),
                 _filter_field(
@@ -1024,7 +1014,6 @@ def _game_fields(
                         placeholder2="e.g. 100",
                         step="0.01",
                         path=["purchase_filter", "converted_price"],
-                        compose=True,
                     ),
                 ),
             ],
@@ -1313,7 +1302,6 @@ def _purchase_fields(existing: dict) -> list:
                         min_value=finished_min,
                         max_value=finished_max,
                         path=["game_filter", "playevent_filter", "ended"],
-                        compose=True,
                     ),
                 ),
                 _filter_field(
@@ -1516,7 +1504,6 @@ def StringFilter(
     placeholder: str = "",
     *,
     path: FilterWidgetPath,
-    compose: bool = False,
 ) -> Node:
     """Renders a string filter with 8 modifier radio options and a text input."""
     from common.criteria import Modifier
@@ -1574,7 +1561,7 @@ def StringFilter(
     return Div(
         attributes=[
             ("class", "flex flex-col gap-2 @container"),
-            *filter_widget_attributes(path, "string", compose=compose),
+            *filter_widget_attributes(path, "string"),
         ],
         children=[
             Div(
@@ -1608,7 +1595,6 @@ def NumberFilter(
     step: str = "1",
     *,
     path: FilterWidgetPath,
-    compose: bool = False,
 ) -> Node:
     """Renders a numeric filter with 8 modifier radio options and two inputs.
 
@@ -1679,7 +1665,7 @@ def NumberFilter(
     return Div(
         attributes=[
             ("class", "flex flex-col gap-2 @container"),
-            *filter_widget_attributes(path, "number", compose=compose),
+            *filter_widget_attributes(path, "number"),
         ],
         children=[
             Div(

--- a/common/components/primitives.py
+++ b/common/components/primitives.py
@@ -64,7 +64,6 @@ def filter_widget_attributes(
     path: FilterWidgetPath,
     kind: FilterWidgetKind,
     *,
-    compose: bool = False,
     relation_child: RelationChild | None = None,
 ) -> list[HTMLAttribute]:
     """The self-describe attributes every filter-bar widget root carries.
@@ -74,26 +73,25 @@ def filter_widget_attributes(
     ``[data-filter-widget]`` root to handle all widgets uniformly. See issue #123
     Phase 2.
 
-    Cross-entity widgets (issue #123 Phase 2d) add two optional markers:
+    Cross-entity widgets are recognised by the serializer from their ``data-path``
+    alone: a multi-segment path is a relation chain, so instead of writing the
+    leaf at ``data-path`` top-level the serializer folds ``data-path`` into a
+    nested object and appends it as its own element of the parent's n-ary ``AND``
+    list — several widgets targeting the same relation compose as *independent*
+    EXISTS rather than merging into one shared relation node (issue #123 Phase 2d;
+    issue #138 removed the redundant ``data-compose`` marker).
 
-    - ``compose=True`` emits ``data-compose="and"``: instead of writing the leaf
-      at ``data-path`` top-level, the serializer folds ``data-path`` into a nested
-      object and appends it as its own element of the parent's n-ary ``AND`` list,
-      so several widgets targeting the same relation compose as *independent*
-      EXISTS rather than merging into one shared relation node.
-    - ``relation_child`` (with ``kind="relation-bool"``) supplies the fixed child
-      criterion of a relation toggled by a boolean radio: ``data-path`` is the
-      relation chain *without* a leaf and ``data-relation-child`` is the child
-      keyed by field, e.g. ``{"emulated": {"value": True, "modifier": "EQUALS"}}``.
-      A ``True`` radio matches ANY, ``False`` sets ``match: "NONE"``.
+    ``relation_child`` (with ``kind="relation-bool"``) supplies the fixed child
+    criterion of a relation toggled by a boolean radio: ``data-path`` is the
+    relation chain *without* a leaf and ``data-relation-child`` is the child
+    keyed by field, e.g. ``{"emulated": {"value": True, "modifier": "EQUALS"}}``.
+    A ``True`` radio matches ANY, ``False`` sets ``match: "NONE"``.
     """
     attributes: list[HTMLAttribute] = [
         ("data-filter-widget", ""),
         ("data-path", json.dumps(path)),
         ("data-kind", kind),
     ]
-    if compose:
-        attributes.append(("data-compose", "and"))
     if relation_child is not None:
         attributes.append(("data-relation-child", json.dumps(relation_child)))
     return attributes

--- a/common/components/search_select.py
+++ b/common/components/search_select.py
@@ -462,7 +462,6 @@ def FilterSelect(
     id: str = "",
     free_text: bool = False,
     path: FilterWidgetPath | None = None,
-    compose: bool = False,
 ) -> Node:
     """Include/exclude filter combobox built on the shared ``_combobox_shell``.
 
@@ -575,9 +574,7 @@ def FilterSelect(
     # filter-bar callers pass ``path``; synthetic/test callers leave it None and
     # get no extra attributes (kind is always "set" for a FilterSelect).
     widget_attributes = (
-        filter_widget_attributes(path, "set", compose=compose)
-        if path is not None
-        else []
+        filter_widget_attributes(path, "set") if path is not None else []
     )
     return _SearchSelect(
         widget_attributes,

--- a/tests/test_filter_paths.py
+++ b/tests/test_filter_paths.py
@@ -49,16 +49,15 @@ class WidgetDescriptor(NamedTuple):
 
     path: list[str]
     kind: str
-    compose: str | None
     relation_child: dict | None
 
 
 class _FilterWidgetCollector(HTMLParser):
     """Collect every ``[data-filter-widget]`` start tag's contract attributes.
 
-    Pairs ``data-path``/``data-kind``/``data-compose``/``data-relation-child``
-    within a single element by reading the start tag's own attribute list — no
-    regex pairing across the document.
+    Pairs ``data-path``/``data-kind``/``data-relation-child`` within a single
+    element by reading the start tag's own attribute list — no regex pairing
+    across the document.
     """
 
     def __init__(self) -> None:
@@ -78,7 +77,6 @@ class _FilterWidgetCollector(HTMLParser):
             WidgetDescriptor(
                 json.loads(raw_path),
                 kind,
-                attributes.get("data-compose"),
                 json.loads(raw_child) if raw_child else None,
             )
         )
@@ -175,14 +173,14 @@ def test_no_widget_path_is_a_prefix_of_another(case: _BarCase) -> None:
 
     A leaf/branch collision among top-level widgets (one targeting a sub-filter
     another steps through) would make the ``setPath`` write ambiguous; forbid it.
-    Cross-entity widgets (``data-compose="and"`` / relation-bool) are excluded:
-    they each build their own AND element (independent EXISTS), so several
-    sharing a relation prefix is intended, not a collision."""
+    Cross-entity widgets (multi-segment path / relation-bool) are excluded: they
+    each build their own AND element (independent EXISTS), so several sharing a
+    relation prefix is intended, not a collision."""
     html = str(case.bar_factory(""))
     paths = [
         widget.path
         for widget in _collect_widgets(html)
-        if widget.compose is None and widget.kind != "relation-bool"
+        if len(widget.path) == 1 and widget.kind != "relation-bool"
     ]
     for outer in paths:
         for inner in paths:

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -252,10 +252,11 @@ function buildFilterJSON(form: HTMLElement): Record<string, unknown> {
 
     const result = readWidget(widget, kind);
     if (result === null) return;
-    // Cross-entity leaf (data-compose="and"): nest the leaf under its relation
-    // chain and append it as its own independent EXISTS element of AND, rather
-    // than merging it into a shared top-level relation node.
-    if (widget.getAttribute("data-compose") === "and") {
+    // A multi-segment path is a cross-entity leaf: nest the leaf under its
+    // relation chain and append it as its own independent EXISTS element of AND,
+    // rather than merging it into a shared top-level relation node. A single-
+    // segment path is a plain top-level field, written in place.
+    if (path.length > 1) {
       appendAnd(filter, nest(path, result));
     } else {
       setPath(filter, path, result);


### PR DESCRIPTION
## Summary

Removes the redundant `compose` / `data-compose` channel from the filter widgets. After issue #123 Phase 2d, for non-relation-bool widgets `data-compose="and"` is exactly equivalent to `path.length > 1`: every `compose=True` call site has a multi-segment path, and relation-bool returns from the serializer before the compose check ever runs. The channel duplicated information already carried by the widget's `data-path`.

## Changes

- **`ts/elements/filter-bar.ts`**: `buildFilterJSON` now branches the cross-entity (`appendAnd` + `nest`) vs top-level (`setPath`) decision on `path.length > 1` instead of reading `data-compose`. Relation-bool keeps its own early branch.
- **`common/components/primitives.py`**: dropped the `compose` parameter and `data-compose` emission from `filter_widget_attributes`.
- Stopped threading `compose` through every widget builder + call site: `_enum_filter` / `_model_filter` / `StringFilter` / `NumberFilter` (`filters.py`), `FilterSelect` (`search_select.py`), `DateRangePicker` (`date_range_picker.py`); removed all 7 `compose=True` call-site flags.
- **`tests/test_filter_paths.py`**: dropped the `data-compose` descriptor field; cross-entity widgets are now excluded by `len(path) == 1` instead. Widget counts unchanged (23/8/14/1/2/4).

Relation-bool widgets are unaffected — their serializer branch never read `data-compose`.

## Verification

- `pytest tests/ --ignore=e2e` — 761 passed
- `make ts` clean; `uv run mypy common/ games/` clean; `ruff check` + format clean
- `make css && make ts` + filter e2e (`test_cross_entity_filter_e2e.py`, `test_set_filter_e2e.py`) — 9 passed; cross-entity round-trip confirmed working with path-length branching

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)