### PR TITLE
Fix cross-entity prefill from top-level ?filter= (#137)

### DIFF
--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -173,6 +173,47 @@ def _string_from_field(field: dict) -> StringValues:
 # sub-filter element (independent EXISTS), so prefill scans that list rather than
 # reading a flat top-level key. Each helper is matched to a widget by the same
 # ``data-path`` the widget serializes to — a single source of truth.
+#
+# Two producers write cross-entity sub-filters in DIFFERENT shapes (#137): the
+# filter bar wraps each in its own ``AND`` element, while stats-links /
+# ``filter_url`` emit them TOP-LEVEL (e.g. ``{"session_filter": {...}}``). Both
+# are valid for ``to_q``, but the helpers below read only ``existing["AND"]``.
+# ``_canonicalize_cross_entity`` folds the top-level shape into ``AND`` once (in
+# ``_FilterBarBase.__init__``) so the helpers have a single canonical shape to
+# read — the fix is concentrated in one place instead of every read helper.
+
+
+def _canonicalize_cross_entity(existing: dict) -> dict:
+    """Fold TOP-LEVEL cross-entity sub-filters into ``existing["AND"]`` (#137).
+
+    Cross-entity relation sub-filters are the OperatorFilter ``*_filter`` fields
+    (``session_filter``, ``purchase_filter``, ``game_filter``, …). When they
+    arrive at the top level (stats-links / ``filter_url``) rather than wrapped in
+    ``AND`` (the bar), the prefill helpers — which scan only ``existing["AND"]``
+    — would miss them and render the matching widget blank, silently dropping the
+    constraint on re-Apply. Each such top-level key is moved into its own ``AND``
+    element (mirroring the bar's per-widget serialization), appended after any
+    existing ``AND`` elements.
+
+    Operator lists (``AND`` / ``OR`` / ``NOT``) and flat criterion keys are left
+    untouched. Returns a shallow copy when anything moves; the raw ``filter_json``
+    (re-serialized on Apply) is never touched, so ``to_q`` semantics are
+    unchanged — only what prefill reads.
+    """
+    relation_keys = [
+        key
+        for key, value in existing.items()
+        if key.endswith("_filter") and isinstance(value, dict)
+    ]
+    if not relation_keys:
+        return existing
+    canonical = {
+        key: value for key, value in existing.items() if key not in relation_keys
+    }
+    and_elements = list(canonical.get("AND") or [])
+    and_elements.extend({key: existing[key]} for key in relation_keys)
+    canonical["AND"] = and_elements
+    return canonical
 
 
 def _deep_get(value: dict, keys: FilterWidgetPath) -> object:
@@ -683,7 +724,10 @@ class _FilterBarBase(BaseComponent):
         self.filter_json = filter_json
         self.preset_list_url = preset_list_url
         self.preset_save_url = preset_save_url
-        self.existing = _filter_parse(filter_json)
+        # Canonicalize TOP-LEVEL cross-entity sub-filters (stats-links /
+        # filter_url) into the bar's AND shape so prefill reads a single shape
+        # and stats-link landings pre-fill their widgets (#137).
+        self.existing = _canonicalize_cross_entity(_filter_parse(filter_json))
 
     def build_fields(self) -> list:
         """Return the per-entity filter body. Implemented by each subclass."""

--- a/tests/test_filter_cross_entity.py
+++ b/tests/test_filter_cross_entity.py
@@ -651,3 +651,74 @@ def test_game_bar_prefills_refunded_false_and_infinite_true_independently(db):
     assert re.search(
         r'name="filter-purchase-infinite"[^>]*value="true"[^>]*checked', html
     )
+
+
+# ── prefill: TOP-LEVEL cross-entity shape (stats-link / filter_url) (#137) ────
+# stats_links / filter_url emit cross-entity sub-filters TOP-LEVEL (no AND
+# wrapper), e.g. {"session_filter": {"device": {...}}}. to_q honours that shape,
+# but prefill historically scanned only existing["AND"], so the matching bar
+# widget rendered BLANK — re-applying the bar silently dropped the constraint.
+# _canonicalize_cross_entity folds the top-level shape into AND so prefill
+# repopulates the widget. The AND-shape tests above stay green — both work.
+
+
+def test_game_bar_prefills_device_from_top_level(db):
+    """Top-level (no AND) session_filter→device prefills the device pill."""
+    deck = Device.objects.create(name="SteamDeck", type=Device.HANDHELD)
+    filter_json = json.dumps(
+        {"session_filter": {"device": _set_criterion(str(deck.id), "SteamDeck")}}
+    )
+    html = str(FilterBar(filter_json))
+    assert "SteamDeck" in html
+
+
+def test_purchase_bar_prefills_finished_from_top_level(db):
+    """Top-level game_filter→playevent_filter→ended prefills the date widget."""
+    filter_json = json.dumps(
+        {
+            "game_filter": {
+                "playevent_filter": {
+                    "ended": {
+                        "value": "2024-01-01",
+                        "value2": "2024-12-31",
+                        "modifier": "BETWEEN",
+                    }
+                }
+            }
+        }
+    )
+    html = str(PurchaseFilterBar(filter_json))
+    assert "2024-01-01" in html
+    assert "2024-12-31" in html
+
+
+def test_game_bar_prefills_session_emulated_true_radio_from_top_level(db):
+    """Top-level (no AND) relation-bool checks the 'True' radio."""
+    filter_json = json.dumps(
+        {"session_filter": {"emulated": {"value": True, "modifier": "EQUALS"}}}
+    )
+    html = str(FilterBar(filter_json))
+    assert re.search(
+        r'name="filter-session-emulated"[^>]*value="true"[^>]*checked', html
+    )
+
+
+def test_game_bar_prefills_top_level_alongside_existing_and(db):
+    """A top-level relation key merges with (does not clobber) an existing AND.
+
+    Mixed shape — one cross-entity constraint already in AND (purchase type) plus
+    a top-level one (session device) — prefills both widgets."""
+    deck = Device.objects.create(name="SteamDeck", type=Device.HANDHELD)
+    filter_json = json.dumps(
+        {
+            "AND": [{"purchase_filter": {"type": _set_criterion("game", "Game")}}],
+            "session_filter": {"device": _set_criterion(str(deck.id), "SteamDeck")},
+        }
+    )
+    html = str(FilterBar(filter_json))
+    assert "SteamDeck" in html
+    include_pills = re.findall(
+        r'data-pill[^>]*?data-value="([^"]+)"[^>]*?data-search-select-type="include"',
+        html,
+    )
+    assert include_pills.count("game") == 1


### PR DESCRIPTION
## Problem

Two producers write the `?filter=` JSON's cross-entity sub-filters in **different shapes**:

- The **filter bar** wraps each in its own `AND` element:
  `{"AND":[{"session_filter":{"device":{...}}}]}`
- **`games/views/stats_links.py` / `filter_url`** emit them **TOP-LEVEL**:
  `{"game_filter":{"playevent_filter":{"ended":{...}}}}` (also `{"session_filter":{...}}`, etc.)

Both shapes are valid for `to_q`, so the list filters correctly either way. But the bar's prefill helpers (`_cross_entity_criterion` / `_cross_entity_bool` in `common/components/filters.py`) scanned **only** `existing["AND"]`. So clicking a stats link landed the user on a correctly-filtered list with the matching bar widget rendered **blank** — and if they opened the bar and hit Apply, the cross-entity constraint was **silently dropped** (re-serialized from an empty widget).

## Fix

This takes the issue's **preferred option (a)**: canonicalize the top-level shape into `AND` **once**, in `_FilterBarBase.__init__`, via a new `_canonicalize_cross_entity()` helper. Each top-level `*_filter` sub-filter is moved into its own `AND` element (mirroring the bar's per-widget serialization), appended after any existing `AND` elements.

The prefill helpers keep their single AND-only read path, so:

- the two-producer-shape knowledge lives in **exactly one place** instead of being duplicated as a dual-read across every helper;
- any future cross-entity widget works automatically — no per-helper changes;
- `to_q` and serialization are **untouched** (the raw `filter_json` re-serialized on Apply is never mutated) — only what prefill *reads* changes.

Mixed shapes (an existing `AND` list plus a top-level relation key) merge rather than clobber.

## Tests

`tests/test_filter_cross_entity.py` gains regression tests proving a TOP-LEVEL (no-`AND`) cross-entity filter prefills the widget:

- games-bar device pill from top-level `session_filter→device`
- purchase-bar `finished` date widget from top-level `game_filter→playevent_filter→ended`
- games-bar relation-bool `emulated` True radio from top-level `session_filter→emulated`
- mixed top-level + existing-`AND` shape prefills both widgets (merge, not clobber)

The existing AND-shape prefill tests stay green — both shapes work.

## Verification

- `uv run --with pytest-django pytest tests/ --ignore=e2e -q` → 765 passed, 56 subtests passed
- `uv run mypy common/ games/` → clean
- `uv run ruff check` + `ruff format --check` on touched files → clean

Closes #137

## Note on #143

This supersedes #143, which implemented the issue's option (b) (a dual-read inside each `_cross_entity_*` helper). Option (a) was chosen as the lower-maintenance, single-source-of-truth approach the issue marks as preferred. Closing #143 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvJACNzfNJUUw5YS5pFrfH)_