### PR TITLE
test(filters): fix main CI — duration tests referenced renamed field

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -192,7 +192,7 @@ def test_session_list_malformed_filter_rejected(auth_client):
 def test_session_list_invalid_filter_semantics_rejected(auth_client):
     # Parseable JSON but a build-time-invalid filter (BETWEEN without value2) must
     # also be a 400, not a 500.
-    bad = json.dumps({"duration_hours": {"modifier": "BETWEEN", "value": 1}})
+    bad = json.dumps({"duration_total_hours": {"modifier": "BETWEEN", "value": 1}})
     response = auth_client.get(f"/api/session/?filter={bad}")
     assert response.status_code == 400
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1354,7 +1354,7 @@ class TestFilterErrorBoundary:
             parse_session_filter(bad)
 
     def test_between_without_value2_duration(self):
-        bad = json.dumps({"duration_hours": {"modifier": "BETWEEN", "value": 1}})
+        bad = json.dumps({"duration_total_hours": {"modifier": "BETWEEN", "value": 1}})
         with pytest.raises(FilterError, match="BETWEEN requires"):
             parse_session_filter(bad)
 
@@ -1398,7 +1398,11 @@ class TestFilterErrorBoundary:
         """An invalid criterion inside a cross-entity sub-filter must raise —
         relation_to_q exercises sub.to_q() during the eager build."""
         bad = json.dumps(
-            {"session_filter": {"duration_hours": {"modifier": "BETWEEN", "value": 1}}}
+            {
+                "session_filter": {
+                    "duration_total_hours": {"modifier": "BETWEEN", "value": 1}
+                }
+            }
         )
         with pytest.raises(FilterError, match="BETWEEN requires"):
             parse_game_filter(bad)
@@ -1425,7 +1429,9 @@ class TestFilterErrorBoundary:
     def test_non_numeric_duration_value(self):
         """A non-numeric duration value makes timedelta() raise TypeError during
         the eager build; the boundary reclassifies it to FilterError."""
-        bad = json.dumps({"duration_hours": {"modifier": "GREATER_THAN", "value": "x"}})
+        bad = json.dumps(
+            {"duration_total_hours": {"modifier": "GREATER_THAN", "value": "x"}}
+        )
         with pytest.raises(FilterError):
             parse_session_filter(bad)
 
@@ -1443,7 +1449,7 @@ class TestFilterErrorBoundary:
             {
                 "session_filter": {
                     "match": "ALL",
-                    "duration_hours": {"modifier": "BETWEEN", "value": 1},
+                    "duration_total_hours": {"modifier": "BETWEEN", "value": 1},
                 }
             }
         )

--- a/tests/test_rendered_pages.py
+++ b/tests/test_rendered_pages.py
@@ -593,7 +593,7 @@ class GameListSessionFilterBoundaryTest(TestCase):
             json.dumps(
                 {
                     "session_filter": {
-                        "duration_hours": {"modifier": "BETWEEN", "value": 1}
+                        "duration_total_hours": {"modifier": "BETWEEN", "value": 1}
                     }
                 }
             )


### PR DESCRIPTION
Fixes red `main` after #156 merged.

#156's boundary tests filtered on `duration_hours`, a `SessionFilter` field that was renamed to `duration_total_hours` on main (in an earlier merge) before #156 landed. The squash brought tests referencing the dead field onto a main that no longer has it. `from_json` silently ignores unknown fields, so the "invalid duration filter" never raised → the expected 400 (API) / warn-and-ignore (view) assertions failed.

Repoints every duration test at `duration_total_hours`, which `SessionFilter.to_q()` actually consumes via `duration_hours_to_q`, so the BETWEEN/type guards are exercised as intended.

Test-only. Full suite green locally (783 passed), including the three previously-failing tests run in isolation (order-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)