### PR TITLE
feat(filters): string-contains field comparison (INCLUDES/EXCLUDES) (#164)

### DIFF
--- a/common/criteria.py
+++ b/common/criteria.py
@@ -101,8 +101,14 @@ class Modifier(str, Enum):
         ]
 
     @classmethod
-    def for_field_comparisons(cls) -> list[Self]:
+    def for_ordered_field_comparisons(cls) -> list[Self]:
+        """Equality + ordering — valid for every comparable group (numeric/date/string)."""
         return [cls.EQUALS, cls.NOT_EQUALS, cls.GREATER_THAN, cls.LESS_THAN]
+
+    @classmethod
+    def for_field_comparisons(cls) -> list[Self]:
+        """Full field-comparison vocabulary: ordering + string containment (string-only)."""
+        return [*cls.for_ordered_field_comparisons(), cls.INCLUDES, cls.EXCLUDES]
 
 
 # ── Relation match-mode ──────────────────────────────────────────────────────
@@ -472,6 +478,15 @@ class FieldComparisonCriterion(_Criterion):
     column is NULL only under schema drift / raw inserts). Ordered comparisons
     (``<``, ``>``) and EQUALS instead *exclude* NULL rows, because the SQL
     expression is NULL (unknown) when either operand is NULL.
+
+    String containment (string operands only, case-insensitive ``__icontains``):
+    INCLUDES (``left__icontains=F(right)``) excludes NULL rows like EQUALS/ordered
+    — the ``LIKE`` is NULL/unknown when either operand is NULL. EXCLUDES
+    (``~Q(left__icontains=F(right))``) mirrors NOT_EQUALS: Django appends an
+    ``IS NOT NULL`` guard per *nullable* operand, so a NULL on a nullable side
+    *includes* the row (symmetric when both are nullable). Empty-string note: an
+    empty ``right`` (``""``, not NULL) is a substring of every non-NULL ``left``,
+    so INCLUDES then matches all rows with a non-NULL ``left``.
     """
 
     # Shadow the inherited `value` field: FieldComparisonCriterion has no
@@ -483,7 +498,9 @@ class FieldComparisonCriterion(_Criterion):
     right: str = ""
     modifier: Modifier = Modifier.EQUALS
 
-    def to_q(self, field_name: str = "") -> Q:  # field_name ignored; operands self-contained
+    def to_q(
+        self, field_name: str = ""
+    ) -> Q:  # field_name ignored; operands self-contained
         return _field_comparison_to_q(self.left, self.right, self.modifier)
 
     def to_json(self) -> dict[str, Any]:
@@ -594,7 +611,9 @@ type RelationChild = dict[
 # one exception: ``"field-comparison"`` is registered to satisfy the
 # _CRITERION_TYPES/_CRITERION_KINDS parity invariant but is never path-reachable —
 # ``field_comparisons`` is a list field, so no path resolves to it (no widget yet).
-type LeafWidgetKind = Literal["string", "number", "date", "bool", "set", "field-comparison"]
+type LeafWidgetKind = Literal[
+    "string", "number", "date", "bool", "set", "field-comparison"
+]
 
 # Every widget ``data-kind`` token the filter-bar serializer dispatches on.
 # ``relation-bool`` extends the leaf kinds: it describes not a leaf criterion but
@@ -607,7 +626,9 @@ type FilterWidgetKind = LeafWidgetKind | Literal["relation-bool"]
 # The DB type "bucket" used to verify that two columns being compared
 # field-to-field share the same kind (e.g. both "date", both "number").
 # date and datetime are intentionally SEPARATE groups.
-type ComparisonGroup = Literal["date", "datetime", "duration", "number", "string", "bool"]
+type ComparisonGroup = Literal[
+    "date", "datetime", "duration", "number", "string", "bool"
+]
 
 _GROUP_BY_INTERNAL_TYPE: dict[str, ComparisonGroup] = {
     "DateField": "date",
@@ -1115,11 +1136,13 @@ def _numeric_to_q(
 def _field_comparison_to_q(left: str, right: str, modifier: Modifier) -> Q:
     """Build a Q comparing two model columns: ``left <op> F(right)``.
 
-    Used by field-to-field comparison criteria. Only the four ordered/equality
-    modifiers are supported; anything else raises FilterError. The
-    ``_apply_operators`` caller pre-validates the modifier via
-    ``_allowed_comparison_modifiers`` before calling this function, so the
-    final ``raise FilterError`` is a defensive guard not reached in normal use.
+    Used by field-to-field comparison criteria. Six modifiers are supported: the
+    four ordered/equality ones (EQUALS, NOT_EQUALS, GREATER_THAN, LESS_THAN) plus
+    case-insensitive string containment (INCLUDES, EXCLUDES) — the latter two are
+    gated to string operands by ``_allowed_comparison_modifiers``. Anything else
+    raises FilterError. The ``_apply_operators`` caller pre-validates the modifier
+    against the operand group before calling this function, so the final
+    ``raise FilterError`` is a defensive guard not reached in normal use.
     """
     if modifier == Modifier.EQUALS:
         return Q(**{left: F(right)})
@@ -1129,6 +1152,10 @@ def _field_comparison_to_q(left: str, right: str, modifier: Modifier) -> Q:
         return Q(**{f"{left}__gt": F(right)})
     if modifier == Modifier.LESS_THAN:
         return Q(**{f"{left}__lt": F(right)})
+    if modifier == Modifier.INCLUDES:
+        return Q(**{f"{left}__icontains": F(right)})
+    if modifier == Modifier.EXCLUDES:
+        return ~Q(**{f"{left}__icontains": F(right)})
     raise FilterError(f"Unsupported modifier {modifier} for field comparison")
 
 
@@ -1169,10 +1196,16 @@ def _comparison_group_for(model: type[models.Model], column: str) -> ComparisonG
 
 
 def _allowed_comparison_modifiers(group: ComparisonGroup) -> list[Modifier]:
-    """Modifiers valid for a comparison group: bool is equality-only; all others ordered."""
+    """Modifiers valid for a comparison group.
+
+    bool is equality-only; string adds case-insensitive containment
+    (INCLUDES/EXCLUDES) on top of ordering; all other groups are ordered-only.
+    """
     if group == "bool":
         return [Modifier.EQUALS, Modifier.NOT_EQUALS]
-    return Modifier.for_field_comparisons()
+    if group == "string":
+        return Modifier.for_field_comparisons()
+    return Modifier.for_ordered_field_comparisons()
 
 
 def duration_hours_to_q(

--- a/docs/superpowers/specs/2026-06-28-field-comparison-criterion-adversarial-review.md
+++ b/docs/superpowers/specs/2026-06-28-field-comparison-criterion-adversarial-review.md
@@ -97,8 +97,8 @@ For the current scale of the application, full table scans are extremely fast (S
 
 ## 4. Future Extensions
 
-### 4.1 String Substring Containment Modifiers
-The initial implementation supports `EQUALS`, `NOT_EQUALS`, `GREATER_THAN`, and `LESS_THAN`. 
+### 4.1 String Substring Containment Modifiers — ✅ implemented (#164)
+The initial implementation supports `EQUALS`, `NOT_EQUALS`, `GREATER_THAN`, and `LESS_THAN`. `INCLUDES`/`EXCLUDES` for string operands were added in #164 — see `docs/superpowers/specs/2026-06-28-string-field-comparison-design.md`.
 
 Because Django supports `F()` expressions inside string containment lookups (verified — `name__icontains=F("sort_name")` compiles to valid `LIKE` SQL on SQLite), future iterations could support:
 * `INCLUDES` -> `Q(**{f"{left}__icontains": F(right)})`

--- a/docs/superpowers/specs/2026-06-28-string-field-comparison-design.md
+++ b/docs/superpowers/specs/2026-06-28-string-field-comparison-design.md
@@ -1,0 +1,89 @@
+# String-contains field comparison (INCLUDES/EXCLUDES) — design (#164)
+
+## Context
+
+Field-to-field comparison (#129) lets a filter compare two model columns via Django
+`F()` expressions (`left <op> right`), with the operands type-checked against the
+filter's model. The initial implementation supported four modifiers: `EQUALS`,
+`NOT_EQUALS`, `GREATER_THAN`, `LESS_THAN`.
+
+The #129 adversarial review (§4.1) flagged a zero-machinery extension: Django accepts an
+`F()` expression as the RHS of a string-containment lookup
+(`name__icontains=F("sort_name")` compiles to valid `LIKE`/`ILIKE` SQL). This change
+(#164) adds **INCLUDES / EXCLUDES** as field-comparison modifiers, gated to **string**
+operands. Concrete use case: find games whose `name` contains their `sort_name`.
+
+Independent of #162 (numeric/date `>=`/`<=` ordering operators).
+
+## Decisions
+
+- **Case-insensitive `__icontains`** (not `__contains`) — matches `StringCriterion.INCLUDES`
+  and keeps PostgreSQL `ILIKE` parity.
+- **String keeps all six operators.** String columns already allowed lexicographic
+  `GREATER_THAN`/`LESS_THAN` field comparison; that stays. The new branch adds
+  `INCLUDES`/`EXCLUDES` on top → string = EQUALS, NOT_EQUALS, GREATER_THAN, LESS_THAN,
+  INCLUDES, EXCLUDES. Numeric/date/datetime/duration groups stay ordered-only (no
+  containment); bool stays equality-only.
+- **Backend-only.** Filter algebra + tests + docs. No filter-bar UI widget (matches
+  #129's deferral).
+
+## Implementation
+
+Three touch-points in `common/criteria.py`, all on the existing `FieldComparisonCriterion`
+(no new criterion class):
+
+1. **`Modifier`** — split the field-comparison vocabulary into an ordered subset and a
+   full set, so there are no duplicated literals:
+   - `for_ordered_field_comparisons()` → `[EQUALS, NOT_EQUALS, GREATER_THAN, LESS_THAN]`
+     (valid for every comparable group).
+   - `for_field_comparisons()` → ordered subset + `[INCLUDES, EXCLUDES]` (the full,
+     string-eligible set).
+
+2. **`_allowed_comparison_modifiers(group)`** — per-group gating:
+   - `bool` → `[EQUALS, NOT_EQUALS]`
+   - `string` → `for_field_comparisons()` (all six)
+   - otherwise (number/date/datetime/duration) → `for_ordered_field_comparisons()`
+
+3. **`_field_comparison_to_q(left, right, modifier)`** — two new cases:
+   - `INCLUDES` → `Q(**{f"{left}__icontains": F(right)})`
+   - `EXCLUDES` → `~Q(**{f"{left}__icontains": F(right)})`
+
+The existing `OperatorFilter._apply_operators` validation (same-group requirement,
+modifier-allowed check, self-compare/relation/unknown-column rejection) already covers the
+new modifiers: a `INCLUDES` on a non-string comparison raises `FilterError` because the
+modifier is not in that group's allowed set, and both operands must share the `string`
+group, so no cross-type containment is possible.
+
+## NULL & empty-string semantics
+
+- **INCLUDES** (`left__icontains=F(right)`) — `LIKE` is NULL/unknown when either operand is
+  NULL, so NULL rows are **excluded** (same as `EQUALS`/ordered).
+- **EXCLUDES** (`~Q(left__icontains=F(right))`) — mirrors `NOT_EQUALS`: Django appends an
+  `IS NOT NULL` guard per *nullable* operand, so a NULL on a nullable side **includes** the
+  row (symmetric when both are nullable). When both operands are non-nullable, EXCLUDES is
+  the exact complement of INCLUDES.
+- **Empty string** — an empty `right` (`""`, not NULL) is a substring of every non-NULL
+  `left`, so INCLUDES then matches all rows with a non-NULL `left`. Documented in the
+  `FieldComparisonCriterion` docstring because `sort_name` (and similar) default to `""`.
+
+## Tests (`tests/test_filters.py`, extending existing T1–T5 classes)
+
+- **T1** — `_field_comparison_to_q` helper cases for INCLUDES/EXCLUDES; updated
+  `for_field_comparisons()` (now six) and new `for_ordered_field_comparisons()` (four).
+- **T2** — `_allowed_comparison_modifiers`: string group adds containment (and keeps
+  ordering); number group excludes containment; date group updated to the ordered subset.
+- **T3** — INCLUDES on a string-group comparison builds the expected Q; INCLUDES on a
+  number-group comparison raises `FilterError`.
+- **T5** — DB-backed `Game.name` INCLUDES/EXCLUDES `Game.sort_name`: containment match,
+  non-match (EXCLUDES complement), case-insensitivity, empty-string semantics, and a JSON
+  round-trip through `parse_game_filter`.
+
+## Verification
+
+- `uv run --with pytest-django pytest tests/test_filters.py` — all green.
+- `make typecheck` (mypy) and `make lint` (ruff) — clean.
+
+## Out of scope
+
+- Filter-bar UI widget for field comparisons (deferred, as in #129).
+- Numeric/date `>=`/`<=` operators (#162).

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1512,6 +1512,16 @@ class TestFieldComparisonCriterion:
             "date_refunded", "date_purchased", Modifier.LESS_THAN
         ) == Q(date_refunded__lt=F("date_purchased"))
 
+    def test_helper_includes(self):
+        assert _field_comparison_to_q("name", "sort_name", Modifier.INCLUDES) == Q(
+            name__icontains=F("sort_name")
+        )
+
+    def test_helper_excludes(self):
+        assert _field_comparison_to_q("name", "sort_name", Modifier.EXCLUDES) == ~Q(
+            name__icontains=F("sort_name")
+        )
+
     def test_helper_unsupported_modifier_raises(self):
         with pytest.raises(FilterError, match="Unsupported modifier"):
             _field_comparison_to_q("date_refunded", "date_purchased", Modifier.BETWEEN)
@@ -1567,12 +1577,23 @@ class TestFieldComparisonCriterion:
 
     # ── Modifier.for_field_comparisons ───────────────────────────────────────
 
+    def test_for_ordered_field_comparisons(self):
+        assert Modifier.for_ordered_field_comparisons() == [
+            Modifier.EQUALS,
+            Modifier.NOT_EQUALS,
+            Modifier.GREATER_THAN,
+            Modifier.LESS_THAN,
+        ]
+
     def test_for_field_comparisons(self):
+        """Full set = ordered subset plus string containment (INCLUDES/EXCLUDES)."""
         assert Modifier.for_field_comparisons() == [
             Modifier.EQUALS,
             Modifier.NOT_EQUALS,
             Modifier.GREATER_THAN,
             Modifier.LESS_THAN,
+            Modifier.INCLUDES,
+            Modifier.EXCLUDES,
         ]
 
 
@@ -1666,7 +1687,25 @@ class TestComparisonGroupResolver:
         ]
 
     def test_date_group_is_ordered(self):
-        assert _allowed_comparison_modifiers("date") == Modifier.for_field_comparisons()
+        assert (
+            _allowed_comparison_modifiers("date")
+            == Modifier.for_ordered_field_comparisons()
+        )
+
+    def test_number_group_excludes_containment(self):
+        allowed = _allowed_comparison_modifiers("number")
+        assert allowed == Modifier.for_ordered_field_comparisons()
+        assert Modifier.INCLUDES not in allowed
+        assert Modifier.EXCLUDES not in allowed
+
+    def test_string_group_adds_containment(self):
+        allowed = _allowed_comparison_modifiers("string")
+        assert allowed == Modifier.for_field_comparisons()
+        assert Modifier.INCLUDES in allowed
+        assert Modifier.EXCLUDES in allowed
+        # string keeps lexicographic ordering too
+        assert Modifier.GREATER_THAN in allowed
+        assert Modifier.LESS_THAN in allowed
 
 
 # ── T3 — OperatorFilter field_comparisons wiring ─────────────────────────────
@@ -1724,7 +1763,11 @@ class TestFieldComparisonWiring:
         serialized = stub.to_json()
         assert "field_comparisons" in serialized
         assert serialized["field_comparisons"] == [
-            {"left": "date_refunded", "right": "date_purchased", "modifier": Modifier.LESS_THAN}
+            {
+                "left": "date_refunded",
+                "right": "date_purchased",
+                "modifier": Modifier.LESS_THAN,
+            }
         ]
 
     def test_empty_field_comparisons_omitted_from_json(self):
@@ -1798,6 +1841,31 @@ class TestFieldComparisonWiring:
         with pytest.raises(FilterError):
             stub.to_q()
 
+    def test_includes_on_string_group_ok(self):
+        stub = _PurchaseStub(
+            field_comparisons=[
+                FieldComparisonCriterion(
+                    left="price_currency",
+                    right="converted_currency",
+                    modifier=Modifier.INCLUDES,
+                )
+            ]
+        )
+        assert stub.to_q() == Q(price_currency__icontains=F("converted_currency"))
+
+    def test_includes_on_number_group_raises(self):
+        stub = _PurchaseStub(
+            field_comparisons=[
+                FieldComparisonCriterion(
+                    left="price",
+                    right="converted_price",
+                    modifier=Modifier.INCLUDES,
+                )
+            ]
+        )
+        with pytest.raises(FilterError):
+            stub.to_q()
+
     def test_relation_column_raises(self):
         stub = _PurchaseStub(
             field_comparisons=[
@@ -1859,7 +1927,11 @@ class TestFieldComparisonWiring:
     def test_integration_bad_column_raises_on_to_q(self):
         bad_json = {
             "field_comparisons": [
-                {"left": "nonexistent", "right": "date_purchased", "modifier": "LESS_THAN"}
+                {
+                    "left": "nonexistent",
+                    "right": "date_purchased",
+                    "modifier": "LESS_THAN",
+                }
             ]
         }
         parsed = _PurchaseStub.from_json(bad_json)
@@ -2254,9 +2326,7 @@ class TestFieldComparisonEndToEnd:
         from games.filters import PlayEventFilter
         from games.models import Game, PlayEvent, Platform
 
-        platform, _ = Platform.objects.get_or_create(
-            name="PESym", icon="pesym"
-        )
+        platform, _ = Platform.objects.get_or_create(name="PESym", icon="pesym")
         game = Game.objects.create(name="PESymGame", platform=platform)
 
         # different (both set) → included
@@ -2395,3 +2465,74 @@ class TestFieldComparisonEndToEnd:
         assert parsed_filter is not None
         result = set(Purchase.objects.filter(parsed_filter.to_q()))
         assert result == {purchase_a}
+
+    def test_string_includes_excludes_end_to_end(self):
+        """Game.name INCLUDES/EXCLUDES Game.sort_name, case-insensitively.
+
+        - M (name contains sort_name) matches INCLUDES, not EXCLUDES.
+        - N (name does not contain sort_name) matches EXCLUDES, not INCLUDES.
+        - P (different case) matches INCLUDES — __icontains is case-insensitive.
+        - O (empty sort_name) matches INCLUDES — "" is a substring of every name.
+        Both operands are non-nullable, so EXCLUDES is the exact complement.
+        """
+        from games.filters import GameFilter
+        from games.models import Game, Platform
+
+        platform, _ = Platform.objects.get_or_create(
+            name="StrCmpTest", icon="strcmptest"
+        )
+        match = Game.objects.create(
+            name="The Legend of Zelda", sort_name="Zelda", platform=platform
+        )
+        no_match = Game.objects.create(name="Halo", sort_name="Doom", platform=platform)
+        case_insensitive = Game.objects.create(
+            name="DARK SOULS", sort_name="dark", platform=platform
+        )
+        empty_sort = Game.objects.create(name="Tetris", sort_name="", platform=platform)
+
+        includes = GameFilter(
+            field_comparisons=[
+                FieldComparisonCriterion(
+                    left="name", right="sort_name", modifier=Modifier.INCLUDES
+                )
+            ]
+        )
+        assert set(Game.objects.filter(includes.to_q())) == {
+            match,
+            case_insensitive,
+            empty_sort,
+        }
+
+        excludes = GameFilter(
+            field_comparisons=[
+                FieldComparisonCriterion(
+                    left="name", right="sort_name", modifier=Modifier.EXCLUDES
+                )
+            ]
+        )
+        assert set(Game.objects.filter(excludes.to_q())) == {no_match}
+
+    def test_json_round_trip_game_string_includes(self):
+        """A string INCLUDES field comparison survives JSON serialization."""
+        from common.criteria import filter_to_json
+        from games.filters import GameFilter, parse_game_filter
+        from games.models import Game, Platform
+
+        platform, _ = Platform.objects.get_or_create(
+            name="StrCmpTest", icon="strcmptest"
+        )
+        match = Game.objects.create(
+            name="Super Mario Bros", sort_name="Mario", platform=platform
+        )
+        Game.objects.create(name="Pong", sort_name="Snake", platform=platform)
+
+        game_filter = GameFilter(
+            field_comparisons=[
+                FieldComparisonCriterion(
+                    left="name", right="sort_name", modifier=Modifier.INCLUDES
+                )
+            ]
+        )
+        parsed_filter = parse_game_filter(filter_to_json(game_filter))
+        assert parsed_filter is not None
+        assert set(Game.objects.filter(parsed_filter.to_q())) == {match}


### PR DESCRIPTION
Closes #164. Follow-up from #129 (adversarial-review §4.1).

## What

Adds case-insensitive text-to-text containment to field-to-field comparison via Django `F()` expressions, gated to **string** operands:

- `INCLUDES` → `Q(left__icontains=F(right))`
- `EXCLUDES` → `~Q(left__icontains=F(right))`

Concrete use case: find games whose `name` contains their `sort_name`.

## Changes (`common/criteria.py`, 3 touch-points)

- **`Modifier`** — split into `for_ordered_field_comparisons()` (the four ordered/equality ops, valid for every comparable group) and `for_field_comparisons()` (full set = ordered + `INCLUDES`/`EXCLUDES`).
- **`_allowed_comparison_modifiers`** — new `string` branch returns the full set; numeric/date/datetime/duration stay ordered-only; bool stays equality-only. **String keeps lexicographic `>`/`<`** (no regression).
- **`_field_comparison_to_q`** — two new cases (`INCLUDES`/`EXCLUDES`).
- **`FieldComparisonCriterion` docstring** — NULL + empty-string semantics.

## NULL / empty-string semantics

- `INCLUDES` excludes NULL rows (`LIKE` is unknown when either operand is NULL).
- `EXCLUDES` mirrors `NOT_EQUALS`: per-nullable-operand `IS NOT NULL` guard → symmetric NULL inclusion when both nullable; exact complement when both non-nullable.
- Empty `right` (`""`, not NULL) is a substring of every non-NULL `left`.

## Tests

Extend existing T1–T5 classes in `tests/test_filters.py`: helper cases, per-group gating (string adds containment, number does not), wiring raise-on-number, and DB-backed `Game.name` INCLUDES/EXCLUDES (case-insensitivity, empty-string, JSON round-trip). **199 filter tests pass; mypy + ruff + format clean.**

## Scope

Backend-only (filter algebra + tests + spec doc), matching #129's deferral. No filter-bar UI widget — tracked separately. Independent of #162 (numeric/date `>=`/`<=`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)