### PR TITLE
feat(filters): field-to-field comparison filter-bar UI (#167)

### DIFF
--- a/common/components/__init__.py
+++ b/common/components/__init__.py
@@ -56,6 +56,7 @@ from common.components.domain import (
 )
 from common.components.filters import (
     DeviceFilterBar,
+    FieldComparisonSet,
     FilterBar,
     NumberFilter,
     PlatformFilterBar,
@@ -91,12 +92,14 @@ from common.components.primitives import (
     Modal,
     ModuleScript,
     Nav,
+    Option,
     Pill,
     Popover,
     Column,
     PopoverTruncated,
     Radio,
     SearchField,
+    Select,
     Span,
     StaticScript,
     StyledButton,
@@ -240,4 +243,7 @@ __all__ = [
     "PlayEventFilterBar",
     "StringFilter",
     "NumberFilter",
+    "FieldComparisonSet",
+    "Option",
+    "Select",
 ]

--- a/common/components/custom_elements.py
+++ b/common/components/custom_elements.py
@@ -153,6 +153,15 @@ register_element("date-range-picker", "DateRangePicker", DateRangePickerProps)
 _DateRangePicker = custom_element_builder("date-range-picker")
 
 
+class FieldComparisonSetProps(TypedDict):
+    columns: str  # JSON of list[ComparableColumn] — drives client option building
+    mode: str  # "AND" | "OR" — how the comparison rows combine
+
+
+register_element("field-comparison-set", "FieldComparisonSet", FieldComparisonSetProps)
+_FieldComparisonSet = custom_element_builder("field-comparison-set")
+
+
 # The <sort-header> builder lives in primitives.py (next to StyledTable, which
 # renders it). Its whole contract is two plain attributes already on the anchor
 # (href + data-shift-href), so the props are empty; registration here is

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -745,8 +745,7 @@ def _field_comparison_row(
             ("data-fc-row", ""),
             (
                 "class",
-                "grid grid-cols-1 gap-2 items-center "
-                "@md:grid-cols-[1fr_auto_1fr_auto]",
+                "grid grid-cols-1 gap-2 items-center md:grid-cols-[1fr_auto_1fr_auto]",
             ),
         ],
         children=[

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -2,8 +2,10 @@
 
 from typing import NamedTuple
 
+from django.db import models
+
 from common.components.core import BaseComponent, Element, Node, Safe
-from common.components.custom_elements import _FilterBarElement
+from common.components.custom_elements import _FieldComparisonSet, _FilterBarElement
 from common.components.date_range_picker import DateRangePicker
 from common.components.primitives import (
     Div,
@@ -11,11 +13,16 @@ from common.components.primitives import (
     FilterWidgetPath,
     Input,
     Label,
+    Option,
     Radio,
     RelationChild,
+    Select,
     Span,
+    StyledButton,
+    Template,
     filter_widget_attributes,
 )
+from common.criteria import ComparableColumn, comparable_columns
 from common.components.search_select import (
     DEFAULT_PREFETCH,
     FilterSelect,
@@ -653,6 +660,214 @@ def _filter_action_row() -> Node:
     )
 
 
+# ── Field-to-field comparison widget (#167) ──────────────────────────────────
+# A set of "left <op> right" rows comparing two columns of the bar's own model,
+# combined by a single AND/OR mode toggle.  The dependent option lists (operator
+# + right column react to the left column's group) and the row serialization live
+# client-side in ts/elements/field-comparison-set.ts and filter-bar.ts.
+#
+# TODO(nested-builder, #168): the AND/OR mode toggle and the single-mode shapes
+# are a stepping stone the nested boolean builder subsumes; the single-row markup
+# (_field_comparison_row) is the permanent part it reuses inside a group node.
+
+
+class FieldComparisonRow(NamedTuple):
+    left: str  # left column name, e.g. "timestamp_end"
+    right: str  # right column name, e.g. "timestamp_start"
+    modifier: str  # a Modifier value, e.g. "LESS_THAN"
+
+
+def _fc_row_from_dict(raw: dict) -> FieldComparisonRow:
+    return FieldComparisonRow(
+        left=str(raw.get("left", "")),
+        right=str(raw.get("right", "")),
+        modifier=str(raw.get("modifier") or "EQUALS"),
+    )
+
+
+def _field_comparison_rows(existing: dict) -> tuple[list[FieldComparisonRow], str]:
+    """Read saved comparison rows + mode from a parsed filter.
+
+    Recognises the two shapes the widget emits (see filter-bar.ts): a top-level
+    ``field_comparisons`` list (AND mode), or a single ``{"OR": [...]}`` element
+    in the ``AND`` list whose entries each hold one ``field_comparisons`` (OR
+    mode). AND wins if both are somehow present (a hand-edited degenerate case).
+    Returns ``([], "AND")`` when neither is found.
+    """
+    raw_and = existing.get("field_comparisons")
+    if isinstance(raw_and, list) and raw_and:
+        rows = [_fc_row_from_dict(item) for item in raw_and if isinstance(item, dict)]
+        if rows:
+            return rows, "AND"
+    for element in existing.get("AND", []) or []:
+        if not isinstance(element, dict) or not isinstance(element.get("OR"), list):
+            continue
+        or_rows: list[FieldComparisonRow] = []
+        for node in element["OR"]:
+            if not isinstance(node, dict):
+                continue
+            inner = node.get("field_comparisons")
+            if isinstance(inner, list) and inner and isinstance(inner[0], dict):
+                or_rows.append(_fc_row_from_dict(inner[0]))
+        if or_rows:
+            return or_rows, "OR"
+    return [], "AND"
+
+
+def _fc_column_options(columns: list[ComparableColumn], selected: str) -> list[Node]:
+    """The shared left-column ``<option>`` set (right/operator are TS-built)."""
+    options: list[Node] = [Option(attributes=[("value", "")], children=["column…"])]
+    for column in columns:
+        attributes = [("value", column["value"]), ("data-group", column["group"])]
+        if column["value"] == selected:
+            attributes.append(("selected", ""))
+        options.append(Option(attributes=attributes, children=[column["label"]]))
+    return options
+
+
+def _field_comparison_row(
+    columns: list[ComparableColumn],
+    row: FieldComparisonRow | None,
+    select_class: str,
+) -> Node:
+    """One ``left <op> right ✕`` row. ``row=None`` is the blank template row.
+
+    The left column carries the full option set; the operator and right-column
+    selects are rendered empty with the saved value stashed in ``data-selected``
+    — ts/elements/field-comparison-set.ts builds their options from the left
+    column's group and restores the selection. This is the reusable single-row
+    unit (see TODO(nested-builder) above)."""
+    left_value = row.left if row else ""
+    operator_value = row.modifier if row else ""
+    right_value = row.right if row else ""
+    return Div(
+        attributes=[
+            ("data-fc-row", ""),
+            (
+                "class",
+                "grid grid-cols-1 gap-2 items-center "
+                "@md:grid-cols-[1fr_auto_1fr_auto]",
+            ),
+        ],
+        children=[
+            Select(
+                attributes=[("data-fc-left", ""), ("class", select_class)],
+                children=_fc_column_options(columns, left_value),
+            ),
+            Select(
+                attributes=[
+                    ("data-fc-op", ""),
+                    ("data-selected", operator_value),
+                    ("class", select_class),
+                ],
+            ),
+            Select(
+                attributes=[
+                    ("data-fc-right", ""),
+                    ("data-selected", right_value),
+                    ("class", select_class),
+                ],
+            ),
+            Element(
+                "button",
+                attributes=[
+                    ("type", "button"),
+                    ("data-fc-remove", ""),
+                    ("aria-label", "Remove comparison"),
+                    ("class", "p-2 text-body hover:text-red-500 cursor-pointer"),
+                ],
+                children=["✕"],
+            ),
+        ],
+    )
+
+
+def _fc_mode_toggle(mode: str) -> Node:
+    return Div(
+        attributes=[("class", "flex items-center gap-3")],
+        children=[
+            Span(attributes=[("class", _FILTER_LABEL_CLASS)], children=["Match"]),
+            Radio(
+                name="field-comparison-mode",
+                label="All",
+                value="AND",
+                checked=(mode != "OR"),
+                attributes=[("data-fc-mode", "")],
+            ),
+            Radio(
+                name="field-comparison-mode",
+                label="Any",
+                value="OR",
+                checked=(mode == "OR"),
+                attributes=[("data-fc-mode", "")],
+            ),
+        ],
+    )
+
+
+def FieldComparisonSet(
+    *,
+    columns: list[ComparableColumn],
+    rows: list[FieldComparisonRow],
+    mode: str,
+) -> Node:
+    """The field-comparison custom element: a mode toggle, the saved rows, a blank
+    template row for client cloning, and an add button. ``columns`` is embedded as
+    a JSON prop so the TS can build the dependent operator/right options."""
+    import json
+
+    from games.forms import SELECT_CLASS
+
+    safe_mode = mode if mode in ("AND", "OR") else "AND"
+    return _FieldComparisonSet(
+        [
+            *filter_widget_attributes(["field_comparisons"], "field-comparison"),
+            ("class", "flex flex-col gap-3 mt-2"),
+        ],
+        columns=json.dumps(columns),
+        mode=safe_mode,
+    )[
+        _fc_mode_toggle(safe_mode),
+        Div(
+            attributes=[("data-fc-rows", ""), ("class", "flex flex-col gap-2")],
+            children=[
+                _field_comparison_row(columns, row, SELECT_CLASS) for row in rows
+            ],
+        ),
+        Template(
+            attributes=[("data-fc-row-template", "")],
+            children=[_field_comparison_row(columns, None, SELECT_CLASS)],
+        ),
+        StyledButton(
+            color="gray",
+            attributes=[("data-fc-add", ""), ("class", "self-start")],
+        )["+ Add comparison"],
+    ]
+
+
+def _field_comparison_section(
+    existing: dict, model: type[models.Model] | None
+) -> Node | None:
+    """The labelled field-comparison field for a bar, or None when unavailable.
+
+    Omitted when the bar's filter has no comparison model, or when no comparison
+    group has at least two columns (a comparison needs two columns of the SAME
+    group, so otherwise no valid row could be built)."""
+    if model is None:
+        return None
+    columns = comparable_columns(model)
+    group_counts: dict[str, int] = {}
+    for column in columns:
+        group_counts[column["group"]] = group_counts.get(column["group"], 0) + 1
+    if not any(count >= 2 for count in group_counts.values()):
+        return None
+    rows, mode = _field_comparison_rows(existing)
+    return _filter_field(
+        "Field comparisons",
+        FieldComparisonSet(columns=columns, rows=rows, mode=mode),
+    )
+
+
 class _FilterBarBase(BaseComponent):
     """Shared collapsible filter-bar chrome.
 
@@ -681,6 +896,21 @@ class _FilterBarBase(BaseComponent):
     def build_fields(self) -> list:
         """Return the per-entity filter body. Implemented by each subclass."""
         raise NotImplementedError
+
+    def comparison_model(self) -> type[models.Model] | None:
+        """The model whose columns the field-comparison widget compares.
+
+        None (the default) hides the widget; concrete bars override it to return
+        their entity model, mirroring ``OperatorFilter._comparison_model``."""
+        return None
+
+    def _body_fields(self) -> list:
+        """The per-entity fields plus the optional field-comparison section."""
+        fields = list(self.build_fields())
+        section = _field_comparison_section(self.existing, self.comparison_model())
+        if section is not None:
+            fields.append(section)
+        return fields
 
     def render(self) -> Node:
         return _FilterBarElement(
@@ -717,7 +947,7 @@ class _FilterBarBase(BaseComponent):
                                             ("value", self.filter_json),
                                         ],
                                     ),
-                                    *self.build_fields(),
+                                    *self._body_fields(),
                                     _filter_action_row(),
                                 ],
                             ),
@@ -743,6 +973,11 @@ class FilterBar(_FilterBarBase):
 
     def build_fields(self) -> list:
         return _game_fields(self.existing, self.status_options)
+
+    def comparison_model(self) -> type[models.Model]:
+        from games.models import Game
+
+        return Game
 
 
 def _game_fields(
@@ -1064,6 +1299,11 @@ class SessionFilterBar(_FilterBarBase):
     def build_fields(self) -> list:
         return _session_fields(self.existing)
 
+    def comparison_model(self) -> type[models.Model]:
+        from games.models import Session
+
+        return Session
+
 
 def _session_fields(existing: dict) -> list:
     from games.models import Game, Session
@@ -1169,6 +1409,11 @@ class PurchaseFilterBar(_FilterBarBase):
 
     def build_fields(self) -> list:
         return _purchase_fields(self.existing)
+
+    def comparison_model(self) -> type[models.Model]:
+        from games.models import Purchase
+
+        return Purchase
 
 
 def _purchase_fields(existing: dict) -> list:
@@ -1362,6 +1607,11 @@ class DeviceFilterBar(_FilterBarBase):
     def build_fields(self) -> list:
         return _device_fields(self.existing)
 
+    def comparison_model(self) -> type[models.Model]:
+        from games.models import Device
+
+        return Device
+
 
 def _device_fields(existing: dict) -> list:
     from games.models import Device
@@ -1393,6 +1643,11 @@ class PlatformFilterBar(_FilterBarBase):
 
     def build_fields(self) -> list:
         return _platform_fields(self.existing)
+
+    def comparison_model(self) -> type[models.Model]:
+        from games.models import Platform
+
+        return Platform
 
 
 def _platform_fields(existing: dict) -> list:
@@ -1436,6 +1691,11 @@ class PlayEventFilterBar(_FilterBarBase):
 
     def build_fields(self) -> list:
         return _playevent_fields(self.existing)
+
+    def comparison_model(self) -> type[models.Model]:
+        from games.models import PlayEvent
+
+        return PlayEvent
 
 
 def _playevent_fields(existing: dict) -> list:

--- a/common/components/primitives.py
+++ b/common/components/primitives.py
@@ -186,6 +186,8 @@ Meta = _html_element("meta")
 Title = _html_element("title")
 Script = _html_element("script")
 Link = _html_element("link")
+Select = _html_element("select")
+Option = _html_element("option")
 
 
 def _popover_html(

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -12,7 +12,7 @@ import json
 from collections.abc import Sequence
 from dataclasses import dataclass, field, fields as dc_fields
 from enum import Enum
-from typing import Any, Literal, Self, TypeVar
+from typing import Any, Literal, Self, TypedDict, TypeVar
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
@@ -1159,12 +1159,46 @@ def _field_comparison_to_q(left: str, right: str, modifier: Modifier) -> Q:
     raise FilterError(f"Unsupported modifier {modifier} for field comparison")
 
 
+def _maybe_group_for(
+    model: type[models.Model], column: str
+) -> ComparisonGroup | None:
+    """Classify a model column into a comparison group, or None if non-comparable.
+
+    Returns None — never raises — for every column that has no comparison group:
+    the column does not exist, is a relation (FK/M2M/reverse), is a GeneratedField
+    with no resolvable output type, or is of a type absent from
+    ``_GROUP_BY_INTERNAL_TYPE`` (e.g. AutoField pk, JSONField).
+
+    This is the single source of truth for the classification; the raising
+    ``_comparison_group_for`` wraps it, and ``comparable_columns`` enumerates with
+    it (so enumeration never has to drive off exceptions).
+    """
+    try:
+        model_field = model._meta.get_field(column)
+    except FieldDoesNotExist:
+        return None
+
+    if model_field.is_relation:
+        return None
+
+    if isinstance(model_field, models.GeneratedField):
+        output_field = model_field.output_field
+        if output_field is None:
+            return None
+        internal_type = output_field.get_internal_type()
+    else:
+        internal_type = model_field.get_internal_type()
+
+    return _GROUP_BY_INTERNAL_TYPE.get(internal_type)
+
+
 def _comparison_group_for(model: type[models.Model], column: str) -> ComparisonGroup:
     """Resolve a model column's comparison group by DB type, or raise FilterError.
 
-    Raises FilterError if the column does not exist, is a relation (FK/M2M/reverse),
-    is a GeneratedField with no resolvable output type, or is of a type with no
-    comparison group (e.g. AutoField pk, JSONField).
+    Thin raising wrapper over ``_maybe_group_for``: where that returns None, this
+    raises FilterError with a message describing why the column is not comparable
+    (does not exist, is a relation, is a GeneratedField with no output type, or is
+    of a type with no comparison group such as AutoField pk / JSONField).
     """
     try:
         model_field = model._meta.get_field(column)
@@ -1176,23 +1210,55 @@ def _comparison_group_for(model: type[models.Model], column: str) -> ComparisonG
             f"{model.__name__}.{column!r} is a relation and is not comparable"
         )
 
-    if isinstance(model_field, models.GeneratedField):
-        output_field = model_field.output_field
-        if output_field is None:
-            raise FilterError(
-                f"{model.__name__}.{column!r} is a generated field with no output type"
-            )
-        internal_type = output_field.get_internal_type()
-    else:
-        internal_type = model_field.get_internal_type()
+    if (
+        isinstance(model_field, models.GeneratedField)
+        and model_field.output_field is None
+    ):
+        raise FilterError(
+            f"{model.__name__}.{column!r} is a generated field with no output type"
+        )
 
-    group = _GROUP_BY_INTERNAL_TYPE.get(internal_type)
+    group = _maybe_group_for(model, column)
     if group is None:
+        internal_type = model_field.get_internal_type()
         raise FilterError(
             f"{model.__name__}.{column!r} is not a comparable type ({internal_type})"
         )
 
     return group
+
+
+class ComparableColumn(TypedDict):
+    """A model column that can take part in a field-to-field comparison, ready for
+    a picker: its field name, a human label, and its comparison group."""
+
+    value: str  # column name, e.g. "timestamp_end"
+    label: str  # field verbose_name, title-cased, e.g. "Timestamp End"
+    group: ComparisonGroup
+
+
+def comparable_columns(model: type[models.Model]) -> list[ComparableColumn]:
+    """Every column of ``model`` with a comparison group, labelled and grouped,
+    sorted by label (case-insensitive).
+
+    Iterates ``model._meta.get_fields()`` and keeps the columns that
+    ``_maybe_group_for`` classifies into a group; relations, reverse relations,
+    M2M, the pk/AutoField, generated-without-output, and JSONField all classify to
+    None and so fall out. The label is the field's ``verbose_name`` title-cased to
+    match how Django presents it.
+    """
+    columns: list[ComparableColumn] = []
+    for model_field in model._meta.get_fields():
+        column = model_field.name
+        group = _maybe_group_for(model, column)
+        if group is None:
+            continue
+        verbose_name = getattr(model_field, "verbose_name", column)
+        columns.append(
+            ComparableColumn(value=column, label=verbose_name.title(), group=group)
+        )
+    columns.sort(key=lambda entry: entry["label"].lower())
+    return columns
 
 
 def _allowed_comparison_modifiers(group: ComparisonGroup) -> list[Modifier]:

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -1159,9 +1159,7 @@ def _field_comparison_to_q(left: str, right: str, modifier: Modifier) -> Q:
     raise FilterError(f"Unsupported modifier {modifier} for field comparison")
 
 
-def _maybe_group_for(
-    model: type[models.Model], column: str
-) -> ComparisonGroup | None:
+def _maybe_group_for(model: type[models.Model], column: str) -> ComparisonGroup | None:
     """Classify a model column into a comparison group, or None if non-comparable.
 
     Returns None — never raises — for every column that has no comparison group:

--- a/docs/superpowers/specs/2026-06-28-field-comparison-filter-ui-design.md
+++ b/docs/superpowers/specs/2026-06-28-field-comparison-filter-ui-design.md
@@ -122,22 +122,37 @@ Registered behaviour follows the project's custom-element convention (native lif
 
 ### 4. Serialization contract (`ts/elements/filter-bar.ts`)
 
-The generic serializer special-cases `data-kind="field-comparison"`. It reads the set's rows and
-mode and emits, into the filter JSON being built:
+**This requires NEW code, not the generic path.** The current serializer's `readWidget()` switch
+has no `field-comparison` case (unknown kinds hit `default` → `null` → the widget is silently
+skipped), and `setPath()` only assigns a single value at a single key — it cannot build a
+top-level array nor the nested `AND`/`OR` tree. So a new branch is added, **modelled on the
+existing `relation-bool` special-case** (which already sidesteps the generic path and calls
+`appendAnd(filter, …)`):
 
-- **AND mode** → top-level `field_comparisons: [ {left, right, modifier}, … ]`. Each entry is
-  AND-combined by the existing `field_comparisons` loop in `_apply_operators`.
-- **OR mode** → a single isolated wrapper:
-  ```json
-  { "AND": [ { "OR": [ {"field_comparisons": [c1]}, {"field_comparisons": [c2]}, … ] } ] }
-  ```
-  Each comparison sits alone in its own node under one `OR` list, wrapped in a single `AND`
-  sub-filter. This is required because top-level `OR` uses `q |= sub.to_q()` in
-  `_apply_operators` and would otherwise OR the comparison group against every other top-level
-  criterion (platform, status, …). The AND-wrapper isolates the OR group so it composes as
-  `(other filters) AND (c1 OR c2 OR …)`.
+- Add a `readFieldComparisonSet(element)` reader that returns the rows (`{left, right, modifier}`)
+  plus the mode.
+- Add an explicit branch in the per-widget loop (before the generic `readWidget` fallback, like
+  the `kind === "relation-bool"` early-return) that emits:
+  - **AND mode** → assign `filter["field_comparisons"] = [ {left, right, modifier}, … ]` (build
+    the array directly; do not route through `setPath`'s scalar assignment). Each entry is
+    AND-combined by the existing `field_comparisons` loop in `_apply_operators`.
+  - **OR mode** → `appendAnd(filter, …)` a single isolated wrapper:
+    ```json
+    { "AND": [ { "OR": [ {"field_comparisons": [c1]}, {"field_comparisons": [c2]}, … ] } ] }
+    ```
+    Each comparison sits alone in its own node under one `OR` list, wrapped in a single `AND`
+    sub-filter. This is required because top-level `OR` uses `q |= sub.to_q()` in
+    `_apply_operators` and would otherwise OR the comparison group against every other top-level
+    criterion (platform, status, …). The AND-wrapper isolates the OR group so it composes as
+    `(other filters) AND (c1 OR c2 OR …)`.
 
 Rows with any of left / operator / right unset are dropped silently (incomplete, not an error).
+
+**Path note:** `data-path=["field_comparisons"]` is informational only for this widget (kept for
+consistency with the self-describe contract). The field-comparison branch is handled entirely by
+the special-case above and does **not** go through `resolve_path_kind` / `_criterion_class_for`,
+which cannot resolve a list field (`field_comparisons` is `list[FieldComparisonCriterion]`, not a
+single `_Criterion`) and would raise. No change to the path-resolution machinery is needed.
 
 ### 5. Validation parity
 
@@ -160,7 +175,9 @@ are merged; this is a degenerate case, not a supported authoring path.
 ### 7. Wiring into the bars
 
 Render the set from the shared `_FilterBarBase` so it appears uniformly in every bar whose
-filter declares a `_comparison_model()` and whose model has ≥2 comparable columns. Each bar
+filter declares a `_comparison_model()` and whose model has **≥2 comparable columns within at
+least one group** (the same-exact-group rule means two columns in different groups can never be
+compared; all six models satisfy this today). Each bar
 subclass declares its model (a class attribute) so the base can call `comparable_columns(model)`.
 This covers `FilterBar` (Game), `SessionFilterBar`, `PurchaseFilterBar`, `DeviceFilterBar`,
 `PlatformFilterBar`, `PlayEventFilterBar` in one place. Widget `Media` bubbles up the node tree

--- a/docs/superpowers/specs/2026-06-28-field-comparison-filter-ui-design.md
+++ b/docs/superpowers/specs/2026-06-28-field-comparison-filter-ui-design.md
@@ -1,0 +1,189 @@
+# Filter-bar UI for field-to-field comparisons
+
+**Issue:** [#167](https://github.com/KucharczykL/timetracker/issues/167) (follow-up from #129, #164)
+**Date:** 2026-06-28
+**Status:** Design approved
+
+## Background
+
+The filter algebra already supports field-to-field comparison: `FieldComparisonCriterion`
+(`common/criteria.py`) compares two model columns via `F()` expressions. It lives in
+`field_comparisons: list[FieldComparisonCriterion]` on every `OperatorFilter`, serializes
+to/from `{"field_comparisons": [{"left": "...", "right": "...", "modifier": "..."}]}`, and is
+validated in `OperatorFilter._apply_operators` (self-compare rejected, cross-group rejected,
+per-group modifier set enforced via `_comparison_group_for` / `_allowed_comparison_modifiers`).
+
+Today this is reachable **only by hand-editing the `?filter=` JSON**. There is no UI.
+
+## Goal
+
+Add a filter-bar control that builds field comparisons without editing JSON: pick left column,
+operator, right column, with the pickers and operator list restricted to compatible comparison
+groups, and self-compare / cross-group rejected at the UI level (already rejected server-side).
+
+## Decisions (from design interview)
+
+- **Cardinality:** multiple stacked comparison rows (add/remove), matching the list data model.
+- **Boolean model:** a single group **AND/OR mode toggle** (all rows ANDed, or all rows ORed).
+  Mixed per-row precedence and nested groups are out of scope. Full nested AND/OR builder is
+  filed as a follow-up issue (§10).
+- **Column source:** auto-enumerate comparable columns per model via introspection (zero
+  maintenance), labelled by `verbose_name`.
+- **Picker control:** native styled `<select>` elements (bounded short lists; trivial dynamic
+  dependent filtering), not the SearchSelect combobox.
+
+## UX
+
+A new **"Field comparisons"** section in the filter bar:
+
+```
+Field comparisons          [ AND | OR ]
+  [ left column ▾ ] [ op ▾ ] [ right column ▾ ]  [✕]
+  [ left column ▾ ] [ op ▾ ] [ right column ▾ ]  [✕]
+  [ + Add comparison ]
+```
+
+Dependent behaviour (client-side, mirroring server validation):
+
+- Left column empty → operator and right pickers disabled.
+- On left column chosen:
+  - operator list = `_allowed_comparison_modifiers(group_of_left)`;
+  - right list = only columns of the **same exact comparison group** (note `datetime`, `date`,
+    `duration`, `number` are distinct groups and only compare within group);
+  - the chosen left column is removed from the right list (no self-compare).
+- Operator labels: `=` (EQUALS), `≠` (NOT_EQUALS), `>` (GREATER_THAN), `<` (LESS_THAN),
+  `contains` (INCLUDES), `doesn't contain` (EXCLUDES). String group offers all six; numeric/date
+  groups offer the first four; bool offers only `=` / `≠`.
+
+## Architecture
+
+### 1. Server — column introspection (`common/criteria.py`)
+
+New named type and helper:
+
+```python
+class ComparableColumn(TypedDict):
+    value: str               # column name, e.g. "timestamp_end"
+    label: str               # verbose_name, title-cased
+    group: ComparisonGroup   # "date" | "datetime" | "duration" | "number" | "string" | "bool"
+
+def comparable_columns(model: type[models.Model]) -> list[ComparableColumn]:
+    """Every column of `model` that has a comparison group, labelled + grouped, sorted by label."""
+```
+
+Implementation iterates `model._meta.get_fields()` and keeps the columns that classify into a
+group. To avoid driving enumeration off exceptions, refactor the existing
+`_comparison_group_for` so its body delegates to a new internal
+`_maybe_group_for(model, column) -> ComparisonGroup | None` (returns `None` instead of raising
+for non-comparable columns); `_comparison_group_for` keeps its raising contract by wrapping
+`_maybe_group_for` and raising `FilterError` on `None`. `comparable_columns` uses
+`_maybe_group_for`. This keeps a single classification source of truth.
+
+Relations, generated fields with no resolvable output type, pk/AutoField, and JSONField are
+excluded (they already have no group).
+
+### 2. Python component — `FieldComparisonSet` (`common/components/filters.py`)
+
+A new custom element `<field-comparison-set>`, registered in
+`common/components/custom_elements.py` via `register_element` with a Props TypedDict (codegen
+target `ts/generated/props.ts` via `make gen-element-types`):
+
+```python
+class FieldComparisonSetProps(TypedDict):
+    columns: str   # JSON of list[ComparableColumn] for the bar's model
+    mode: str      # "AND" | "OR" (initial)
+```
+
+The component:
+
+- carries the filter-widget self-describe contract:
+  `data-filter-widget`, `data-path = ["field_comparisons"]`, `data-kind = "field-comparison"`
+  (the kind already registered in `LeafWidgetKind` but until now unreachable — it becomes
+  reachable here);
+- server-renders the current rows from prefill (§6);
+- includes a hidden `<template>` row the client clones for "+ Add comparison";
+- uses native `<select>` styled with the shared `SELECT_CLASS` from `primitives.py`;
+- declares its `Media` (compiled `dist/elements/field-comparison-set.js`) via the
+  `custom_element_builder` factory, so `Page()` emits the script automatically.
+
+### 3. Client — `ts/elements/field-comparison-set.ts`
+
+Vanilla custom element (`customElements.define`, native `connectedCallback`), no Alpine. Reads
+props with the generated `readFieldComparisonSetProps`. Responsibilities:
+
+- add row (clone template) / remove row;
+- on left-column change, repopulate the operator and right-column `<select>`s from the
+  `columns` data filtered to the left column's group (and excluding the left column itself);
+  disable operator/right while left is empty;
+- mode toggle state.
+
+Registered behaviour follows the project's custom-element convention (native lifecycle, not
+`onSwap`).
+
+### 4. Serialization contract (`ts/elements/filter-bar.ts`)
+
+The generic serializer special-cases `data-kind="field-comparison"`. It reads the set's rows and
+mode and emits, into the filter JSON being built:
+
+- **AND mode** → top-level `field_comparisons: [ {left, right, modifier}, … ]`. Each entry is
+  AND-combined by the existing `field_comparisons` loop in `_apply_operators`.
+- **OR mode** → a single isolated wrapper:
+  ```json
+  { "AND": [ { "OR": [ {"field_comparisons": [c1]}, {"field_comparisons": [c2]}, … ] } ] }
+  ```
+  Each comparison sits alone in its own node under one `OR` list, wrapped in a single `AND`
+  sub-filter. This is required because top-level `OR` uses `q |= sub.to_q()` in
+  `_apply_operators` and would otherwise OR the comparison group against every other top-level
+  criterion (platform, status, …). The AND-wrapper isolates the OR group so it composes as
+  `(other filters) AND (c1 OR c2 OR …)`.
+
+Rows with any of left / operator / right unset are dropped silently (incomplete, not an error).
+
+### 5. Validation parity
+
+No new server validation. The UI prevents self-compare, cross-group, and out-of-group operators
+by construction; `_apply_operators` remains the authority and still rejects hand-edited bad JSON.
+
+### 6. Prefill / round-trip
+
+The set reads from the bar's already-parsed `self.existing` (the canonicalized filter), and
+recognizes both shapes it can emit:
+
+- top-level `field_comparisons` (non-empty) → render those rows in **AND** mode;
+- the `AND: [ { OR: [ {field_comparisons:[…]}, … ] } ]` wrapper of single-comparison nodes →
+  render those rows in **OR** mode.
+
+This round-trips losslessly (parse → render → serialize yields an equivalent filter). If both
+shapes are somehow present (only via hand-edited JSON), AND mode takes precedence and the rows
+are merged; this is a degenerate case, not a supported authoring path.
+
+### 7. Wiring into the bars
+
+Render the set from the shared `_FilterBarBase` so it appears uniformly in every bar whose
+filter declares a `_comparison_model()` and whose model has ≥2 comparable columns. Each bar
+subclass declares its model (a class attribute) so the base can call `comparable_columns(model)`.
+This covers `FilterBar` (Game), `SessionFilterBar`, `PurchaseFilterBar`, `DeviceFilterBar`,
+`PlatformFilterBar`, `PlayEventFilterBar` in one place. Widget `Media` bubbles up the node tree
+automatically; no view changes (`scripts=`) needed.
+
+## Testing
+
+- **`tests/test_filters.py`** — `comparable_columns()` per model: correct groups and labels;
+  excludes relations, generated-without-output, pk/AutoField, JSONField. `_maybe_group_for`
+  returns `None` where `_comparison_group_for` raises.
+- **`tests/test_filter_bars.py`** — the set renders in each applicable bar; AND-mode and OR-mode
+  **round-trip**: a filter JSON parses, the bar renders, and re-serializing produces the expected
+  shape (`field_comparisons` for AND; `AND:[{OR:[…]}]` for OR).
+- **`tests/test_components.py`** — `FieldComparisonSet` render and prefill from both shapes.
+- **`e2e/test_widgets_e2e.py`** — pick left column → operator and right lists repopulate by
+  group and exclude the left column; add/remove rows; mode toggle; Apply yields the expected
+  `?filter=`. Concrete cases from the issue:
+  - `Session.timestamp_end` `<` `timestamp_start`
+  - `Purchase.date_refunded` `<` `date_purchased`
+  - `Game.name` `contains` `sort_name`
+
+## Out of scope / follow-ups to file
+
+- **Nested AND/OR groups (full boolean query builder)** — generalize the single mode toggle into
+  parenthesizable AND/OR groups, i.e. the app's general filter-tree UI. File as a GitHub issue.
+- Independent of #162 (numeric/date `>=` / `<=` operators).

--- a/docs/superpowers/specs/2026-06-28-field-comparison-filter-ui-design.md
+++ b/docs/superpowers/specs/2026-06-28-field-comparison-filter-ui-design.md
@@ -199,8 +199,41 @@ automatically; no view changes (`scripts=`) needed.
   - `Purchase.date_refunded` `<` `date_purchased`
   - `Game.name` `contains` `sort_name`
 
-## Out of scope / follow-ups to file
+## Out of scope / follow-ups
 
-- **Nested AND/OR groups (full boolean query builder)** — generalize the single mode toggle into
-  parenthesizable AND/OR groups, i.e. the app's general filter-tree UI. File as a GitHub issue.
+- **Nested AND/OR/NOT filter builder (full boolean query UI)** — generalize the single mode
+  toggle into parenthesizable groups, i.e. the app's general filter-tree UI. Filed as
+  [#168](https://github.com/KucharczykL/timetracker/issues/168). See §11 for the
+  transitional/permanent split.
 - Independent of #162 (numeric/date `>=` / `<=` operators).
+
+## 11. Relationship to the nested-builder follow-up (#168)
+
+The nested builder (#168) **replaces** the flat serializer model, it does not extend it. A
+recursive tree serializer (group node → filter JSON) subsumes the current `setPath` / `appendAnd`
+/ `readWidget`-switch glue. So part of this design is a deliberate stepping stone and part is
+permanent infrastructure. Be explicit about which, so #168 knows what to delete vs reuse.
+
+**Transitional — #168 makes these obsolete.** Mark each in code with `TODO(nested-builder)`
+(Python `#`, TS `//`):
+
+- the AND/OR **mode toggle** on the set (superseded by the surrounding group's connective);
+- the OR-isolation **wrapper** `{"AND":[{"OR":[{"field_comparisons":[c]}, …]}]}` (the tree nests
+  naturally — a comparison sits in an OR group node like any leaf, no wrapper);
+- the **flat-serializer `field-comparison` special-case branch** in `filter-bar.ts` (replaced by
+  the recursive tree serializer).
+
+**Permanent — #168 reuses verbatim; build these clean, not as glue:**
+
+- server: `comparable_columns()` + `_maybe_group_for` (the builder needs the same column-options
+  source and group classification);
+- client: the **single comparison row** in `field-comparison-set.ts` (left/op/right + dependent
+  repopulation). One row is identical inside a nested group; only the multi-row set container +
+  its flat serialization is transitional.
+
+**Design constraint for this issue:** keep the single-row logic in `field-comparison-set.ts`
+(option building, group-dependent repopulation) **separable** from the set/mode/serialization
+glue, so #168 can lift the row module directly. Costs nothing now.
+
+**Do NOT** speculatively generalize `filter-bar.ts` into a tree serializer now — #168 is
+unscheduled and separately designed; building its plumbing blind is YAGNI.

--- a/e2e/test_field_comparison_e2e.py
+++ b/e2e/test_field_comparison_e2e.py
@@ -1,0 +1,171 @@
+"""End-to-end Playwright test for the field-to-field comparison widget (#167):
+dependent operator/right-column option building, AND/OR serialization, and
+prefill round-trip."""
+
+import json
+import urllib.parse
+
+import pytest
+from django.http import HttpResponse
+from django.test import override_settings
+from django.urls import path
+
+from common.components import SessionFilterBar
+
+
+def _bar_page(filter_json: str = "") -> str:
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>Field comparison E2E</title>
+    <script src="/static/js/htmx.min.js"></script>
+    <script src="/static/js/dist/elements/search-select.js" type="module"></script>
+    <script src="/static/js/dist/elements/field-comparison-set.js" type="module"></script>
+    <script src="/static/js/dist/elements/filter-bar.js" type="module"></script>
+</head>
+<body>
+    {SessionFilterBar(filter_json=filter_json, preset_list_url="/p/l", preset_save_url="/p/s")}
+</body>
+</html>"""
+
+
+def empty_bar_view(request):
+    return HttpResponse(_bar_page())
+
+
+def prefilled_and_view(request):
+    filter_json = json.dumps(
+        {
+            "field_comparisons": [
+                {
+                    "left": "timestamp_end",
+                    "right": "timestamp_start",
+                    "modifier": "LESS_THAN",
+                }
+            ]
+        }
+    )
+    return HttpResponse(_bar_page(filter_json=filter_json))
+
+
+urlpatterns = [
+    path("test-fc-empty/", empty_bar_view),
+    path("test-fc-prefilled-and/", prefilled_and_view),
+]
+
+
+def _filter_from_url(url: str) -> dict:
+    query = urllib.parse.urlparse(url).query
+    params = urllib.parse.parse_qs(query)
+    raw = params.get("filter", [""])[0]
+    return json.loads(raw) if raw else {}
+
+
+def _submit(page):
+    with page.expect_navigation():
+        page.evaluate(
+            "document.getElementById('filter-bar-form')"
+            ".dispatchEvent(new Event('submit', {cancelable: true}))"
+        )
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_field_comparison_e2e")
+def test_dependent_options_and_and_mode(live_server, page):
+    page.goto(live_server.url + "/test-fc-empty/")
+
+    # No rows until the user adds one.
+    assert page.locator("[data-fc-row]").count() == 0
+    page.locator("[data-fc-add]").click()
+    row = page.locator("[data-fc-row]").first
+
+    left = row.locator("[data-fc-left]")
+    operator = row.locator("[data-fc-op]")
+    right = row.locator("[data-fc-right]")
+
+    # Operator/right are disabled until a left column is chosen.
+    assert not operator.is_enabled()
+    assert not right.is_enabled()
+
+    left.select_option("timestamp_end")
+
+    # Operator list is now the datetime (ordered) set; string-only ops are absent.
+    assert operator.is_enabled()
+    assert operator.locator('option[value="LESS_THAN"]').count() == 1
+    assert operator.locator('option[value="INCLUDES"]').count() == 0
+    # Right column excludes the chosen left column and offers same-group columns.
+    assert right.locator('option[value="timestamp_start"]').count() == 1
+    assert right.locator('option[value="timestamp_end"]').count() == 0
+
+    operator.select_option("LESS_THAN")
+    right.select_option("timestamp_start")
+    _submit(page)
+
+    parsed = _filter_from_url(page.url)
+    assert parsed["field_comparisons"] == [
+        {"left": "timestamp_end", "right": "timestamp_start", "modifier": "LESS_THAN"}
+    ]
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_field_comparison_e2e")
+def test_or_mode_serializes_isolated_wrapper(live_server, page):
+    page.goto(live_server.url + "/test-fc-empty/")
+    page.locator("[data-fc-add]").click()
+    row = page.locator("[data-fc-row]").first
+    row.locator("[data-fc-left]").select_option("timestamp_end")
+    row.locator("[data-fc-op]").select_option("LESS_THAN")
+    row.locator("[data-fc-right]").select_option("timestamp_start")
+
+    # Switch the group to OR.
+    page.locator('[data-fc-mode][value="OR"]').click()
+    _submit(page)
+
+    parsed = _filter_from_url(page.url)
+    assert parsed == {
+        "AND": [
+            {
+                "OR": [
+                    {
+                        "field_comparisons": [
+                            {
+                                "left": "timestamp_end",
+                                "right": "timestamp_start",
+                                "modifier": "LESS_THAN",
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_field_comparison_e2e")
+def test_and_prefill_round_trip(live_server, page):
+    page.goto(live_server.url + "/test-fc-prefilled-and/")
+
+    row = page.locator("[data-fc-row]").first
+    assert row.locator("[data-fc-left]").input_value() == "timestamp_end"
+    assert row.locator("[data-fc-op]").input_value() == "LESS_THAN"
+    assert row.locator("[data-fc-right]").input_value() == "timestamp_start"
+    assert page.locator('[data-fc-mode][value="AND"]').is_checked()
+
+    # Re-applying without changes round-trips to the same shape.
+    _submit(page)
+    parsed = _filter_from_url(page.url)
+    assert parsed["field_comparisons"] == [
+        {"left": "timestamp_end", "right": "timestamp_start", "modifier": "LESS_THAN"}
+    ]
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_field_comparison_e2e")
+def test_remove_row(live_server, page):
+    page.goto(live_server.url + "/test-fc-empty/")
+    page.locator("[data-fc-add]").click()
+    page.locator("[data-fc-add]").click()
+    assert page.locator("[data-fc-row]").count() == 2
+    page.locator("[data-fc-row]").first.locator("[data-fc-remove]").click()
+    assert page.locator("[data-fc-row]").count() == 1

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -597,3 +597,96 @@ class NumberFilterRenderTest(TestCase):
         # EQUALS is the only checked radio when an invalid modifier is given.
         self.assertRegex(html, r'value="EQUALS"[^>]*checked="true"')
         self.assertNotRegex(html, r'value="INCLUDES"')
+
+
+class FieldComparisonWidgetTest(TestCase):
+    """The field-to-field comparison widget (#167): presence in every bar, the
+    embedded column options, and AND/OR prefill round-trip shapes."""
+
+    def _bars(self):
+        from common.components import (
+            DeviceFilterBar,
+            FilterBar,
+            PlatformFilterBar,
+            PlayEventFilterBar,
+            PurchaseFilterBar,
+            SessionFilterBar,
+        )
+
+        return [
+            FilterBar,
+            SessionFilterBar,
+            PurchaseFilterBar,
+            DeviceFilterBar,
+            PlatformFilterBar,
+            PlayEventFilterBar,
+        ]
+
+    def test_widget_present_in_every_bar(self):
+        for bar in self._bars():
+            html = str(bar(filter_json=""))
+            self.assertIn("<field-comparison-set", html, bar.__name__)
+            self.assertIn('data-kind="field-comparison"', html, bar.__name__)
+            self.assertIn("data-fc-row-template", html, bar.__name__)
+            self.assertIn("data-fc-add", html, bar.__name__)
+
+    def test_columns_prop_embedded(self):
+        html = str(SessionFilterBar(filter_json=""))
+        # The element's columns prop carries the model's comparable columns as
+        # JSON (escaped into the attribute); the datetime pair is what the issue's
+        # use case compares.
+        self.assertIn("timestamp_end", html)
+        self.assertIn("timestamp_start", html)
+        self.assertIn('mode="AND"', html)
+
+    def test_no_double_escaped_markup(self):
+        # The columns JSON attribute must not introduce escaped element markup.
+        html = str(SessionFilterBar(filter_json=""))
+        for marker in _ESCAPED_TAG_MARKERS:
+            self.assertNotIn(marker, html)
+
+    def test_and_prefill_renders_row(self):
+        filter_json = json.dumps(
+            {
+                "field_comparisons": [
+                    {
+                        "left": "timestamp_end",
+                        "right": "timestamp_start",
+                        "modifier": "LESS_THAN",
+                    }
+                ]
+            }
+        )
+        html = str(SessionFilterBar(filter_json=filter_json))
+        # Template row + the prefilled row.
+        self.assertGreaterEqual(html.count("data-fc-row"), 2)
+        # Saved operator + right column stashed for the TS to restore.
+        self.assertIn('data-selected="LESS_THAN"', html)
+        self.assertIn('data-selected="timestamp_start"', html)
+        # AND mode is the checked toggle.
+        self.assertRegex(html, r'value="AND"[^>]*checked="true"')
+        self.assertNotRegex(html, r'value="OR"[^>]*checked="true"')
+
+    def test_or_prefill_selects_or_mode(self):
+        filter_json = json.dumps(
+            {
+                "AND": [
+                    {
+                        "OR": [
+                            {
+                                "field_comparisons": [
+                                    {
+                                        "left": "timestamp_end",
+                                        "right": "timestamp_start",
+                                        "modifier": "LESS_THAN",
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+        html = str(SessionFilterBar(filter_json=filter_json))
+        self.assertRegex(html, r'value="OR"[^>]*checked="true"')
+        self.assertIn('data-selected="LESS_THAN"', html)

--- a/tests/test_filter_paths.py
+++ b/tests/test_filter_paths.py
@@ -102,13 +102,18 @@ class _BarCase(NamedTuple):
 # stops emitting ``data-filter-widget``), which the per-path checks below cannot
 # catch — only an exact count does. Update these numbers deliberately whenever a
 # filter field is added or removed.
+# Each count includes the field-comparison widget (#167), present in every bar
+# whose model has >=2 columns in one comparison group. Unlike the other widgets
+# its ``["field_comparisons"]`` path does NOT resolve through resolve_path_kind
+# (it's a list field, serialized by filter-bar.ts's special-case branch), so the
+# resolution check below skips kind=="field-comparison".
 _BAR_CASES = [
-    _BarCase("game", FilterBar, GameFilter, 23),
-    _BarCase("session", SessionFilterBar, SessionFilter, 8),
-    _BarCase("purchase", PurchaseFilterBar, PurchaseFilter, 14),
-    _BarCase("device", DeviceFilterBar, DeviceFilter, 1),
-    _BarCase("platform", PlatformFilterBar, PlatformFilter, 2),
-    _BarCase("playevent", PlayEventFilterBar, PlayEventFilter, 4),
+    _BarCase("game", FilterBar, GameFilter, 24),
+    _BarCase("session", SessionFilterBar, SessionFilter, 9),
+    _BarCase("purchase", PurchaseFilterBar, PurchaseFilter, 15),
+    _BarCase("device", DeviceFilterBar, DeviceFilter, 2),
+    _BarCase("platform", PlatformFilterBar, PlatformFilter, 3),
+    _BarCase("playevent", PlayEventFilterBar, PlayEventFilter, 5),
 ]
 
 
@@ -160,6 +165,15 @@ def test_every_widget_path_resolves_to_its_kind(case: _BarCase) -> None:
         if widget.kind == "relation-bool":
             _assert_relation_bool_resolves(case.filter_cls, widget)
             continue
+        # field_comparisons is a list field handled by filter-bar.ts's
+        # special-case branch, not the generic path resolver — resolve_path_kind
+        # cannot (and need not) resolve it. See the LeafWidgetKind note in
+        # common/criteria.py and the #167 design (§4 path note).
+        if widget.kind == "field-comparison":
+            assert widget.path == ["field_comparisons"], (
+                f"{case.name} field-comparison widget has unexpected path {widget.path}"
+            )
+            continue
         resolved = resolve_path_kind(case.filter_cls, widget.path)
         assert resolved == widget.kind, (
             f"{case.name} widget {widget.path} declares kind {widget.kind!r} "
@@ -180,7 +194,8 @@ def test_no_widget_path_is_a_prefix_of_another(case: _BarCase) -> None:
     paths = [
         widget.path
         for widget in _collect_widgets(html)
-        if len(widget.path) == 1 and widget.kind != "relation-bool"
+        if len(widget.path) == 1
+        and widget.kind not in ("relation-bool", "field-comparison")
     ]
     for outer in paths:
         for inner in paths:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -21,6 +21,8 @@ from common.criteria import (
     _allowed_comparison_modifiers,
     _comparison_group_for,
     _field_comparison_to_q,
+    _maybe_group_for,
+    comparable_columns,
 )
 from common.components import FilterBar
 from games.filters import (
@@ -1706,6 +1708,135 @@ class TestComparisonGroupResolver:
         # string keeps lexicographic ordering too
         assert Modifier.GREATER_THAN in allowed
         assert Modifier.LESS_THAN in allowed
+
+
+class TestMaybeGroupFor:
+    """_maybe_group_for mirrors _comparison_group_for but returns None instead of
+    raising for non-comparable columns."""
+
+    # ── comparable columns → group (parity with _comparison_group_for) ───────
+
+    def test_date_field(self):
+        from games.models import Purchase
+
+        assert _maybe_group_for(Purchase, "date_purchased") == "date"
+
+    def test_datetime_field(self):
+        from games.models import Session
+
+        assert _maybe_group_for(Session, "timestamp_start") == "datetime"
+
+    def test_generated_field_duration(self):
+        from games.models import Session
+
+        assert _maybe_group_for(Session, "duration_total") == "duration"
+
+    def test_integer_field(self):
+        from games.models import Game
+
+        assert _maybe_group_for(Game, "year_released") == "number"
+
+    def test_char_field(self):
+        from games.models import Game
+
+        assert _maybe_group_for(Game, "name") == "string"
+
+    def test_bool_field(self):
+        from games.models import Game
+
+        assert _maybe_group_for(Game, "mastered") == "bool"
+
+    # ── non-comparable columns → None (where _comparison_group_for raises) ───
+
+    def test_nonexistent_column_returns_none(self):
+        from games.models import Game
+
+        assert _maybe_group_for(Game, "nonexistent") is None
+
+    def test_fk_relation_returns_none(self):
+        from games.models import Game
+
+        assert _maybe_group_for(Game, "platform") is None
+
+    def test_m2m_relation_returns_none(self):
+        from games.models import Purchase
+
+        assert _maybe_group_for(Purchase, "games") is None
+
+    def test_auto_pk_returns_none(self):
+        from games.models import Game
+
+        assert _maybe_group_for(Game, "id") is None
+
+    def test_contract_parity_with_raising_wrapper(self):
+        """Every column that makes _comparison_group_for raise must return None
+        from _maybe_group_for, and vice-versa for comparable ones."""
+        from games.models import Game
+
+        for column in ("nonexistent", "platform", "id"):
+            assert _maybe_group_for(Game, column) is None
+            with pytest.raises(FilterError):
+                _comparison_group_for(Game, column)
+        for column in ("name", "year_released", "mastered"):
+            assert _maybe_group_for(Game, column) is not None
+            assert _comparison_group_for(Game, column) == _maybe_group_for(Game, column)
+
+
+class TestComparableColumns:
+    """comparable_columns enumerates a model's comparable columns, labelled and
+    grouped, sorted by label."""
+
+    def _by_value(self, model):
+        return {entry["value"]: entry for entry in comparable_columns(model)}
+
+    def test_entries_have_value_label_group_keys(self):
+        from games.models import Game
+
+        for entry in comparable_columns(Game):
+            assert set(entry.keys()) == {"value", "label", "group"}
+
+    def test_known_game_columns(self):
+        from games.models import Game
+
+        columns = self._by_value(Game)
+        assert columns["name"]["group"] == "string"
+        assert columns["year_released"]["group"] == "number"
+        assert columns["mastered"]["group"] == "bool"
+
+    def test_session_datetime_column(self):
+        from games.models import Session
+
+        columns = self._by_value(Session)
+        assert columns["timestamp_end"]["group"] == "datetime"
+        assert columns["timestamp_start"]["group"] == "datetime"
+
+    def test_purchase_date_columns(self):
+        from games.models import Purchase
+
+        columns = self._by_value(Purchase)
+        assert columns["date_purchased"]["group"] == "date"
+        assert columns["date_refunded"]["group"] == "date"
+
+    def test_relations_and_pk_absent(self):
+        from games.models import Game, Purchase
+
+        game_columns = self._by_value(Game)
+        assert "platform" not in game_columns
+        assert "id" not in game_columns
+        assert "games" not in self._by_value(Purchase)
+
+    def test_labels_are_title_cased_verbose_names(self):
+        from games.models import Game
+
+        columns = self._by_value(Game)
+        assert columns["name"]["label"] == "Name"
+        assert columns["year_released"]["label"] == "Year Released"
+
+    def test_sorted_by_label_case_insensitive(self):
+        from games.models import Session
+
+        labels = [entry["label"] for entry in comparable_columns(Session)]
+        assert labels == sorted(labels, key=str.lower)
 
 
 # ── T3 — OperatorFilter field_comparisons wiring ─────────────────────────────

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,6 +6,7 @@ from dataclasses import field as dc_field
 
 import pytest
 from django.db.models import F, Q
+from django.test import SimpleTestCase as TestCase
 
 from common.criteria import (
     BoolCriterion,
@@ -2667,3 +2668,73 @@ class TestFieldComparisonEndToEnd:
         parsed_filter = parse_game_filter(filter_to_json(game_filter))
         assert parsed_filter is not None
         assert set(Game.objects.filter(parsed_filter.to_q())) == {match}
+
+
+class FieldComparisonPrefillTest(TestCase):
+    """_field_comparison_rows: the two on-disk shapes the widget round-trips."""
+
+    def test_empty(self):
+        from common.components.filters import _field_comparison_rows
+
+        rows, mode = _field_comparison_rows({})
+        self.assertEqual(rows, [])
+        self.assertEqual(mode, "AND")
+
+    def test_and_shape(self):
+        from common.components.filters import _field_comparison_rows
+
+        rows, mode = _field_comparison_rows(
+            {
+                "field_comparisons": [
+                    {"left": "a", "right": "b", "modifier": "LESS_THAN"},
+                    {"left": "c", "right": "d", "modifier": "EQUALS"},
+                ]
+            }
+        )
+        self.assertEqual(mode, "AND")
+        self.assertEqual([r.left for r in rows], ["a", "c"])
+        self.assertEqual(rows[0].modifier, "LESS_THAN")
+
+    def test_or_shape(self):
+        from common.components.filters import _field_comparison_rows
+
+        rows, mode = _field_comparison_rows(
+            {
+                "AND": [
+                    {
+                        "OR": [
+                            {"field_comparisons": [{"left": "a", "right": "b", "modifier": "EQUALS"}]},
+                            {"field_comparisons": [{"left": "c", "right": "d", "modifier": "INCLUDES"}]},
+                        ]
+                    }
+                ]
+            }
+        )
+        self.assertEqual(mode, "OR")
+        self.assertEqual([(r.left, r.right) for r in rows], [("a", "b"), ("c", "d")])
+        self.assertEqual(rows[1].modifier, "INCLUDES")
+
+    def test_and_wins_over_or(self):
+        from common.components.filters import _field_comparison_rows
+
+        rows, mode = _field_comparison_rows(
+            {
+                "field_comparisons": [{"left": "a", "right": "b", "modifier": "EQUALS"}],
+                "AND": [{"OR": [{"field_comparisons": [{"left": "c", "right": "d", "modifier": "EQUALS"}]}]}],
+            }
+        )
+        self.assertEqual(mode, "AND")
+        self.assertEqual(rows[0].left, "a")
+
+    def test_section_none_without_model(self):
+        from common.components.filters import _field_comparison_section
+
+        self.assertIsNone(_field_comparison_section({}, None))
+
+    def test_section_present_for_real_model(self):
+        from common.components.filters import _field_comparison_section
+        from games.models import Session
+
+        node = _field_comparison_section({}, Session)
+        self.assertIsNotNone(node)
+        self.assertIn("field-comparison-set", str(node))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -2703,8 +2703,16 @@ class FieldComparisonPrefillTest(TestCase):
                 "AND": [
                     {
                         "OR": [
-                            {"field_comparisons": [{"left": "a", "right": "b", "modifier": "EQUALS"}]},
-                            {"field_comparisons": [{"left": "c", "right": "d", "modifier": "INCLUDES"}]},
+                            {
+                                "field_comparisons": [
+                                    {"left": "a", "right": "b", "modifier": "EQUALS"}
+                                ]
+                            },
+                            {
+                                "field_comparisons": [
+                                    {"left": "c", "right": "d", "modifier": "INCLUDES"}
+                                ]
+                            },
                         ]
                     }
                 ]
@@ -2719,8 +2727,20 @@ class FieldComparisonPrefillTest(TestCase):
 
         rows, mode = _field_comparison_rows(
             {
-                "field_comparisons": [{"left": "a", "right": "b", "modifier": "EQUALS"}],
-                "AND": [{"OR": [{"field_comparisons": [{"left": "c", "right": "d", "modifier": "EQUALS"}]}]}],
+                "field_comparisons": [
+                    {"left": "a", "right": "b", "modifier": "EQUALS"}
+                ],
+                "AND": [
+                    {
+                        "OR": [
+                            {
+                                "field_comparisons": [
+                                    {"left": "c", "right": "d", "modifier": "EQUALS"}
+                                ]
+                            }
+                        ]
+                    }
+                ],
             }
         )
         self.assertEqual(mode, "AND")

--- a/ts/elements/field-comparison-set.ts
+++ b/ts/elements/field-comparison-set.ts
@@ -1,0 +1,169 @@
+/**
+ * FieldComparisonSet — build "left <op> right" field-to-field comparison rows.
+ *
+ * Drives common/components/filters.py FieldComparisonSet. Each row's left column
+ * is server-rendered with the full column option set; this module fills the
+ * operator and right-column selects from the chosen left column's comparison
+ * group (mirroring the server's _allowed_comparison_modifiers / same-group rule),
+ * restoring any saved value stashed in data-selected. The set's rows + AND/OR
+ * mode are read back by filter-bar.ts on Apply (see readFieldComparisonSet).
+ *
+ * The single-row logic (refreshRow) is intentionally separable from the set
+ * container so the nested boolean builder (#168) can reuse it inside a group.
+ */
+import { readFieldComparisonSetProps } from "../generated/props.js";
+
+interface Column {
+  value: string;
+  label: string;
+  group: string;
+}
+
+export interface ComparisonRow {
+  left: string;
+  right: string;
+  modifier: string;
+}
+
+// Operator labels by Modifier value — must match the modifiers the server
+// accepts per group (common/criteria.py _allowed_comparison_modifiers).
+const OPERATOR_LABELS: Record<string, string> = {
+  EQUALS: "=",
+  NOT_EQUALS: "≠",
+  GREATER_THAN: ">",
+  LESS_THAN: "<",
+  INCLUDES: "contains",
+  EXCLUDES: "doesn't contain",
+};
+
+function operatorsForGroup(group: string): string[] {
+  if (group === "bool") return ["EQUALS", "NOT_EQUALS"];
+  if (group === "string") {
+    return ["EQUALS", "NOT_EQUALS", "GREATER_THAN", "LESS_THAN", "INCLUDES", "EXCLUDES"];
+  }
+  return ["EQUALS", "NOT_EQUALS", "GREATER_THAN", "LESS_THAN"];
+}
+
+function groupOf(columns: Column[], value: string): string | null {
+  const column = columns.find((candidate) => candidate.value === value);
+  return column ? column.group : null;
+}
+
+function fillSelect(
+  select: HTMLSelectElement,
+  options: [string, string][],
+  selected: string,
+  placeholder: string,
+): void {
+  select.textContent = "";
+  const blank = document.createElement("option");
+  blank.value = "";
+  blank.textContent = placeholder;
+  select.appendChild(blank);
+  for (const [value, label] of options) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    if (value === selected) option.selected = true;
+    select.appendChild(option);
+  }
+}
+
+/** Rebuild a row's operator + right-column options from its left column. The
+ * reusable single-row unit (see file header). */
+function refreshRow(row: HTMLElement, columns: Column[]): void {
+  const left = row.querySelector<HTMLSelectElement>("[data-fc-left]");
+  const operator = row.querySelector<HTMLSelectElement>("[data-fc-op]");
+  const right = row.querySelector<HTMLSelectElement>("[data-fc-right]");
+  if (!left || !operator || !right) return;
+
+  // Saved values: data-selected on first paint, then the live value afterwards.
+  const operatorSaved = operator.getAttribute("data-selected") ?? operator.value;
+  const rightSaved = right.getAttribute("data-selected") ?? right.value;
+  operator.removeAttribute("data-selected");
+  right.removeAttribute("data-selected");
+
+  const group = groupOf(columns, left.value);
+  if (!group) {
+    fillSelect(operator, [], "", "—");
+    fillSelect(right, [], "", "column…");
+    operator.disabled = true;
+    right.disabled = true;
+    return;
+  }
+  operator.disabled = false;
+  right.disabled = false;
+  fillSelect(
+    operator,
+    operatorsForGroup(group).map((modifier) => [modifier, OPERATOR_LABELS[modifier]]),
+    operatorSaved,
+    "—",
+  );
+  fillSelect(
+    right,
+    columns
+      .filter((column) => column.group === group && column.value !== left.value)
+      .map((column) => [column.value, column.label]),
+    rightSaved,
+    "column…",
+  );
+}
+
+function wireRow(row: HTMLElement, columns: Column[]): void {
+  refreshRow(row, columns);
+  row
+    .querySelector<HTMLSelectElement>("[data-fc-left]")
+    ?.addEventListener("change", () => refreshRow(row, columns));
+  row
+    .querySelector<HTMLElement>("[data-fc-remove]")
+    ?.addEventListener("click", () => row.remove());
+}
+
+/** Read the set's mode + complete rows for filter-bar.ts serialization. */
+export function readFieldComparisonSet(element: HTMLElement): {
+  mode: string;
+  comparisons: ComparisonRow[];
+} {
+  const mode =
+    element.querySelector<HTMLInputElement>("[data-fc-mode]:checked")?.value === "OR"
+      ? "OR"
+      : "AND";
+  const comparisons: ComparisonRow[] = [];
+  element.querySelectorAll<HTMLElement>("[data-fc-row]").forEach((row) => {
+    const left = row.querySelector<HTMLSelectElement>("[data-fc-left]")?.value ?? "";
+    const modifier = row.querySelector<HTMLSelectElement>("[data-fc-op]")?.value ?? "";
+    const right = row.querySelector<HTMLSelectElement>("[data-fc-right]")?.value ?? "";
+    if (left && right && modifier && left !== right) {
+      comparisons.push({ left, right, modifier });
+    }
+  });
+  return { mode, comparisons };
+}
+
+class FieldComparisonSetElement extends HTMLElement {
+  connectedCallback(): void {
+    const { columns: columnsJson } = readFieldComparisonSetProps(this);
+    let columns: Column[] = [];
+    try {
+      columns = JSON.parse(columnsJson || "[]");
+    } catch {
+      console.warn("field-comparison-set: malformed columns prop", columnsJson);
+    }
+    const rowsContainer = this.querySelector<HTMLElement>("[data-fc-rows]");
+    const template = this.querySelector<HTMLTemplateElement>("[data-fc-row-template]");
+    if (!rowsContainer || !template) return;
+
+    rowsContainer
+      .querySelectorAll<HTMLElement>("[data-fc-row]")
+      .forEach((row) => wireRow(row, columns));
+
+    this.querySelector<HTMLElement>("[data-fc-add]")?.addEventListener("click", () => {
+      const clone = template.content.firstElementChild?.cloneNode(true) as HTMLElement | null;
+      if (!clone) return;
+      rowsContainer.appendChild(clone);
+      wireRow(clone, columns);
+    });
+  }
+}
+
+customElements.define("field-comparison-set", FieldComparisonSetElement);

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -6,6 +6,7 @@
  * preset_save_url) are read from the element's typed attributes via codegen.
  */
 import { readFilterBarProps } from "../generated/props.js";
+import { readFieldComparisonSet } from "./field-comparison-set.js";
 import { readSearchSelect } from "./search-select.js";
 
 interface Criterion {
@@ -253,6 +254,27 @@ function buildFilterJSON(form: HTMLElement): Record<string, unknown> {
     if (kind === "relation-bool") {
       const element = readRelationBoolWidget(widget, path);
       if (element !== null) appendAnd(filter, element);
+      return;
+    }
+
+    // Field-to-field comparison set: a list-valued widget, so it cannot use the
+    // single-leaf setPath model. AND mode writes the top-level field_comparisons
+    // array (each entry AND'd by _apply_operators); OR mode appends one isolated
+    // AND wrapper holding an OR of single-comparison nodes, so the OR never leaks
+    // onto the other top-level criteria.
+    // TODO(nested-builder, #168): the mode toggle + these two shapes are a
+    // stepping stone the recursive tree serializer replaces.
+    if (kind === "field-comparison") {
+      const { mode, comparisons } = readFieldComparisonSet(widget);
+      if (comparisons.length > 0) {
+        if (mode === "OR") {
+          appendAnd(filter, {
+            OR: comparisons.map((comparison) => ({ field_comparisons: [comparison] })),
+          });
+        } else {
+          filter.field_comparisons = comparisons;
+        }
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

Adds a filter-bar UI for **field-to-field comparisons** (#167) — comparing two columns of a model (e.g. `Session.timestamp_end` < `timestamp_start`) without hand-editing the `?filter=` JSON. The `FieldComparisonCriterion` algebra already existed; this is the missing UI.

> **Note:** This PR is based on `main` but also carries the one unmerged commit from #164 (`feat(filters): string-contains field comparison INCLUDES/EXCLUDES`), which had no separate PR. So merging this lands **both #164 and #167**.

## What's included (#167)

- **Server introspection** — `comparable_columns(model)` enumerates a model's comparison-eligible columns (value/label/group); the classifier is split into a non-raising `_maybe_group_for` (single source of truth) wrapped by the raising `_comparison_group_for`.
- **`<field-comparison-set>` widget** in every filter bar (Game/Session/Purchase/Device/Platform/PlayEvent): stacked `left <op> right ✕` rows + a single **AND/OR mode toggle** + add/remove. Native styled selects; per-bar `comparison_model()` wiring on the shared `_FilterBarBase`.
- **Client** (`ts/elements/field-comparison-set.ts`) builds the dependent operator + right-column options from the chosen left column's comparison group (mirrors `_allowed_comparison_modifiers` and the same-group rule; excludes self-compare).
- **Serialization** (`filter-bar.ts`): AND mode → top-level `field_comparisons` array; OR mode → an isolated `AND:[{OR:[…]}]` wrapper so the OR never leaks onto other top-level criteria. Prefill reads both shapes back and round-trips losslessly.

## Design

Spec: `docs/superpowers/specs/2026-06-28-field-comparison-filter-ui-design.md` (interviewed, adversarially reviewed, corrected). Boolean model is a single AND/OR toggle by design; the full nested builder and cross-model comparison are deferred.

## Scope decisions / follow-ups

- Single AND/OR toggle now; **nested AND/OR/NOT builder** → #168.
- Same-model comparison only; **cross-model (relation-spanning) comparison** → #169.
- The transitional pieces (mode toggle, OR wrapper, serializer branch) are marked `TODO(nested-builder, #168)`; the single-row markup and server introspection are the permanent parts #168/#169 reuse.

## Testing

- Unit: `comparable_columns` / `_maybe_group_for` (18 tests), `_field_comparison_rows` parsing, widget presence + AND/OR prefill round-trip; updated `test_filter_paths` counts + skip (the list-field path bypasses `resolve_path_kind` by design).
- E2E (real browser): dependent option building, AND + OR serialization shapes, AND prefill round-trip, add/remove rows.
- Visually verified the row layout in a real browser with compiled CSS.
- `make check` green (1000 tests + lint + format + mypy + ts-check).

Closes #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
