### PR TITLE
refactor(filters): first-class FilterField descriptors, generic to_q (#161)

### DIFF
--- a/common/criteria.py
+++ b/common/criteria.py
@@ -9,10 +9,10 @@ filtering from *how* you're comparing, and makes filter serialization trivial.
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field, fields as dc_fields
 from enum import Enum
-from typing import Any, Literal, Self, TypedDict, TypeVar
+from typing import Any, ClassVar, Literal, Self, TypedDict, TypeVar
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
@@ -508,6 +508,35 @@ class FieldComparisonCriterion(_Criterion):
         return {"left": self.left, "right": self.right, "modifier": self.modifier}
 
 
+# ── Field descriptors ──────────────────────────────────────────────────────
+
+# A custom criterion→Q builder for a filter field whose mapping is not a plain
+# ``criterion.to_q(lookup)`` — e.g. hours→duration conversion or a bool
+# presence/zero test. Built by the factories below (see ``duration_hours_handler``).
+type FieldHandler = Callable[[_Criterion], Q]
+
+
+@dataclass(frozen=True)
+class FilterField:
+    """Declarative attr→ORM-lookup mapping for one filter field.
+
+    Lifts the per-field mapping a filter's ``to_q`` used to do imperatively into a
+    single declarative table (see ``OperatorFilter.fields``). ``lookup`` overrides
+    the ORM path (defaulting to the attribute name, so a plain field needs no
+    argument); ``handler`` supplies bespoke Q logic for fields whose mapping is not
+    a plain ``criterion.to_q(lookup)`` — the hours→duration and bool
+    presence/zero cases.
+    """
+
+    lookup: str | None = None
+    handler: FieldHandler | None = None
+
+    def to_q(self, attr_name: str, criterion: _Criterion) -> Q:
+        if self.handler is not None:
+            return self.handler(criterion)
+        return criterion.to_q(self.lookup or attr_name)
+
+
 # ── OperatorFilter base ────────────────────────────────────────────────────
 
 FilterType = TypeVar("FilterType", bound="OperatorFilter")
@@ -780,6 +809,19 @@ class OperatorFilter:
     # concrete filter with no re-declaration needed.
     field_comparisons: list[FieldComparisonCriterion] = field(default_factory=list)
 
+    # Declarative attr→lookup table consumed by the generic ``to_q``. Each concrete
+    # filter overrides this with a ``FilterField`` per simple criterion field (the
+    # single source of truth for the ORM mapping); aggregates, M2M, ``search`` and
+    # relation sub-filters are absent — they live in ``_extra_q``. Declared as a
+    # ClassVar so the dataclass machinery does not treat it as a field.
+    fields: ClassVar[dict[str, FilterField]] = {}
+
+    # Criterion fields deliberately handled imperatively in ``_extra_q`` rather than
+    # via ``fields`` (e.g. the M2M ``games``). ``search`` is here for every filter.
+    # The drift-guard test (tests/test_filters.py) asserts ``fields`` plus this set
+    # plus the aggregate-typed fields partitions every criterion field.
+    _IMPERATIVE_CRITERIA: ClassVar[set[str]] = {"search"}
+
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         # Register concrete filter classes so from_json can resolve a
@@ -899,13 +941,29 @@ class OperatorFilter:
         return names
 
     def to_q(self) -> Q:
-        """Build a Django Q object from this filter and its sub-filters."""
+        """Build a Django Q object from this filter and its sub-filters.
+
+        Generic for every concrete filter: walk the declarative ``fields`` table
+        (each set criterion mapped to its ORM lookup/handler), then fold in the
+        imperative tail (``_extra_q``: aggregates, M2M, free-text search, relation
+        sub-filters), then the AND/OR/NOT operators and field comparisons.
+        """
         q = Q()
-        for field_name in self._criterion_fields():
-            c = getattr(self, field_name)
-            if c is not None:
-                q &= c.to_q(field_name)
+        for attr_name, descriptor in self.fields.items():
+            criterion = getattr(self, attr_name)
+            if criterion is not None:
+                q &= descriptor.to_q(attr_name, criterion)
+        q &= self._extra_q()
         return self._apply_operators(q)
+
+    def _extra_q(self) -> Q:
+        """Q for criterion fields handled imperatively rather than via ``fields``.
+
+        Default is empty; concrete filters override to add aggregates, the M2M
+        ``games`` handler, free-text ``search``, and relation sub-filters. Kept a
+        separate hook so the generic ``to_q`` never needs overriding.
+        """
+        return Q()
 
     @classmethod
     def from_json(cls, data: dict[str, Any] | None) -> Self | None:
@@ -1327,6 +1385,68 @@ def duration_hours_to_q(
     if modifier == Modifier.NOT_NULL:
         return ~Q(**{field_name: timedelta(0)})
     raise FilterError(f"Unsupported modifier {modifier} for duration comparison")
+
+
+# ── Field-handler factories ──────────────────────────────────────────────────
+# Reusable criterion→Q builders for the non-plain ``FilterField`` mappings, so a
+# filter's descriptor table can express hours→duration and bool presence/zero
+# fields declaratively instead of in an imperative ``to_q`` block.
+
+
+def duration_hours_handler(field_name: str) -> FieldHandler:
+    """Map an hours-based ``IntCriterion`` onto a DurationField via timedelta."""
+
+    def handler(c: _Criterion) -> Q:
+        # ``value2`` is the optional upper bound (BETWEEN); only numeric criteria
+        # declare it, so read it None-tolerantly off the base-typed criterion.
+        value2 = getattr(c, "value2", None)
+        return duration_hours_to_q(c.value, value2, c.modifier, field_name)
+
+    return handler
+
+
+def bool_isnull_handler(field_name: str, *, invert: bool = False) -> FieldHandler:
+    """Map a ``BoolCriterion`` onto a ``__isnull`` presence test.
+
+    ``invert=False``: True means the column IS NULL (e.g. is_active → an open
+    session has ``timestamp_end IS NULL``).  ``invert=True``: True means the
+    column IS NOT NULL (e.g. is_refunded → ``date_refunded IS NOT NULL``).
+    """
+    return lambda c: Q(
+        **{f"{field_name}__isnull": (not c.value) if invert else c.value}
+    )
+
+
+def bool_nonzero_duration_handler(field_name: str) -> FieldHandler:
+    """Map a ``BoolCriterion`` onto a non-zero DurationField test.
+
+    True selects rows whose duration differs from ``timedelta(0)`` (e.g. is_manual
+    → ``duration_manual`` was entered by hand); False selects the zero rows.
+    """
+    from datetime import timedelta
+
+    return lambda c: (
+        (~Q(**{field_name: timedelta(0)}))
+        if c.value
+        else Q(**{field_name: timedelta(0)})
+    )
+
+
+def search_q(criterion: StringCriterion, *field_names: str) -> Q:
+    """Free-text OR across several ``__icontains`` columns, negated on EXCLUDES.
+
+    Mirrors the per-filter free-text ``search`` block: an empty value contributes
+    no constraint; otherwise each column is OR'd, and ``EXCLUDES`` negates the
+    whole disjunction. ``field_names`` must be non-empty.
+    """
+    if not criterion.value:
+        return Q()
+    combined = Q(**{f"{field_names[0]}__icontains": criterion.value})
+    for field_name in field_names[1:]:
+        combined |= Q(**{f"{field_name}__icontains": criterion.value})
+    if criterion.modifier == Modifier.EXCLUDES:
+        combined = ~combined
+    return combined
 
 
 # The related/parent model is the concrete Django model the filter targets.

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -510,6 +510,9 @@ class FieldComparisonCriterion(_Criterion):
 
 # ── Field descriptors ──────────────────────────────────────────────────────
 
+type AttrName = str  # a filter dataclass field name, e.g. "playtime_hours"
+type ORMLookup = str  # a Django query path, e.g. "platform__group"
+
 # A custom criterion→Q builder for a filter field whose mapping is not a plain
 # ``criterion.to_q(lookup)`` — e.g. hours→duration conversion or a bool
 # presence/zero test. Built by the factories below (see ``duration_hours_handler``).
@@ -525,13 +528,19 @@ class FilterField:
     the ORM path (defaulting to the attribute name, so a plain field needs no
     argument); ``handler`` supplies bespoke Q logic for fields whose mapping is not
     a plain ``criterion.to_q(lookup)`` — the hours→duration and bool
-    presence/zero cases.
+    presence/zero cases. The two are mutually exclusive: a handler is fully
+    self-contained, so a ``lookup`` alongside it would be silently ignored —
+    ``__post_init__`` rejects that misconfiguration at import time.
     """
 
-    lookup: str | None = None
+    lookup: ORMLookup | None = None
     handler: FieldHandler | None = None
 
-    def to_q(self, attr_name: str, criterion: _Criterion) -> Q:
+    def __post_init__(self) -> None:
+        if self.lookup is not None and self.handler is not None:
+            raise ValueError("FilterField takes lookup OR handler, not both")
+
+    def to_q(self, attr_name: AttrName, criterion: _Criterion) -> Q:
         if self.handler is not None:
             return self.handler(criterion)
         return criterion.to_q(self.lookup or attr_name)
@@ -814,7 +823,7 @@ class OperatorFilter:
     # single source of truth for the ORM mapping); aggregates, M2M, ``search`` and
     # relation sub-filters are absent — they live in ``_extra_q``. Declared as a
     # ClassVar so the dataclass machinery does not treat it as a field.
-    fields: ClassVar[dict[str, FilterField]] = {}
+    fields: ClassVar[dict[AttrName, FilterField]] = {}
 
     # Criterion fields deliberately handled imperatively in ``_extra_q`` rather than
     # via ``fields`` (e.g. the M2M ``games``). ``search`` is here for every filter.
@@ -928,17 +937,6 @@ class OperatorFilter:
                     )
                 q &= comparison.to_q()
         return q
-
-    def _criterion_fields(self) -> list[str]:
-        """Return field names that hold a _Criterion instance."""
-        names: list[str] = []
-        for f in dc_fields(self):
-            if f.name in _OPERATOR_FIELDS:
-                continue
-            v = getattr(self, f.name)
-            if isinstance(v, _Criterion):
-                names.append(f.name)
-        return names
 
     def to_q(self) -> Q:
         """Build a Django Q object from this filter and its sub-filters.

--- a/games/filters.py
+++ b/games/filters.py
@@ -113,7 +113,8 @@ class GameFilter(OperatorFilter):
     playevent_filter: PlayEventFilter | None = None
     platform_filter: PlatformFilter | None = None
 
-    # Declarative attr→ORM-lookup table (order mirrors the old to_q emission).
+    # Declarative attr→ORM-lookup table, kept in the old to_q emission order for a
+    # reviewable diff (AND-composition makes the order semantically irrelevant).
     fields = {
         "name": FilterField(),
         "sort_name": FilterField(),
@@ -283,7 +284,8 @@ class SessionFilter(OperatorFilter):
     # Cross-entity: sessions for devices matching these criteria
     device_filter: DeviceFilter | None = None
 
-    # Declarative attr→ORM-lookup table (order mirrors the old to_q emission).
+    # Declarative attr→ORM-lookup table, kept in the old to_q emission order for a
+    # reviewable diff (AND-composition makes the order semantically irrelevant).
     fields = {
         "game": FilterField("game_id"),
         "device": FilterField("device_id"),
@@ -389,7 +391,8 @@ class PurchaseFilter(OperatorFilter):
     # Cross-entity: purchases for platforms matching these criteria
     platform_filter: PlatformFilter | None = None
 
-    # Declarative attr→ORM-lookup table (order mirrors the old to_q emission).
+    # Declarative attr→ORM-lookup table, kept in the old to_q emission order for a
+    # reviewable diff (AND-composition makes the order semantically irrelevant).
     # ``games`` (M2M) and ``search`` stay imperative — see ``_IMPERATIVE_CRITERIA``
     # and ``_extra_q``.
     fields = {
@@ -425,7 +428,9 @@ class PurchaseFilter(OperatorFilter):
     def _extra_q(self) -> Q:
         q = Q()
 
-        # M2M games: applied at the field position the old to_q used (after platform).
+        # M2M games: chained subqueries for INCLUDES_ALL/_ONLY keep it out of the
+        # declarative fields table. AND-composed into the same Q, so its position
+        # relative to the simple fields does not affect results.
         if self.games is not None:
             q &= self._games_to_q(self.games)
 
@@ -543,7 +548,8 @@ class DeviceFilter(OperatorFilter):
     # Cross-entity: Devices that have sessions matching these criteria
     session_filter: SessionFilter | None = None
 
-    # Declarative attr→ORM-lookup table (order mirrors the old to_q emission).
+    # Declarative attr→ORM-lookup table, kept in the old to_q emission order for a
+    # reviewable diff (AND-composition makes the order semantically irrelevant).
     fields = {
         "name": FilterField(),
         "type": FilterField(),
@@ -598,7 +604,8 @@ class PlatformFilter(OperatorFilter):
     game_filter: GameFilter | None = None
     purchase_filter: PurchaseFilter | None = None
 
-    # Declarative attr→ORM-lookup table (order mirrors the old to_q emission).
+    # Declarative attr→ORM-lookup table, kept in the old to_q emission order for a
+    # reviewable diff (AND-composition makes the order semantically irrelevant).
     fields = {
         "name": FilterField(),
         "group": FilterField(),
@@ -662,7 +669,8 @@ class PlayEventFilter(OperatorFilter):
     # Cross-entity: PlayEvents for games matching these criteria
     game_filter: GameFilter | None = None
 
-    # Declarative attr→ORM-lookup table (order mirrors the old to_q emission).
+    # Declarative attr→ORM-lookup table, kept in the old to_q emission order for a
+    # reviewable diff (AND-composition makes the order semantically irrelevant).
     fields = {
         "game": FilterField("game_id"),
         "started": FilterField(),

--- a/games/filters.py
+++ b/games/filters.py
@@ -34,6 +34,7 @@ from common.criteria import (
     ChoiceCriterion,
     DateCriterion,
     FilterError,
+    FilterField,
     FloatCriterion,
     IntCriterion,
     Modifier,
@@ -41,10 +42,13 @@ from common.criteria import (
     OperatorFilter,
     StringCriterion,
     aggregate_to_q,
-    duration_hours_to_q,
+    bool_isnull_handler,
+    bool_nonzero_duration_handler,
+    duration_hours_handler,
     filter_from_json,
     filter_to_json,
     relation_to_q,
+    search_q,
 )
 
 # ── FindFilter (sort / pagination) ─────────────────────────────────────────
@@ -109,6 +113,22 @@ class GameFilter(OperatorFilter):
     playevent_filter: PlayEventFilter | None = None
     platform_filter: PlatformFilter | None = None
 
+    # Declarative attr→ORM-lookup table (order mirrors the old to_q emission).
+    fields = {
+        "name": FilterField(),
+        "sort_name": FilterField(),
+        "year_released": FilterField(),
+        "original_year_released": FilterField(),
+        "wikidata": FilterField(),
+        "platform": FilterField("platform_id"),
+        "status": FilterField(),
+        "mastered": FilterField(),
+        "playtime_hours": FilterField(handler=duration_hours_handler("playtime")),
+        "created_at": FilterField(),
+        "updated_at": FilterField(),
+        "platform_group": FilterField("platform__group"),
+    }
+
     # Uppercase ``Type[...]`` (not the modern ``type[...]``) is deliberate: two
     # filters below (PurchaseFilter, DeviceFilter) declare a field named ``type``
     # that shadows the builtin in annotation scope, so ``type[Purchase]`` fails
@@ -119,36 +139,10 @@ class GameFilter(OperatorFilter):
 
         return Game
 
-    def to_q(self) -> Q:
+    def _extra_q(self) -> Q:
         q = Q()
 
-        # ── individual criteria ──
-        if self.name is not None:
-            q &= self.name.to_q("name")
-        if self.sort_name is not None:
-            q &= self.sort_name.to_q("sort_name")
-        if self.year_released is not None:
-            q &= self.year_released.to_q("year_released")
-        if self.original_year_released is not None:
-            q &= self.original_year_released.to_q("original_year_released")
-        if self.wikidata is not None:
-            q &= self.wikidata.to_q("wikidata")
-        if self.platform is not None:
-            q &= self.platform.to_q("platform_id")
-        if self.status is not None:
-            q &= self.status.to_q("status")
-        if self.mastered is not None:
-            q &= self.mastered.to_q("mastered")
-        if self.playtime_hours is not None:
-            q &= self._playtime_to_q(self.playtime_hours)
-        if self.created_at is not None:
-            q &= self.created_at.to_q("created_at")
-        if self.updated_at is not None:
-            q &= self.updated_at.to_q("updated_at")
-
-        if self.platform_group is not None:
-            q &= self.platform_group.to_q("platform__group")
-
+        # ── aggregates over the game's relations ──
         if self.session_count is not None:
             from games.models import Game
 
@@ -218,15 +212,8 @@ class GameFilter(OperatorFilter):
             )
 
         # ── free-text search (OR across multiple fields) ──
-        if self.search is not None and self.search.value:
-            search_q = (
-                Q(name__icontains=self.search.value)
-                | Q(sort_name__icontains=self.search.value)
-                | Q(platform__name__icontains=self.search.value)
-            )
-            if self.search.modifier == Modifier.EXCLUDES:
-                search_q = ~search_q
-            q &= search_q
+        if self.search is not None:
+            q &= search_q(self.search, "name", "sort_name", "platform__name")
 
         # Cross-entity sub-filters (ANY/NONE via each sub-filter's match mode)
         if self.session_filter is not None:
@@ -260,17 +247,7 @@ class GameFilter(OperatorFilter):
                 parent_field="platform_id",
             )
 
-        # ── AND / OR / NOT sub-filters (n-ary; see OperatorFilter) ──
-        return self._apply_operators(q)
-
-    @staticmethod
-    def _playtime_to_q(c: IntCriterion) -> Q:
-        return GameFilter._playtime_to_q_for_field(c, "playtime")
-
-    @staticmethod
-    def _playtime_to_q_for_field(c: IntCriterion, field: str) -> Q:
-        """Convert an hours-based criterion to a DurationField Q object."""
-        return duration_hours_to_q(c.value, c.value2, c.modifier, field)
+        return q
 
 
 # ── SessionFilter ──────────────────────────────────────────────────────────
@@ -306,65 +283,48 @@ class SessionFilter(OperatorFilter):
     # Cross-entity: sessions for devices matching these criteria
     device_filter: DeviceFilter | None = None
 
+    # Declarative attr→ORM-lookup table (order mirrors the old to_q emission).
+    fields = {
+        "game": FilterField("game_id"),
+        "device": FilterField("device_id"),
+        "emulated": FilterField(),
+        "note": FilterField(),
+        "duration_total_hours": FilterField(
+            handler=duration_hours_handler("duration_total")
+        ),
+        "duration_manual_hours": FilterField(
+            handler=duration_hours_handler("duration_manual")
+        ),
+        "duration_calculated_hours": FilterField(
+            handler=duration_hours_handler("duration_calculated")
+        ),
+        "is_active": FilterField(handler=bool_isnull_handler("timestamp_end")),
+        # Compare the date portion so a date matches the datetime column.
+        "timestamp_start": FilterField("timestamp_start__date"),
+        "timestamp_end": FilterField("timestamp_end__date"),
+        "is_manual": FilterField(
+            handler=bool_nonzero_duration_handler("duration_manual")
+        ),
+        "created_at": FilterField(),
+    }
+
     def _comparison_model(self) -> Type[Session]:
         from games.models import Session
 
         return Session
 
-    def _duration_to_q(self, c: IntCriterion, field: str) -> Q:
-        """Convert an hours-based criterion to a DurationField Q object."""
-        return duration_hours_to_q(c.value, c.value2, c.modifier, field)
-
-    def to_q(self) -> Q:
-        from datetime import timedelta
-
+    def _extra_q(self) -> Q:
         q = Q()
 
-        if self.game is not None:
-            q &= self.game.to_q("game_id")
-        if self.device is not None:
-            q &= self.device.to_q("device_id")
-        if self.emulated is not None:
-            q &= self.emulated.to_q("emulated")
-        if self.note is not None:
-            q &= self.note.to_q("note")
-        if self.duration_total_hours is not None:
-            q &= self._duration_to_q(self.duration_total_hours, "duration_total")
-        if self.duration_manual_hours is not None:
-            q &= self._duration_to_q(self.duration_manual_hours, "duration_manual")
-        if self.duration_calculated_hours is not None:
-            q &= self._duration_to_q(
-                self.duration_calculated_hours, "duration_calculated"
-            )
-        if self.is_active is not None:
-            if self.is_active.value:
-                q &= Q(timestamp_end__isnull=True)
-            else:
-                q &= Q(timestamp_end__isnull=False)
-        if self.timestamp_start is not None:
-            # Compare the date portion so a date matches the datetime column.
-            q &= self.timestamp_start.to_q("timestamp_start__date")
-        if self.timestamp_end is not None:
-            q &= self.timestamp_end.to_q("timestamp_end__date")
-        if self.is_manual is not None:
-            if self.is_manual.value:
-                q &= ~Q(duration_manual=timedelta(0))
-            else:
-                q &= Q(duration_manual=timedelta(0))
-        if self.created_at is not None:
-            q &= self.created_at.to_q("created_at")
-
         # Free-text search
-        if self.search is not None and self.search.value:
-            search_q = (
-                Q(game__name__icontains=self.search.value)
-                | Q(game__platform__name__icontains=self.search.value)
-                | Q(device__name__icontains=self.search.value)
-                | Q(device__type__icontains=self.search.value)
+        if self.search is not None:
+            q &= search_q(
+                self.search,
+                "game__name",
+                "game__platform__name",
+                "device__name",
+                "device__type",
             )
-            if self.search.modifier == Modifier.EXCLUDES:
-                search_q = ~search_q
-            q &= search_q
 
         # Cross-entity sub-filters: sessions for matching games / devices
         if self.game_filter is not None:
@@ -387,8 +347,7 @@ class SessionFilter(OperatorFilter):
                 parent_field="device_id",
             )
 
-        # AND / OR / NOT (n-ary; see OperatorFilter)
-        return self._apply_operators(q)
+        return q
 
 
 # ── PurchaseFilter ─────────────────────────────────────────────────────────
@@ -430,59 +389,49 @@ class PurchaseFilter(OperatorFilter):
     # Cross-entity: purchases for platforms matching these criteria
     platform_filter: PlatformFilter | None = None
 
+    # Declarative attr→ORM-lookup table (order mirrors the old to_q emission).
+    # ``games`` (M2M) and ``search`` stay imperative — see ``_IMPERATIVE_CRITERIA``
+    # and ``_extra_q``.
+    fields = {
+        "name": FilterField(),
+        "platform": FilterField("platform_id"),
+        "date_purchased": FilterField(),
+        "date_refunded": FilterField(),
+        "is_refunded": FilterField(
+            handler=bool_isnull_handler("date_refunded", invert=True)
+        ),
+        "price": FilterField(),
+        "converted_price": FilterField(),
+        "price_currency": FilterField(),
+        "num_purchases": FilterField(),
+        "ownership_type": FilterField(),
+        "type": FilterField(),
+        "created_at": FilterField(),
+        "updated_at": FilterField(),
+        "infinite": FilterField(),
+        "needs_price_update": FilterField(),
+        "converted_currency": FilterField(),
+    }
+
+    # ``games`` is a many-to-many handled by ``_games_to_q`` (INCLUDES_ALL/_ONLY
+    # need chained subqueries), so it stays out of ``fields``.
+    _IMPERATIVE_CRITERIA = {"search", "games"}
+
     def _comparison_model(self) -> Type[Purchase]:
         from games.models import Purchase
 
         return Purchase
 
-    def to_q(self) -> Q:
+    def _extra_q(self) -> Q:
         q = Q()
 
-        if self.name is not None:
-            q &= self.name.to_q("name")
-        if self.platform is not None:
-            q &= self.platform.to_q("platform_id")
+        # M2M games: applied at the field position the old to_q used (after platform).
         if self.games is not None:
             q &= self._games_to_q(self.games)
-        if self.date_purchased is not None:
-            q &= self.date_purchased.to_q("date_purchased")
-        if self.date_refunded is not None:
-            q &= self.date_refunded.to_q("date_refunded")
-        if self.is_refunded is not None:
-            q &= Q(date_refunded__isnull=not self.is_refunded.value)
-        if self.price is not None:
-            q &= self.price.to_q("price")
-        if self.converted_price is not None:
-            q &= self.converted_price.to_q("converted_price")
-        if self.price_currency is not None:
-            q &= self.price_currency.to_q("price_currency")
-        if self.num_purchases is not None:
-            q &= self.num_purchases.to_q("num_purchases")
-        if self.ownership_type is not None:
-            q &= self.ownership_type.to_q("ownership_type")
-        if self.type is not None:
-            q &= self.type.to_q("type")
-        if self.created_at is not None:
-            q &= self.created_at.to_q("created_at")
-        if self.updated_at is not None:
-            q &= self.updated_at.to_q("updated_at")
-        if self.infinite is not None:
-            q &= self.infinite.to_q("infinite")
-        if self.needs_price_update is not None:
-            q &= self.needs_price_update.to_q("needs_price_update")
-        if self.converted_currency is not None:
-            q &= self.converted_currency.to_q("converted_currency")
 
         # Free-text search
-        if self.search is not None and self.search.value:
-            search_q = (
-                Q(name__icontains=self.search.value)
-                | Q(games__name__icontains=self.search.value)
-                | Q(platform__name__icontains=self.search.value)
-            )
-            if self.search.modifier == Modifier.EXCLUDES:
-                search_q = ~search_q
-            q &= search_q
+        if self.search is not None:
+            q &= search_q(self.search, "name", "games__name", "platform__name")
 
         # Cross-entity sub-filters: purchases for matching games / platforms
         if self.game_filter is not None:
@@ -505,8 +454,7 @@ class PurchaseFilter(OperatorFilter):
                 parent_field="platform_id",
             )
 
-        # AND / OR / NOT (n-ary; see OperatorFilter)
-        return self._apply_operators(q)
+        return q
 
     @staticmethod
     def _games_to_q(criterion: ChoiceCriterion) -> Q:
@@ -595,29 +543,24 @@ class DeviceFilter(OperatorFilter):
     # Cross-entity: Devices that have sessions matching these criteria
     session_filter: SessionFilter | None = None
 
+    # Declarative attr→ORM-lookup table (order mirrors the old to_q emission).
+    fields = {
+        "name": FilterField(),
+        "type": FilterField(),
+        "created_at": FilterField(),
+    }
+
     def _comparison_model(self) -> Type[Device]:
         from games.models import Device
 
         return Device
 
-    def to_q(self) -> Q:
+    def _extra_q(self) -> Q:
         q = Q()
 
-        if self.name is not None:
-            q &= self.name.to_q("name")
-        if self.type is not None:
-            q &= self.type.to_q("type")
-        if self.created_at is not None:
-            q &= self.created_at.to_q("created_at")
-
         # Free-text search
-        if self.search is not None and self.search.value:
-            search_q = Q(name__icontains=self.search.value) | Q(
-                type__icontains=self.search.value
-            )
-            if self.search.modifier == Modifier.EXCLUDES:
-                search_q = ~search_q
-            q &= search_q
+        if self.search is not None:
+            q &= search_q(self.search, "name", "type")
 
         # Cross-entity sub-filter: devices that have matching sessions
         if self.session_filter is not None:
@@ -629,8 +572,7 @@ class DeviceFilter(OperatorFilter):
                 related_lookup="device_id",
             )
 
-        # AND / OR / NOT (n-ary; see OperatorFilter)
-        return self._apply_operators(q)
+        return q
 
 
 # ── PlatformFilter ─────────────────────────────────────────────────────────
@@ -656,31 +598,25 @@ class PlatformFilter(OperatorFilter):
     game_filter: GameFilter | None = None
     purchase_filter: PurchaseFilter | None = None
 
+    # Declarative attr→ORM-lookup table (order mirrors the old to_q emission).
+    fields = {
+        "name": FilterField(),
+        "group": FilterField(),
+        "icon": FilterField(),
+        "created_at": FilterField(),
+    }
+
     def _comparison_model(self) -> Type[Platform]:
         from games.models import Platform
 
         return Platform
 
-    def to_q(self) -> Q:
+    def _extra_q(self) -> Q:
         q = Q()
 
-        if self.name is not None:
-            q &= self.name.to_q("name")
-        if self.group is not None:
-            q &= self.group.to_q("group")
-        if self.icon is not None:
-            q &= self.icon.to_q("icon")
-        if self.created_at is not None:
-            q &= self.created_at.to_q("created_at")
-
         # Free-text search
-        if self.search is not None and self.search.value:
-            search_q = Q(name__icontains=self.search.value) | Q(
-                group__icontains=self.search.value
-            )
-            if self.search.modifier == Modifier.EXCLUDES:
-                search_q = ~search_q
-            q &= search_q
+        if self.search is not None:
+            q &= search_q(self.search, "name", "group")
 
         # Cross-entity sub-filters: platforms with matching games / purchases
         if self.game_filter is not None:
@@ -699,8 +635,7 @@ class PlatformFilter(OperatorFilter):
                 related_lookup="platform_id",
             )
 
-        # AND / OR / NOT (n-ary; see OperatorFilter)
-        return self._apply_operators(q)
+        return q
 
 
 # ── PlayEventFilter ────────────────────────────────────────────────────────
@@ -727,35 +662,27 @@ class PlayEventFilter(OperatorFilter):
     # Cross-entity: PlayEvents for games matching these criteria
     game_filter: GameFilter | None = None
 
+    # Declarative attr→ORM-lookup table (order mirrors the old to_q emission).
+    fields = {
+        "game": FilterField("game_id"),
+        "started": FilterField(),
+        "ended": FilterField(),
+        "days_to_finish": FilterField(),
+        "note": FilterField(),
+        "created_at": FilterField(),
+    }
+
     def _comparison_model(self) -> Type[PlayEvent]:
         from games.models import PlayEvent
 
         return PlayEvent
 
-    def to_q(self) -> Q:
+    def _extra_q(self) -> Q:
         q = Q()
 
-        if self.game is not None:
-            q &= self.game.to_q("game_id")
-        if self.started is not None:
-            q &= self.started.to_q("started")
-        if self.ended is not None:
-            q &= self.ended.to_q("ended")
-        if self.days_to_finish is not None:
-            q &= self.days_to_finish.to_q("days_to_finish")
-        if self.note is not None:
-            q &= self.note.to_q("note")
-        if self.created_at is not None:
-            q &= self.created_at.to_q("created_at")
-
         # Free-text search
-        if self.search is not None and self.search.value:
-            search_q = Q(game__name__icontains=self.search.value) | Q(
-                note__icontains=self.search.value
-            )
-            if self.search.modifier == Modifier.EXCLUDES:
-                search_q = ~search_q
-            q &= search_q
+        if self.search is not None:
+            q &= search_q(self.search, "game__name", "note")
 
         # Cross-entity sub-filter: playevents for matching games
         if self.game_filter is not None:
@@ -768,8 +695,7 @@ class PlayEventFilter(OperatorFilter):
                 parent_field="game_id",
             )
 
-        # AND / OR / NOT (n-ary; see OperatorFilter)
-        return self._apply_operators(q)
+        return q
 
 
 # ── Convenience helpers ────────────────────────────────────────────────────

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,5 +1,6 @@
 """Tests for the filtering system."""
 
+import dataclasses
 import json
 from dataclasses import dataclass
 from dataclasses import field as dc_field
@@ -9,6 +10,7 @@ from django.db.models import F, Q
 from django.test import SimpleTestCase as TestCase
 
 from common.criteria import (
+    AggregateCriterion,
     BoolCriterion,
     ChoiceCriterion,
     DateCriterion,
@@ -21,13 +23,19 @@ from common.criteria import (
     StringCriterion,
     _allowed_comparison_modifiers,
     _comparison_group_for,
+    _criterion_class_for,
     _field_comparison_to_q,
     _maybe_group_for,
     comparable_columns,
 )
 from common.components import FilterBar
 from games.filters import (
+    DeviceFilter,
     GameFilter,
+    PlatformFilter,
+    PlayEventFilter,
+    PurchaseFilter,
+    SessionFilter,
     parse_game_filter,
     parse_purchase_filter,
     parse_session_filter,
@@ -2758,3 +2766,76 @@ class FieldComparisonPrefillTest(TestCase):
         node = _field_comparison_section({}, Session)
         self.assertIsNotNone(node)
         self.assertIn("field-comparison-set", str(node))
+
+
+# ── Descriptor drift guard (issue #161) ──────────────────────────────────────
+
+
+class TestFilterFieldDescriptors:
+    """Guard the declarative ``fields`` table against drift from the dataclass.
+
+    Each concrete filter's generic ``to_q`` walks ``fields`` for its simple
+    criteria and delegates the rest to ``_extra_q``. These tests assert that
+    every declared criterion field is accounted for exactly once — in ``fields``,
+    as an aggregate, or in ``_IMPERATIVE_CRITERIA`` — so a newly added field can't
+    silently fall through (and thus be ignored by ``to_q``).
+    """
+
+    ALL_FILTERS = [
+        GameFilter,
+        SessionFilter,
+        PurchaseFilter,
+        DeviceFilter,
+        PlatformFilter,
+        PlayEventFilter,
+    ]
+
+    @staticmethod
+    def _declared_criterion_fields(filter_cls) -> set[str]:
+        """Every dataclass field whose annotation resolves to a criterion type."""
+        return {
+            f.name
+            for f in dataclasses.fields(filter_cls)
+            if _criterion_class_for(filter_cls, f.name) is not None
+        }
+
+    @classmethod
+    def _aggregate_fields(cls, filter_cls) -> set[str]:
+        result: set[str] = set()
+        for name in cls._declared_criterion_fields(filter_cls):
+            criterion_cls = _criterion_class_for(filter_cls, name)
+            if criterion_cls is not None and issubclass(
+                criterion_cls, AggregateCriterion
+            ):
+                result.add(name)
+        return result
+
+    @pytest.mark.parametrize("filter_cls", ALL_FILTERS)
+    def test_partition_covers_every_criterion_field(self, filter_cls):
+        declared = self._declared_criterion_fields(filter_cls)
+        descriptor_keys = set(filter_cls.fields)
+        aggregates = self._aggregate_fields(filter_cls)
+        imperative = set(filter_cls._IMPERATIVE_CRITERIA)
+        covered = descriptor_keys | aggregates | imperative
+        assert covered == declared, (
+            f"{filter_cls.__name__}: fields∪aggregates∪imperative != declared "
+            f"criterion fields; missing={declared - covered}, "
+            f"extra={covered - declared}"
+        )
+
+    @pytest.mark.parametrize("filter_cls", ALL_FILTERS)
+    def test_partition_has_no_overlap(self, filter_cls):
+        descriptor_keys = set(filter_cls.fields)
+        aggregates = self._aggregate_fields(filter_cls)
+        imperative = set(filter_cls._IMPERATIVE_CRITERIA)
+        assert descriptor_keys.isdisjoint(aggregates)
+        assert descriptor_keys.isdisjoint(imperative)
+        assert aggregates.isdisjoint(imperative)
+
+    @pytest.mark.parametrize("filter_cls", ALL_FILTERS)
+    def test_descriptor_keys_are_real_criterion_fields(self, filter_cls):
+        declared = self._declared_criterion_fields(filter_cls)
+        for key in filter_cls.fields:
+            assert key in declared, (
+                f"{filter_cls.__name__}.fields[{key!r}] is not a criterion field"
+            )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -16,6 +16,7 @@ from common.criteria import (
     DateCriterion,
     FieldComparisonCriterion,
     FilterError,
+    FilterField,
     IntCriterion,
     Modifier,
     MultiCriterion,
@@ -26,7 +27,11 @@ from common.criteria import (
     _criterion_class_for,
     _field_comparison_to_q,
     _maybe_group_for,
+    bool_isnull_handler,
+    bool_nonzero_duration_handler,
     comparable_columns,
+    duration_hours_handler,
+    search_q,
 )
 from common.components import FilterBar
 from games.filters import (
@@ -2839,3 +2844,122 @@ class TestFilterFieldDescriptors:
             assert key in declared, (
                 f"{filter_cls.__name__}.fields[{key!r}] is not a criterion field"
             )
+
+
+# ── FilterField handlers (issue #161) ────────────────────────────────────────
+
+
+class TestFilterField:
+    """The descriptor's lookup/handler contract."""
+
+    def test_plain_field_defaults_lookup_to_attr_name(self):
+        assert FilterField().to_q("name", StringCriterion(value="x")) == Q(name="x")
+
+    def test_lookup_override(self):
+        assert FilterField("platform_id").to_q(
+            "platform", MultiCriterion(value=[1, 2])
+        ) == Q(platform_id__in=[1, 2])
+
+    def test_lookup_and_handler_together_rejected(self):
+        with pytest.raises(ValueError, match="lookup OR handler"):
+            FilterField("x", handler=lambda c: Q())
+
+
+class TestFilterFieldHandlers:
+    """Each handler factory's Q output, and that the right handler is wired to the
+    field it serves (a plain FilterField regression would pass the drift guard but
+    fail here)."""
+
+    def test_duration_hours_equals_bucket(self):
+        from datetime import timedelta
+
+        handler = duration_hours_handler("duration_total")
+        assert handler(IntCriterion(value=4, modifier=Modifier.EQUALS)) == Q(
+            duration_total__gte=timedelta(hours=4),
+            duration_total__lt=timedelta(hours=5),
+        )
+
+    def test_duration_hours_between_passes_value2(self):
+        # The refactor reads value2 via getattr — confirm it actually flows through.
+        from datetime import timedelta
+
+        handler = duration_hours_handler("duration_total")
+        assert handler(IntCriterion(value=1, value2=5, modifier=Modifier.BETWEEN)) == Q(
+            duration_total__gte=timedelta(hours=1),
+            duration_total__lte=timedelta(hours=5),
+        )
+
+    def test_bool_isnull_handler_direct(self):
+        assert bool_isnull_handler("timestamp_end")(BoolCriterion(value=True)) == Q(
+            timestamp_end__isnull=True
+        )
+        assert bool_isnull_handler("timestamp_end")(BoolCriterion(value=False)) == Q(
+            timestamp_end__isnull=False
+        )
+
+    def test_bool_isnull_handler_invert(self):
+        assert bool_isnull_handler("date_refunded", invert=True)(
+            BoolCriterion(value=True)
+        ) == Q(date_refunded__isnull=False)
+        assert bool_isnull_handler("date_refunded", invert=True)(
+            BoolCriterion(value=False)
+        ) == Q(date_refunded__isnull=True)
+
+    def test_bool_nonzero_duration_handler(self):
+        from datetime import timedelta
+
+        handler = bool_nonzero_duration_handler("duration_manual")
+        assert handler(BoolCriterion(value=True)) == ~Q(duration_manual=timedelta(0))
+        assert handler(BoolCriterion(value=False)) == Q(duration_manual=timedelta(0))
+
+    # ── wiring: the field maps to the intended handler via the generic to_q ──
+
+    def test_is_active_wired(self):
+        assert SessionFilter(is_active=BoolCriterion(value=True)).to_q() == Q(
+            timestamp_end__isnull=True
+        )
+
+    def test_is_manual_wired(self):
+        from datetime import timedelta
+
+        assert SessionFilter(is_manual=BoolCriterion(value=True)).to_q() == ~Q(
+            duration_manual=timedelta(0)
+        )
+
+    def test_is_refunded_wired(self):
+        # value=False must select non-refunded (date_refunded IS NULL).
+        assert PurchaseFilter(is_refunded=BoolCriterion(value=False)).to_q() == Q(
+            date_refunded__isnull=True
+        )
+
+    def test_playtime_hours_wired(self):
+        from datetime import timedelta
+
+        assert GameFilter(
+            playtime_hours=IntCriterion(value=2, modifier=Modifier.GREATER_THAN)
+        ).to_q() == Q(playtime__gt=timedelta(hours=2))
+
+
+class TestSearchQHelper:
+    """search_q: empty short-circuit, multi-column OR, EXCLUDES negation."""
+
+    def test_empty_value_no_constraint(self):
+        assert search_q(StringCriterion(value=""), "name", "note") == Q()
+
+    def test_empty_value_excludes_still_no_constraint(self):
+        # Matches the old `if search and search.value` guard: empty value never
+        # negates to zero rows, regardless of modifier.
+        assert (
+            search_q(StringCriterion(value="", modifier=Modifier.EXCLUDES), "name")
+            == Q()
+        )
+
+    def test_multi_column_or(self):
+        assert search_q(StringCriterion(value="x"), "a", "b") == (
+            Q(a__icontains="x") | Q(b__icontains="x")
+        )
+
+    def test_excludes_negates_whole_disjunction(self):
+        assert search_q(
+            StringCriterion(value="x", modifier=Modifier.EXCLUDES), "a", "b"
+        ) == ~(Q(a__icontains="x") | Q(b__icontains="x"))


### PR DESCRIPTION
Closes #161. First part of Wave 1 of the filter overhaul roadmap (#171).

## Problem
Every concrete filter (`GameFilter`, `SessionFilter`, `PurchaseFilter`, `DeviceFilter`, `PlatformFilter`, `PlayEventFilter`) **overrode** `OperatorFilter.to_q` with a near-identical block hand-mapping each dataclass attribute to its real ORM lookup — FK `_id` suffix (`platform`→`platform_id`), relation traversal (`platform_group`→`platform__group`), date projection (`timestamp_start`→`timestamp_start__date`), hours→timedelta conversion, and custom bool→Q logic (`is_active`/`is_manual`/`is_refunded`). Six overrides duplicated the same shape; the attr≠lookup mapping was a silent footgun.

## Change
- **`common/criteria.py`**: new `FilterField` descriptor (`lookup` + optional `handler`) + `FieldHandler` type; reusable handler factories `duration_hours_handler` / `bool_isnull_handler` / `bool_nonzero_duration_handler` / `search_q`. `OperatorFilter.to_q` is now **generic**: walk the declarative `fields` table → fold in an overridable `_extra_q()` tail → `_apply_operators`.
- **`games/filters.py`**: all six filters drop their `to_q` override for a declarative `fields = {...}` table + an `_extra_q()` holding the imperative tail (aggregates, M2M `games`, free-text search, relation sub-filters). Deleted dead helpers (`_playtime_to_q*`, `_duration_to_q`). **−130 lines.**
- **`tests/test_filters.py`**: drift-guard test (18 cases) asserting `fields ∪ aggregates ∪ _IMPERATIVE_CRITERIA` exactly partitions each filter's declared criterion fields — a new field can't silently bypass `to_q`.

Per the issue, M2M / relations / aggregates stay imperative. The issue's "criterion type" is the annotation (validated by the drift test, not duplicated); the lone "group" case is expressed via `lookup`.

## Verification
`ruff format` ✓ · `ruff check` ✓ · `mypy .` ✓ (144 files) · `pytest tests/` → **899 passed + 56 subtests**. Behavior-preserving — Q output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)