### PR TITLE
feat(filters): field-comparison >=/<= and date-granular datetime compare (#162)

### DIFF
--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -772,11 +772,17 @@ def _field_comparison_row(
                 ],
             ),
             # Day-granular toggle — only meaningful for datetime operands, so
-            # field-comparison-set.ts shows/hides it from the chosen left column.
+            # field-comparison-set.ts shows/hides it based on the chosen left
+            # column. Hand-rolled (not Checkbox()) because the wrapper Label must
+            # carry data-fc-granularity-wrap + hidden; the input reuses Checkbox's
+            # utility classes so it matches every other checkbox in the app.
             Label(
                 attributes=[
                     ("data-fc-granularity-wrap", ""),
-                    ("class", "flex items-center gap-1 text-sm text-body"),
+                    (
+                        "class",
+                        "flex items-center gap-1 text-sm text-body cursor-pointer",
+                    ),
                     *([] if granularity_date else [("hidden", "")]),
                 ],
                 children=[
@@ -785,7 +791,12 @@ def _field_comparison_row(
                         attributes=[
                             ("type", "checkbox"),
                             ("data-fc-granularity", ""),
-                            ("class", "cursor-pointer"),
+                            (
+                                "class",
+                                "rounded border-default-medium"
+                                " bg-neutral-secondary-medium text-brand"
+                                " focus:ring-brand cursor-pointer",
+                            ),
                             *([("checked", "")] if granularity_date else []),
                         ],
                     ),

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -675,6 +675,7 @@ class FieldComparisonRow(NamedTuple):
     left: str  # left column name, e.g. "timestamp_end"
     right: str  # right column name, e.g. "timestamp_start"
     modifier: str  # a Modifier value, e.g. "LESS_THAN"
+    granularity: str  # "raw" or "date" (day-granular datetime compare)
 
 
 def _fc_row_from_dict(raw: dict) -> FieldComparisonRow:
@@ -682,6 +683,7 @@ def _fc_row_from_dict(raw: dict) -> FieldComparisonRow:
         left=str(raw.get("left", "")),
         right=str(raw.get("right", "")),
         modifier=str(raw.get("modifier") or "EQUALS"),
+        granularity="date" if raw.get("granularity") == "date" else "raw",
     )
 
 
@@ -740,12 +742,14 @@ def _field_comparison_row(
     left_value = row.left if row else ""
     operator_value = row.modifier if row else ""
     right_value = row.right if row else ""
+    granularity_date = bool(row and row.granularity == "date")
     return Div(
         attributes=[
             ("data-fc-row", ""),
             (
                 "class",
-                "grid grid-cols-1 gap-2 items-center md:grid-cols-[1fr_auto_1fr_auto]",
+                "grid grid-cols-1 gap-2 items-center"
+                " md:grid-cols-[1fr_auto_1fr_auto_auto]",
             ),
         ],
         children=[
@@ -765,6 +769,27 @@ def _field_comparison_row(
                     ("data-fc-right", ""),
                     ("data-selected", right_value),
                     ("class", select_class),
+                ],
+            ),
+            # Day-granular toggle — only meaningful for datetime operands, so
+            # field-comparison-set.ts shows/hides it from the chosen left column.
+            Label(
+                attributes=[
+                    ("data-fc-granularity-wrap", ""),
+                    ("class", "flex items-center gap-1 text-sm text-body"),
+                    *([] if granularity_date else [("hidden", "")]),
+                ],
+                children=[
+                    Element(
+                        "input",
+                        attributes=[
+                            ("type", "checkbox"),
+                            ("data-fc-granularity", ""),
+                            ("class", "cursor-pointer"),
+                            *([("checked", "")] if granularity_date else []),
+                        ],
+                    ),
+                    "by day",
                 ],
             ),
             Element(

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -469,7 +469,7 @@ class AggregateCriterion(_Criterion):
         )
 
 
-type ComparisonGranularity = Literal["raw", "date"]  # e.g. "date"
+type ComparisonGranularity = Literal["raw", "date"]
 
 
 @dataclass
@@ -535,6 +535,16 @@ class FieldComparisonCriterion(_Criterion):
         if self.granularity != "raw":
             payload["granularity"] = self.granularity
         return payload
+
+    @classmethod
+    def from_json(cls, data: dict | None) -> Self | None:
+        # Validate granularity here (the base loop assigns it verbatim, like any
+        # field) so an unknown value is rejected at parse time rather than
+        # silently degrading to a raw comparison — mirrors the modifier coercion.
+        result = super().from_json(data)
+        if result is not None and result.granularity not in ("raw", "date"):
+            raise FilterError(f"unknown granularity {result.granularity!r}")
+        return result
 
 
 # ── Field descriptors ──────────────────────────────────────────────────────

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -17,6 +17,7 @@ from typing import Any, ClassVar, Literal, Self, TypedDict, TypeVar
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models import F, Q
+from django.db.models.functions import TruncDate
 
 # ── Errors ─────────────────────────────────────────────────────────────────
 
@@ -48,6 +49,8 @@ class Modifier(str, Enum):
     NOT_EQUALS = "NOT_EQUALS"
     GREATER_THAN = "GREATER_THAN"
     LESS_THAN = "LESS_THAN"
+    GREATER_THAN_OR_EQUAL = "GREATER_THAN_OR_EQUAL"
+    LESS_THAN_OR_EQUAL = "LESS_THAN_OR_EQUAL"
     BETWEEN = "BETWEEN"
     NOT_BETWEEN = "NOT_BETWEEN"
     INCLUDES = "INCLUDES"
@@ -103,7 +106,14 @@ class Modifier(str, Enum):
     @classmethod
     def for_ordered_field_comparisons(cls) -> list[Self]:
         """Equality + ordering — valid for every comparable group (numeric/date/string)."""
-        return [cls.EQUALS, cls.NOT_EQUALS, cls.GREATER_THAN, cls.LESS_THAN]
+        return [
+            cls.EQUALS,
+            cls.NOT_EQUALS,
+            cls.GREATER_THAN,
+            cls.LESS_THAN,
+            cls.GREATER_THAN_OR_EQUAL,
+            cls.LESS_THAN_OR_EQUAL,
+        ]
 
     @classmethod
     def for_field_comparisons(cls) -> list[Self]:
@@ -459,6 +469,9 @@ class AggregateCriterion(_Criterion):
         )
 
 
+type ComparisonGranularity = Literal["raw", "date"]  # e.g. "date"
+
+
 @dataclass
 class FieldComparisonCriterion(_Criterion):
     """Compare one model column to another (``left <op> right``) via F() expressions.
@@ -487,6 +500,11 @@ class FieldComparisonCriterion(_Criterion):
     *includes* the row (symmetric when both are nullable). Empty-string note: an
     empty ``right`` (``""``, not NULL) is a substring of every non-NULL ``left``,
     so INCLUDES then matches all rows with a non-NULL ``left``.
+
+    Granularity: ``granularity="date"`` truncates *both* operands to calendar day
+    at query time (``left__date <op> TruncDate(F(right))``) using the active
+    timezone — only valid when both operands are the ``datetime`` group (validated
+    by the base OperatorFilter). ``"raw"`` (the default) compares the columns as-is.
     """
 
     # Shadow the inherited `value` field: FieldComparisonCriterion has no
@@ -497,15 +515,26 @@ class FieldComparisonCriterion(_Criterion):
     left: str = ""
     right: str = ""
     modifier: Modifier = Modifier.EQUALS
+    granularity: ComparisonGranularity = "raw"
 
     def to_q(
         self, field_name: str = ""
     ) -> Q:  # field_name ignored; operands self-contained
-        return _field_comparison_to_q(self.left, self.right, self.modifier)
+        return _field_comparison_to_q(
+            self.left, self.right, self.modifier, self.granularity
+        )
 
     def to_json(self) -> dict[str, Any]:
         # left/right default to "" — the base to_json would drop them. Force-emit, like BoolCriterion.
-        return {"left": self.left, "right": self.right, "modifier": self.modifier}
+        payload: dict[str, Any] = {
+            "left": self.left,
+            "right": self.right,
+            "modifier": self.modifier,
+        }
+        # Emit granularity only when non-default to keep existing filter JSON byte-compatible.
+        if self.granularity != "raw":
+            payload["granularity"] = self.granularity
+        return payload
 
 
 # ── Field descriptors ──────────────────────────────────────────────────────
@@ -935,6 +964,11 @@ class OperatorFilter:
                         f"modifier {comparison.modifier} not allowed"
                         f" for {left_group} comparison"
                     )
+                if comparison.granularity == "date" and left_group != "datetime":
+                    raise FilterError(
+                        f"date-granular comparison needs datetime operands"
+                        f" (got {left_group})"
+                    )
                 q &= comparison.to_q()
         return q
 
@@ -1189,29 +1223,49 @@ def _numeric_to_q(
     raise FilterError(f"Unsupported modifier {modifier} for numeric comparison")
 
 
-def _field_comparison_to_q(left: str, right: str, modifier: Modifier) -> Q:
+def _field_comparison_to_q(
+    left: str,
+    right: str,
+    modifier: Modifier,
+    granularity: ComparisonGranularity = "raw",
+) -> Q:
     """Build a Q comparing two model columns: ``left <op> F(right)``.
 
-    Used by field-to-field comparison criteria. Six modifiers are supported: the
-    four ordered/equality ones (EQUALS, NOT_EQUALS, GREATER_THAN, LESS_THAN) plus
-    case-insensitive string containment (INCLUDES, EXCLUDES) — the latter two are
-    gated to string operands by ``_allowed_comparison_modifiers``. Anything else
-    raises FilterError. The ``_apply_operators`` caller pre-validates the modifier
-    against the operand group before calling this function, so the final
-    ``raise FilterError`` is a defensive guard not reached in normal use.
+    Used by field-to-field comparison criteria. Eight modifiers are supported: the
+    six ordered/equality ones (EQUALS, NOT_EQUALS, GREATER_THAN, LESS_THAN,
+    GREATER_THAN_OR_EQUAL, LESS_THAN_OR_EQUAL) plus case-insensitive string
+    containment (INCLUDES, EXCLUDES) — the latter two are gated to string operands
+    by ``_allowed_comparison_modifiers``. Anything else raises FilterError. The
+    ``_apply_operators`` caller pre-validates the modifier against the operand
+    group before calling this function, so the final ``raise FilterError`` is a
+    defensive guard not reached in normal use.
+
+    With ``granularity="date"`` both operands are truncated to calendar day at
+    query time (``left__date <op> TruncDate(F(right))``) using the active timezone;
+    ``_apply_operators`` gates this to the datetime group.
     """
+    if granularity == "date":
+        left_base = f"{left}__date"
+        right_expr: F | TruncDate = TruncDate(F(right))
+    else:
+        left_base = left
+        right_expr = F(right)
     if modifier == Modifier.EQUALS:
-        return Q(**{left: F(right)})
+        return Q(**{left_base: right_expr})
     if modifier == Modifier.NOT_EQUALS:
-        return ~Q(**{left: F(right)})
+        return ~Q(**{left_base: right_expr})
     if modifier == Modifier.GREATER_THAN:
-        return Q(**{f"{left}__gt": F(right)})
+        return Q(**{f"{left_base}__gt": right_expr})
     if modifier == Modifier.LESS_THAN:
-        return Q(**{f"{left}__lt": F(right)})
+        return Q(**{f"{left_base}__lt": right_expr})
+    if modifier == Modifier.GREATER_THAN_OR_EQUAL:
+        return Q(**{f"{left_base}__gte": right_expr})
+    if modifier == Modifier.LESS_THAN_OR_EQUAL:
+        return Q(**{f"{left_base}__lte": right_expr})
     if modifier == Modifier.INCLUDES:
-        return Q(**{f"{left}__icontains": F(right)})
+        return Q(**{f"{left_base}__icontains": right_expr})
     if modifier == Modifier.EXCLUDES:
-        return ~Q(**{f"{left}__icontains": F(right)})
+        return ~Q(**{f"{left_base}__icontains": right_expr})
     raise FilterError(f"Unsupported modifier {modifier} for field comparison")
 
 

--- a/e2e/test_field_comparison_e2e.py
+++ b/e2e/test_field_comparison_e2e.py
@@ -48,9 +48,26 @@ def prefilled_and_view(request):
     return HttpResponse(_bar_page(filter_json=filter_json))
 
 
+def prefilled_granularity_view(request):
+    filter_json = json.dumps(
+        {
+            "field_comparisons": [
+                {
+                    "left": "timestamp_start",
+                    "right": "timestamp_end",
+                    "modifier": "LESS_THAN_OR_EQUAL",
+                    "granularity": "date",
+                }
+            ]
+        }
+    )
+    return HttpResponse(_bar_page(filter_json=filter_json))
+
+
 urlpatterns = [
     path("test-fc-empty/", empty_bar_view),
     path("test-fc-prefilled-and/", prefilled_and_view),
+    path("test-fc-prefilled-granularity/", prefilled_granularity_view),
 ]
 
 
@@ -157,6 +174,78 @@ def test_and_prefill_round_trip(live_server, page):
     parsed = _filter_from_url(page.url)
     assert parsed["field_comparisons"] == [
         {"left": "timestamp_end", "right": "timestamp_start", "modifier": "LESS_THAN"}
+    ]
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_field_comparison_e2e")
+def test_by_day_toggle_serializes_granularity(live_server, page):
+    page.goto(live_server.url + "/test-fc-empty/")
+    page.locator("[data-fc-add]").click()
+    row = page.locator("[data-fc-row]").first
+    by_day = row.locator("[data-fc-granularity-wrap]")
+
+    # Hidden until a datetime left column is chosen.
+    assert not by_day.is_visible()
+    row.locator("[data-fc-left]").select_option("timestamp_start")
+    assert by_day.is_visible()
+    # >= / <= are offered for the datetime (ordered) set.
+    operator = row.locator("[data-fc-op]")
+    assert operator.locator('option[value="LESS_THAN_OR_EQUAL"]').count() == 1
+
+    by_day.locator("[data-fc-granularity]").check()
+    operator.select_option("LESS_THAN_OR_EQUAL")
+    row.locator("[data-fc-right]").select_option("timestamp_end")
+    _submit(page)
+
+    parsed = _filter_from_url(page.url)
+    assert parsed["field_comparisons"] == [
+        {
+            "left": "timestamp_start",
+            "right": "timestamp_end",
+            "modifier": "LESS_THAN_OR_EQUAL",
+            "granularity": "date",
+        }
+    ]
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_field_comparison_e2e")
+def test_by_day_hidden_for_non_datetime_left(live_server, page):
+    page.goto(live_server.url + "/test-fc-empty/")
+    page.locator("[data-fc-add]").click()
+    row = page.locator("[data-fc-row]").first
+    by_day = row.locator("[data-fc-granularity-wrap]")
+
+    # Datetime → visible; switching to a non-datetime column hides + clears it.
+    row.locator("[data-fc-left]").select_option("timestamp_start")
+    by_day.locator("[data-fc-granularity]").check()
+    assert by_day.is_visible()
+    row.locator("[data-fc-left]").select_option("note")
+    assert not by_day.is_visible()
+    assert not by_day.locator("[data-fc-granularity]").is_checked()
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_field_comparison_e2e")
+def test_granularity_prefill_round_trip(live_server, page):
+    page.goto(live_server.url + "/test-fc-prefilled-granularity/")
+
+    row = page.locator("[data-fc-row]").first
+    by_day = row.locator("[data-fc-granularity-wrap]")
+    assert by_day.is_visible()
+    assert by_day.locator("[data-fc-granularity]").is_checked()
+    assert row.locator("[data-fc-op]").input_value() == "LESS_THAN_OR_EQUAL"
+
+    _submit(page)
+    parsed = _filter_from_url(page.url)
+    assert parsed["field_comparisons"] == [
+        {
+            "left": "timestamp_start",
+            "right": "timestamp_end",
+            "modifier": "LESS_THAN_OR_EQUAL",
+            "granularity": "date",
+        }
     ]
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -13,6 +13,7 @@ from common.criteria import (
     AggregateCriterion,
     BoolCriterion,
     ChoiceCriterion,
+    ComparisonGranularity,
     DateCriterion,
     FieldComparisonCriterion,
     FilterError,
@@ -1615,6 +1616,27 @@ class TestFieldComparisonCriterion:
         assert restored is not None
         assert restored.granularity == "raw"
 
+    def test_from_json_rejects_unknown_granularity(self):
+        with pytest.raises(FilterError, match="unknown granularity"):
+            FieldComparisonCriterion.from_json(
+                {
+                    "left": "a",
+                    "right": "b",
+                    "modifier": "EQUALS",
+                    "granularity": "month",
+                }
+            )
+
+    def test_helper_date_granular_strict_ordering(self):
+        from django.db.models.functions import TruncDate
+
+        assert _field_comparison_to_q(
+            "timestamp_start", "timestamp_end", Modifier.GREATER_THAN, "date"
+        ) == Q(timestamp_start__date__gt=TruncDate(F("timestamp_end")))
+        assert _field_comparison_to_q(
+            "timestamp_start", "timestamp_end", Modifier.LESS_THAN, "date"
+        ) == Q(timestamp_start__date__lt=TruncDate(F("timestamp_end")))
+
     # ── FieldComparisonCriterion.to_q ────────────────────────────────────────
 
     def test_to_q_delegates_to_helper(self):
@@ -2041,6 +2063,23 @@ class TestFieldComparisonWiring:
         with pytest.raises(FilterError, match="datetime operands"):
             stub.to_q()
 
+    def test_includes_on_datetime_rejected_before_granularity(self):
+        """INCLUDES/EXCLUDES (string-only) and date-granular (datetime-only) are
+        mutually exclusive by group: an INCLUDES on a datetime pair is rejected by
+        the modifier gate, so the nonsense __date__icontains query is unreachable."""
+        stub = _SessionStub(
+            field_comparisons=[
+                FieldComparisonCriterion(
+                    left="timestamp_start",
+                    right="timestamp_end",
+                    modifier=Modifier.INCLUDES,
+                    granularity="date",
+                )
+            ]
+        )
+        with pytest.raises(FilterError, match="not allowed"):
+            stub.to_q()
+
     def test_roundtrip_restores_equal_object(self):
         stub = _PurchaseStub(
             field_comparisons=[
@@ -2463,6 +2502,60 @@ class TestFieldComparisonEndToEnd:
         )
         result = set(Session.objects.filter(session_filter.to_q()))
         assert result == {session_x}
+
+    def test_date_granular_same_day_behavior(self):
+        """granularity='date' matches by calendar day, unlike a raw comparison.
+
+        SAME spans one day (different clock times); CROSS spans two days. Uses
+        timestamps far from midnight in any near-UTC timezone so the active tz of
+        the test run cannot flip which calendar day a boundary falls on.
+        """
+        import datetime
+
+        from games.filters import SessionFilter
+        from games.models import Session
+
+        _, game = self._make_platform_and_game()
+
+        same = Session.objects.create(
+            game=game,
+            timestamp_start=datetime.datetime(
+                2024, 6, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+            timestamp_end=datetime.datetime(
+                2024, 6, 1, 14, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+        )
+        cross = Session.objects.create(
+            game=game,
+            timestamp_start=datetime.datetime(
+                2024, 6, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+            timestamp_end=datetime.datetime(
+                2024, 6, 3, 10, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+        )
+
+        def run(modifier: Modifier, granularity: ComparisonGranularity) -> set:
+            session_filter = SessionFilter(
+                field_comparisons=[
+                    FieldComparisonCriterion(
+                        left="timestamp_start",
+                        right="timestamp_end",
+                        modifier=modifier,
+                        granularity=granularity,
+                    )
+                ]
+            )
+            return set(Session.objects.filter(session_filter.to_q()))
+
+        # date-granular EQUALS: only the same-calendar-day session.
+        assert run(Modifier.EQUALS, "date") == {same}
+        # raw EQUALS: neither (clock times always differ) — the contrast that
+        # motivates the feature.
+        assert run(Modifier.EQUALS, "raw") == set()
+        # date-granular LESS_THAN (start day < end day): only the cross-day one.
+        assert run(Modifier.LESS_THAN, "date") == {cross}
 
     def test_generated_field_as_comparison_operand(self):
         """duration_total > duration_manual finds only P.

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1538,9 +1538,82 @@ class TestFieldComparisonCriterion:
             name__icontains=F("sort_name")
         )
 
+    def test_helper_greater_than_or_equal(self):
+        assert _field_comparison_to_q(
+            "date_refunded", "date_purchased", Modifier.GREATER_THAN_OR_EQUAL
+        ) == Q(date_refunded__gte=F("date_purchased"))
+
+    def test_helper_less_than_or_equal(self):
+        assert _field_comparison_to_q(
+            "date_refunded", "date_purchased", Modifier.LESS_THAN_OR_EQUAL
+        ) == Q(date_refunded__lte=F("date_purchased"))
+
     def test_helper_unsupported_modifier_raises(self):
         with pytest.raises(FilterError, match="Unsupported modifier"):
             _field_comparison_to_q("date_refunded", "date_purchased", Modifier.BETWEEN)
+
+    # ── date-granular comparison (granularity="date") ────────────────────────
+
+    def test_helper_date_granular_equals(self):
+        from django.db.models.functions import TruncDate
+
+        assert _field_comparison_to_q(
+            "timestamp_start", "timestamp_end", Modifier.EQUALS, "date"
+        ) == Q(timestamp_start__date=TruncDate(F("timestamp_end")))
+
+    def test_helper_date_granular_gte(self):
+        from django.db.models.functions import TruncDate
+
+        assert _field_comparison_to_q(
+            "timestamp_start",
+            "timestamp_end",
+            Modifier.GREATER_THAN_OR_EQUAL,
+            "date",
+        ) == Q(timestamp_start__date__gte=TruncDate(F("timestamp_end")))
+
+    def test_helper_date_granular_not_equals(self):
+        from django.db.models.functions import TruncDate
+
+        assert _field_comparison_to_q(
+            "timestamp_start", "timestamp_end", Modifier.NOT_EQUALS, "date"
+        ) == ~Q(timestamp_start__date=TruncDate(F("timestamp_end")))
+
+    def test_to_q_passes_granularity(self):
+        from django.db.models.functions import TruncDate
+
+        criterion = FieldComparisonCriterion(
+            left="timestamp_start",
+            right="timestamp_end",
+            modifier=Modifier.LESS_THAN_OR_EQUAL,
+            granularity="date",
+        )
+        assert criterion.to_q() == Q(
+            timestamp_start__date__lte=TruncDate(F("timestamp_end"))
+        )
+
+    def test_to_json_emits_granularity_only_when_date(self):
+        raw = FieldComparisonCriterion(left="a", right="b")
+        assert "granularity" not in raw.to_json()
+        dated = FieldComparisonCriterion(
+            left="timestamp_start", right="timestamp_end", granularity="date"
+        )
+        assert dated.to_json()["granularity"] == "date"
+
+    def test_roundtrip_granularity_date(self):
+        criterion = FieldComparisonCriterion(
+            left="timestamp_start",
+            right="timestamp_end",
+            modifier=Modifier.EQUALS,
+            granularity="date",
+        )
+        assert FieldComparisonCriterion.from_json(criterion.to_json()) == criterion
+
+    def test_from_json_defaults_granularity_to_raw(self):
+        restored = FieldComparisonCriterion.from_json(
+            {"left": "a", "right": "b", "modifier": "EQUALS"}
+        )
+        assert restored is not None
+        assert restored.granularity == "raw"
 
     # ── FieldComparisonCriterion.to_q ────────────────────────────────────────
 
@@ -1599,6 +1672,8 @@ class TestFieldComparisonCriterion:
             Modifier.NOT_EQUALS,
             Modifier.GREATER_THAN,
             Modifier.LESS_THAN,
+            Modifier.GREATER_THAN_OR_EQUAL,
+            Modifier.LESS_THAN_OR_EQUAL,
         ]
 
     def test_for_field_comparisons(self):
@@ -1608,6 +1683,8 @@ class TestFieldComparisonCriterion:
             Modifier.NOT_EQUALS,
             Modifier.GREATER_THAN,
             Modifier.LESS_THAN,
+            Modifier.GREATER_THAN_OR_EQUAL,
+            Modifier.LESS_THAN_OR_EQUAL,
             Modifier.INCLUDES,
             Modifier.EXCLUDES,
         ]
@@ -1877,6 +1954,18 @@ class _NoModelStub(OperatorFilter):
     NOT: list["_NoModelStub"] = dc_field(default_factory=list)
 
 
+@dataclass
+class _SessionStub(OperatorFilter):
+    AND: list["_SessionStub"] = dc_field(default_factory=list)
+    OR: list["_SessionStub"] = dc_field(default_factory=list)
+    NOT: list["_SessionStub"] = dc_field(default_factory=list)
+
+    def _comparison_model(self):
+        from games.models import Session
+
+        return Session
+
+
 @pytest.mark.django_db
 class TestFieldComparisonWiring:
     # 1. Happy path — to_q produces the expected Q
@@ -1918,6 +2007,39 @@ class TestFieldComparisonWiring:
     def test_empty_field_comparisons_omitted_from_json(self):
         stub = _PurchaseStub()
         assert "field_comparisons" not in stub.to_json()
+
+    # granularity="date" — valid on datetime operands, rejected elsewhere
+
+    def test_date_granularity_on_datetime_ok(self):
+        from django.db.models.functions import TruncDate
+
+        stub = _SessionStub(
+            field_comparisons=[
+                FieldComparisonCriterion(
+                    left="timestamp_start",
+                    right="timestamp_end",
+                    modifier=Modifier.LESS_THAN_OR_EQUAL,
+                    granularity="date",
+                )
+            ]
+        )
+        assert stub.to_q() == Q(
+            timestamp_start__date__lte=TruncDate(F("timestamp_end"))
+        )
+
+    def test_date_granularity_on_non_datetime_raises(self):
+        stub = _PurchaseStub(
+            field_comparisons=[
+                FieldComparisonCriterion(
+                    left="date_refunded",
+                    right="date_purchased",
+                    modifier=Modifier.EQUALS,
+                    granularity="date",
+                )
+            ]
+        )
+        with pytest.raises(FilterError, match="datetime operands"):
+            stub.to_q()
 
     def test_roundtrip_restores_equal_object(self):
         stub = _PurchaseStub(

--- a/ts/elements/field-comparison-set.ts
+++ b/ts/elements/field-comparison-set.ts
@@ -23,6 +23,7 @@ export interface ComparisonRow {
   left: string;
   right: string;
   modifier: string;
+  granularity?: string; // omitted when "raw" to keep filter JSON compact
 }
 
 // Operator labels by Modifier value — must match the modifiers the server
@@ -32,16 +33,25 @@ const OPERATOR_LABELS: Record<string, string> = {
   NOT_EQUALS: "≠",
   GREATER_THAN: ">",
   LESS_THAN: "<",
+  GREATER_THAN_OR_EQUAL: "≥",
+  LESS_THAN_OR_EQUAL: "≤",
   INCLUDES: "contains",
   EXCLUDES: "doesn't contain",
 };
 
+const ORDERED = [
+  "EQUALS",
+  "NOT_EQUALS",
+  "GREATER_THAN",
+  "LESS_THAN",
+  "GREATER_THAN_OR_EQUAL",
+  "LESS_THAN_OR_EQUAL",
+];
+
 function operatorsForGroup(group: string): string[] {
   if (group === "bool") return ["EQUALS", "NOT_EQUALS"];
-  if (group === "string") {
-    return ["EQUALS", "NOT_EQUALS", "GREATER_THAN", "LESS_THAN", "INCLUDES", "EXCLUDES"];
-  }
-  return ["EQUALS", "NOT_EQUALS", "GREATER_THAN", "LESS_THAN"];
+  if (group === "string") return [...ORDERED, "INCLUDES", "EXCLUDES"];
+  return ORDERED;
 }
 
 function groupOf(columns: Column[], value: string): string | null {
@@ -84,6 +94,14 @@ function refreshRow(row: HTMLElement, columns: Column[]): void {
   right.removeAttribute("data-selected");
 
   const group = groupOf(columns, left.value);
+
+  // Day-granular toggle is only meaningful for datetime operands.
+  const granularityWrap = row.querySelector<HTMLElement>("[data-fc-granularity-wrap]");
+  const granularityInput = row.querySelector<HTMLInputElement>("[data-fc-granularity]");
+  const isDatetime = group === "datetime";
+  if (granularityWrap) granularityWrap.hidden = !isDatetime;
+  if (granularityInput && !isDatetime) granularityInput.checked = false;
+
   if (!group) {
     fillSelect(operator, [], "", "—");
     fillSelect(right, [], "", "column…");
@@ -133,8 +151,13 @@ export function readFieldComparisonSet(element: HTMLElement): {
     const left = row.querySelector<HTMLSelectElement>("[data-fc-left]")?.value ?? "";
     const modifier = row.querySelector<HTMLSelectElement>("[data-fc-op]")?.value ?? "";
     const right = row.querySelector<HTMLSelectElement>("[data-fc-right]")?.value ?? "";
+    const byDay = row.querySelector<HTMLInputElement>("[data-fc-granularity]");
+    const byDayWrap = row.querySelector<HTMLElement>("[data-fc-granularity-wrap]");
+    const isDate = Boolean(byDay?.checked && byDayWrap && !byDayWrap.hidden);
     if (left && right && modifier && left !== right) {
-      comparisons.push({ left, right, modifier });
+      const entry: ComparisonRow = { left, right, modifier };
+      if (isDate) entry.granularity = "date";
+      comparisons.push(entry);
     }
   });
   return { mode, comparisons };

--- a/ts/elements/field-comparison-set.ts
+++ b/ts/elements/field-comparison-set.ts
@@ -23,7 +23,7 @@ export interface ComparisonRow {
   left: string;
   right: string;
   modifier: string;
-  granularity?: string; // omitted when "raw" to keep filter JSON compact
+  granularity?: "date"; // omitted when "raw" to keep filter JSON compact
 }
 
 // Operator labels by Modifier value — must match the modifiers the server


### PR DESCRIPTION
Closes #162.

Extends the field-to-field comparison filter (from #129 / #164) with the two gaps in #162.

## 1. `>=` / `<=` operators
`Modifier` gains `GREATER_THAN_OR_EQUAL` / `LESS_THAN_OR_EQUAL`, added to `for_ordered_field_comparisons()` (so they propagate to validation, the string set, and UI parity), mapped to `__gte` / `__lte` in `_field_comparison_to_q`. UI shows `≥` / `≤`.

## 2. Date-granular datetime compare
A first-class `granularity` flag on `FieldComparisonCriterion`. `granularity="date"` truncates **both** operands to calendar day **at query time**:

```
timestamp_start__date <op> TruncDate(F(timestamp_end))
```

using the active timezone, gated to the `datetime` group by `_apply_operators`. UI: a **"by day"** checkbox per row, shown only when the left column is a datetime. `to_json` omits `granularity` when `"raw"`, so existing filter JSON/URLs are byte-identical.

The motivating example — "session started and ended on the same day" — is now `timestamp_start = timestamp_end` with **by day** checked.

### Why query-time, not a stored date column
A per-row tz column + STORED `GeneratedField` was prototyped and *works* (verified: per-row truncation, recompute on tz `UPDATE`, and a `TIME_ZONE` change is data-not-schema so `makemigrations` reports "No changes"). It was **rejected**: tz is a *user* attribute, so a per-row copy denormalizes it across every datetime table, creates a cross-table sync invariant, and a second notion of "day" vs the existing single-field `__date` filters — all in an app that isn't user-scoped yet. Query-time `TruncDate` keeps **one source of truth** and becomes per-user-correct automatically once per-user tz activation lands (#177).

## Tests
- `>=` / `<=` → `__gte` / `__lte`; both in `for_ordered_field_comparisons()` / `for_field_comparisons()` / `_allowed_comparison_modifiers`.
- date-granular `to_q` for EQUALS / GTE / NOT_EQUALS; `granularity="date"` on a non-datetime group raises; datetime path builds the `TruncDate` Q end-to-end via `SessionFilter`.
- serialization round-trip preserves `granularity`; omitted/`"raw"` parses to `"raw"`.
- 926 unit tests pass; mypy + ruff + ts-check clean.

## Follow-up
- #177 — per-user timezone (tz field + activation middleware); makes all query-time date truncation per-user-correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)