### PR TITLE
fix(filters): validate criterion value types at parse (#157)

### DIFF
--- a/common/criteria.py
+++ b/common/criteria.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable, Sequence
+from datetime import date
 from dataclasses import dataclass, field, fields as dc_fields
 from enum import Enum
 from typing import Any, ClassVar, Literal, Self, TypedDict, TypeVar
@@ -136,6 +137,41 @@ class RelationMatch(str, Enum):
     ALL = "ALL"  # every related row matches; vacuously true for zero-row parents
 
 
+# ── Value coercers ───────────────────────────────────────────────────────────
+# Parse-time value validators (issue #157). A criterion declares one via its
+# ``_coerce`` hook; ``from_json`` applies it so a wrong-typed hand-edited
+# ``?filter=`` value raises ``FilterError`` at parse rather than escaping the
+# error boundary and 500-ing when the DB rejects it at query-execution time.
+# Each returns the coerced value or raises ``FilterError`` (a ``ValueError``,
+# caught by the boundary).
+
+
+def _coerce_int(raw: Any) -> int:
+    try:
+        return int(raw)
+    except (ValueError, TypeError) as exc:
+        raise FilterError(f"expected an integer, got {raw!r}") from exc
+
+
+def _coerce_float(raw: Any) -> float:
+    try:
+        return float(raw)
+    except (ValueError, TypeError) as exc:
+        raise FilterError(f"expected a number, got {raw!r}") from exc
+
+
+def _coerce_date(raw: Any) -> str:
+    # Keep the ISO string (``to_q`` passes it to ``Q``; the DB parses it); only
+    # validate that it is one, so a bad date is rejected here, not at eval.
+    if not isinstance(raw, str):
+        raise FilterError(f"expected an ISO date string, got {raw!r}")
+    try:
+        date.fromisoformat(raw)
+    except ValueError as exc:
+        raise FilterError(f"expected an ISO date string, got {raw!r}") from exc
+    return raw
+
+
 # ── Base criterion ─────────────────────────────────────────────────────────
 
 T = TypeVar("T")
@@ -147,6 +183,13 @@ class _Criterion:
 
     value: Any = None
     modifier: Modifier = Modifier.EQUALS
+
+    # Parse-time value validator (issue #157); ``None`` accepts the value as-is
+    # (string/bool/choice — never a 500 vector). Concrete classes whose value
+    # has a field-column type (int/float/date) set one of the ``_coerce_*``
+    # helpers; ``from_json`` applies it so a wrong-typed hand-edited value raises
+    # ``FilterError`` at parse instead of escaping to a query-execution 500.
+    _coerce: ClassVar[Callable[[Any], Any] | None] = None
 
     def to_q(self, field_name: str) -> Q:
         raise NotImplementedError
@@ -183,6 +226,35 @@ class _Criterion:
 
 
 @dataclass
+class _ScalarCriterion(_Criterion):
+    """Base for criteria whose ``value``/``value2`` are single field-column values
+    (int / float / date). Applies the class ``_coerce`` validator at parse so a
+    wrong-typed hand-edited value raises ``FilterError`` here, not as a 500 when
+    the DB rejects it at query-execution time (issue #157)."""
+
+    value2: Any = None
+
+    @classmethod
+    def from_json(cls, data: dict | None) -> Self | None:
+        result = super().from_json(data)
+        # ``result`` is non-None only when ``data`` was a dict (base contract).
+        if result is None or cls._coerce is None or data is None:
+            return result
+        # Presence tests ignore the value entirely, and widgets emit a placeholder
+        # (``value: ""``) for them — so don't coerce it (an empty string is not a
+        # valid date/number). For value-using modifiers a bad value still raises.
+        if result.modifier in (Modifier.IS_NULL, Modifier.NOT_NULL):
+            return result
+        coerce = cls._coerce
+        # Coerce only keys the user actually supplied and that aren't null, so a
+        # defaulted ``value``/``value2`` is never coerced.
+        for key in ("value", "value2"):
+            if data.get(key) is not None:
+                setattr(result, key, coerce(getattr(result, key)))
+        return result
+
+
+@dataclass
 class StringCriterion(_Criterion):
     value: str = ""
     modifier: Modifier = Modifier.EQUALS
@@ -209,10 +281,11 @@ class StringCriterion(_Criterion):
 
 
 @dataclass
-class IntCriterion(_Criterion):
+class IntCriterion(_ScalarCriterion):
     value: int = 0
     value2: int | None = None
     modifier: Modifier = Modifier.EQUALS
+    _coerce: ClassVar[Callable[[Any], Any] | None] = staticmethod(_coerce_int)
 
     def to_q(self, field_name: str) -> Q:
         m = self.modifier
@@ -246,10 +319,11 @@ class IntCriterion(_Criterion):
 
 
 @dataclass
-class FloatCriterion(_Criterion):
+class FloatCriterion(_ScalarCriterion):
     value: float = 0.0
     value2: float | None = None
     modifier: Modifier = Modifier.EQUALS
+    _coerce: ClassVar[Callable[[Any], Any] | None] = staticmethod(_coerce_float)
 
     def to_q(self, field_name: str) -> Q:
         m = self.modifier
@@ -283,10 +357,11 @@ class FloatCriterion(_Criterion):
 
 
 @dataclass
-class DateCriterion(_Criterion):
+class DateCriterion(_ScalarCriterion):
     value: str = ""
     value2: str | None = None
     modifier: Modifier = Modifier.EQUALS
+    _coerce: ClassVar[Callable[[Any], Any] | None] = staticmethod(_coerce_date)
 
     def to_q(self, field_name: str) -> Q:
         m = self.modifier
@@ -418,6 +493,14 @@ class _SetCriterion(_Criterion):
         result.excludes = [
             item["id"] if isinstance(item, dict) else item for item in result.excludes
         ]
+        # Coerce each element against the field-column type (issue #157), so an
+        # int-set field (MultiCriterion) rejects a wrong-typed id at parse rather
+        # than letting ``field__in=["xyz"]`` 500 at query execution. ChoiceCriterion
+        # leaves ``_coerce`` None (string codes against char columns never 500).
+        if cls._coerce is not None:
+            coerce = cls._coerce
+            result.value = [coerce(item) for item in result.value]
+            result.excludes = [coerce(item) for item in result.excludes]
         return result
 
 
@@ -431,6 +514,7 @@ class MultiCriterion(_SetCriterion):
 
     value: list[int] = field(default_factory=list)
     excludes: list[int] = field(default_factory=list)
+    _coerce: ClassVar[Callable[[Any], Any] | None] = staticmethod(_coerce_int)
 
 
 @dataclass
@@ -446,7 +530,7 @@ class ChoiceCriterion(_SetCriterion):
 
 
 @dataclass
-class AggregateCriterion(_Criterion):
+class AggregateCriterion(_ScalarCriterion):
     """Filter a parent entity by a reducer (count / sum / avg) over one of its
     relations, compared numerically — e.g. "games with > 5 sessions" or "sum of
     a game's purchase prices between X and Y".
@@ -459,6 +543,10 @@ class AggregateCriterion(_Criterion):
     value: int | float = 0
     value2: int | float | None = None
     modifier: Modifier = Modifier.EQUALS
+    # Aggregates compare numerically; coerce to float so a wrong-typed bound is
+    # caught at parse rather than surfacing as a query-execution 500. The eager
+    # build can't catch it: ``aggregate_to_q`` feeds the value straight into Q.
+    _coerce: ClassVar[Callable[[Any], Any] | None] = staticmethod(_coerce_float)
 
     def to_q(self, field_name: str) -> Q:
         # Unlike sibling criteria, an aggregate is not self-contained: its meaning
@@ -1154,10 +1242,13 @@ def filter_from_json(cls: type[FilterType], json_str: str) -> FilterType | None:
     on the result can raise. (A genuine wiring bug raises a non-``ValueError`` —
     see ``aggregate_to_q`` — and is intentionally *not* caught, so it still 500s.)
 
-    Note: this guarantee is scoped to ``to_q()`` itself. A wrong-typed value that
-    the database only rejects at query-execution time (e.g. a non-numeric
-    ``year_released``) is not caught here — tracked in issue #157
-    (parse-time value-type validation).
+    Wrong-typed *values* are caught even earlier (issue #157): each criterion's
+    ``from_json`` coerces/validates its value against the field-column type (int /
+    float / ISO date / int-id set), raising ``FilterError`` at parse — so a value
+    the database would only reject at query-execution time (e.g. a non-numeric
+    ``year_released``) never reaches the DB. The eager ``to_q()`` build below then
+    covers the remaining structural conversions (BETWEEN bounds, M2M id coercion
+    in ``_games_to_q``, hours→timedelta).
     """
     if not json_str:
         return None

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -173,6 +173,14 @@ def _coerce_float(raw: Any) -> float:
         raise FilterError(f"expected a number, got {raw!r}") from exc
 
 
+def _coerce_number(raw: Any) -> int | float:
+    # For fields that may be integer (a count) or fractional (a sum/avg): validate
+    # numerically but keep an integral value an ``int`` so a count round-trips as
+    # ``5`` rather than ``5.0`` in serialized filter JSON. Querying is unaffected.
+    number = _coerce_float(raw)
+    return int(number) if number.is_integer() else number
+
+
 def _strip_set_label(item: Any) -> Any:
     """Reduce a set-criterion element to its bare id. Widgets send ``{id, label}``
     dicts (label is display-only); a hand-edited dict missing ``id`` is bad input
@@ -320,7 +328,7 @@ class IntCriterion(_ScalarCriterion):
     value: int = 0
     value2: int | None = None
     modifier: Modifier = Modifier.EQUALS
-    _coerce: ClassVar[Callable[[Any], Any] | None] = staticmethod(_coerce_int)
+    _coerce: ClassVar[Coercer | None] = staticmethod(_coerce_int)
 
     def to_q(self, field_name: str) -> Q:
         m = self.modifier
@@ -358,7 +366,7 @@ class FloatCriterion(_ScalarCriterion):
     value: float = 0.0
     value2: float | None = None
     modifier: Modifier = Modifier.EQUALS
-    _coerce: ClassVar[Callable[[Any], Any] | None] = staticmethod(_coerce_float)
+    _coerce: ClassVar[Coercer | None] = staticmethod(_coerce_float)
 
     def to_q(self, field_name: str) -> Q:
         m = self.modifier
@@ -396,7 +404,7 @@ class DateCriterion(_ScalarCriterion):
     value: str = ""
     value2: str | None = None
     modifier: Modifier = Modifier.EQUALS
-    _coerce: ClassVar[Callable[[Any], Any] | None] = staticmethod(_coerce_date)
+    _coerce: ClassVar[Coercer | None] = staticmethod(_coerce_date)
 
     def to_q(self, field_name: str) -> Q:
         m = self.modifier
@@ -550,7 +558,7 @@ class MultiCriterion(_SetCriterion):
 
     value: list[int] = field(default_factory=list)
     excludes: list[int] = field(default_factory=list)
-    _coerce: ClassVar[Callable[[Any], Any] | None] = staticmethod(_coerce_int)
+    _coerce: ClassVar[Coercer | None] = staticmethod(_coerce_int)
 
 
 @dataclass
@@ -579,10 +587,11 @@ class AggregateCriterion(_ScalarCriterion):
     value: int | float = 0
     value2: int | float | None = None
     modifier: Modifier = Modifier.EQUALS
-    # Aggregates compare numerically; coerce to float so a wrong-typed bound is
-    # caught at parse rather than surfacing as a query-execution 500. The eager
-    # build can't catch it: ``aggregate_to_q`` feeds the value straight into Q.
-    _coerce: ClassVar[Callable[[Any], Any] | None] = staticmethod(_coerce_float)
+    # Aggregates compare numerically; coerce so a wrong-typed bound is caught at
+    # parse rather than surfacing as a query-execution 500 (the eager build can't
+    # catch it: ``aggregate_to_q`` feeds the value straight into Q). ``_coerce_number``
+    # keeps an integral count an int so it round-trips as ``5``, not ``5.0``.
+    _coerce: ClassVar[Coercer | None] = staticmethod(_coerce_number)
 
     def to_q(self, field_name: str) -> Q:
         # Unlike sibling criteria, an aggregate is not self-contained: its meaning

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -146,7 +146,17 @@ class RelationMatch(str, Enum):
 # caught by the boundary).
 
 
+# An ``int``/``float``/ISO-date coercer for a criterion's value (raises
+# ``FilterError`` on mismatch). Used as a criterion's ``_coerce`` hook.
+type Coercer = Callable[[Any], Any]  # e.g. _coerce_int
+
+
 def _coerce_int(raw: Any) -> int:
+    # Reject what ``int()`` would silently *accept and rewrite* rather than flag as
+    # the wrong type: a JSON bool (``int(True) == 1``) and a non-integral float
+    # (``int(3.9) == 3``). Both are wrong-typed input #157 means to surface.
+    if isinstance(raw, bool) or (isinstance(raw, float) and not raw.is_integer()):
+        raise FilterError(f"expected an integer, got {raw!r}")
     try:
         return int(raw)
     except (ValueError, TypeError) as exc:
@@ -154,10 +164,24 @@ def _coerce_int(raw: Any) -> int:
 
 
 def _coerce_float(raw: Any) -> float:
+    # Reject JSON bool (``float(True) == 1.0``); a boolean is not a numeric bound.
+    if isinstance(raw, bool):
+        raise FilterError(f"expected a number, got {raw!r}")
     try:
         return float(raw)
     except (ValueError, TypeError) as exc:
         raise FilterError(f"expected a number, got {raw!r}") from exc
+
+
+def _strip_set_label(item: Any) -> Any:
+    """Reduce a set-criterion element to its bare id. Widgets send ``{id, label}``
+    dicts (label is display-only); a hand-edited dict missing ``id`` is bad input
+    and raises ``FilterError`` rather than a boundary-bypassing ``KeyError``."""
+    if not isinstance(item, dict):
+        return item
+    if "id" not in item:
+        raise FilterError(f"set filter element is missing an id: {item!r}")
+    return item["id"]
 
 
 def _coerce_date(raw: Any) -> str:
@@ -189,7 +213,8 @@ class _Criterion:
     # has a field-column type (int/float/date) set one of the ``_coerce_*``
     # helpers; ``from_json`` applies it so a wrong-typed hand-edited value raises
     # ``FilterError`` at parse instead of escaping to a query-execution 500.
-    _coerce: ClassVar[Callable[[Any], Any] | None] = None
+    # ``_ScalarCriterion`` enforces that its scalar subclasses set one.
+    _coerce: ClassVar[Coercer | None] = None
 
     def to_q(self, field_name: str) -> Q:
         raise NotImplementedError
@@ -234,22 +259,32 @@ class _ScalarCriterion(_Criterion):
 
     value2: Any = None
 
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        # The whole point of a scalar criterion is that its value has a column type
+        # to validate. A subclass that forgets ``_coerce`` silently reverts to the
+        # pre-#157 500 vector, so fail at class-definition time instead.
+        super().__init_subclass__(**kwargs)
+        if cls._coerce is None:
+            raise TypeError(f"{cls.__name__} must set a _coerce validator (issue #157)")
+
     @classmethod
     def from_json(cls, data: dict | None) -> Self | None:
         result = super().from_json(data)
         # ``result`` is non-None only when ``data`` was a dict (base contract).
-        if result is None or cls._coerce is None or data is None:
+        if result is None or cls._coerce is None:
             return result
-        # Presence tests ignore the value entirely, and widgets emit a placeholder
-        # (``value: ""``) for them — so don't coerce it (an empty string is not a
-        # valid date/number). For value-using modifiers a bad value still raises.
+        # Presence tests ignore the value entirely (and widgets emit a placeholder
+        # ``value: ""`` for them), so skip coercion — the value never reaches to_q.
         if result.modifier in (Modifier.IS_NULL, Modifier.NOT_NULL):
             return result
         coerce = cls._coerce
-        # Coerce only keys the user actually supplied and that aren't null, so a
-        # defaulted ``value``/``value2`` is never coerced.
+        # Coerce every non-None value/value2: ``None`` is the DB-safe sentinel (an
+        # explicit null or a missing BETWEEN bound — compiled to IS NULL or caught
+        # by the BETWEEN guard), but a non-None default *can* be invalid (the
+        # DateCriterion ``""`` default with a value-using modifier), so it must be
+        # validated too rather than gated on user-supplied-ness. (Finding #157.)
         for key in ("value", "value2"):
-            if data.get(key) is not None:
+            if getattr(result, key) is not None:
                 setattr(result, key, coerce(getattr(result, key)))
         return result
 
@@ -486,17 +521,18 @@ class _SetCriterion(_Criterion):
         if result is None:
             return None
         # Labels embedded as {id, label} dicts are display-only; strip to bare ids
-        # so the querying layer stays clean and typed.
-        result.value = [
-            item["id"] if isinstance(item, dict) else item for item in result.value
-        ]
-        result.excludes = [
-            item["id"] if isinstance(item, dict) else item for item in result.excludes
-        ]
+        # so the querying layer stays clean and typed. A hand-edited dict without
+        # an ``id`` is bad input — raise FilterError (not a bare KeyError, which
+        # would bypass the boundary and 500).
+        result.value = [_strip_set_label(item) for item in result.value]
+        result.excludes = [_strip_set_label(item) for item in result.excludes]
         # Coerce each element against the field-column type (issue #157), so an
         # int-set field (MultiCriterion) rejects a wrong-typed id at parse rather
         # than letting ``field__in=["xyz"]`` 500 at query execution. ChoiceCriterion
-        # leaves ``_coerce`` None (string codes against char columns never 500).
+        # leaves ``_coerce`` None: its string-code fields (status, ownership_type,
+        # group, …) run against char columns and never 500. The one id-bearing
+        # ChoiceCriterion, PurchaseFilter.games (M2M int ids), is made 500-safe
+        # separately by _games_to_q's explicit int() coercion, not here.
         if cls._coerce is not None:
             coerce = cls._coerce
             result.value = [coerce(item) for item in result.value]

--- a/games/filters.py
+++ b/games/filters.py
@@ -81,13 +81,13 @@ class GameFilter(OperatorFilter):
     year_released: IntCriterion | None = None
     original_year_released: IntCriterion | None = None
     wikidata: StringCriterion | None = None
-    platform: ChoiceCriterion | None = None  # selectable filter widget
-    platform_group: MultiCriterion | None = None  # platform__group__in
+    platform: MultiCriterion | None = None  # platform_id (int FK)
+    platform_group: ChoiceCriterion | None = None  # platform__group (str)
     status: ChoiceCriterion | None = None  # selectable filter widget
     mastered: BoolCriterion | None = None
     playtime_hours: IntCriterion | None = None  # converted to timedelta on to_q()
-    created_at: StringCriterion | None = None  # date string
-    updated_at: StringCriterion | None = None  # date string
+    created_at: DateCriterion | None = None  # compared via __date
+    updated_at: DateCriterion | None = None  # compared via __date
 
     # Aggregates over the game's relations (count / sum / avg). The reducer +
     # relation accessor + source + unit are supplied at query time via
@@ -125,8 +125,8 @@ class GameFilter(OperatorFilter):
         "status": FilterField(),
         "mastered": FilterField(),
         "playtime_hours": FilterField(handler=duration_hours_handler("playtime")),
-        "created_at": FilterField(),
-        "updated_at": FilterField(),
+        "created_at": FilterField("created_at__date"),
+        "updated_at": FilterField("updated_at__date"),
         "platform_group": FilterField("platform__group"),
     }
 
@@ -273,7 +273,7 @@ class SessionFilter(OperatorFilter):
     timestamp_start: DateCriterion | None = None  # date, compared via __date
     timestamp_end: DateCriterion | None = None  # date, compared via __date
     is_manual: BoolCriterion | None = None  # duration_manual > 0
-    created_at: StringCriterion | None = None
+    created_at: DateCriterion | None = None  # compared via __date
 
     # Free-text search
     search: StringCriterion | None = None
@@ -307,7 +307,7 @@ class SessionFilter(OperatorFilter):
         "is_manual": FilterField(
             handler=bool_nonzero_duration_handler("duration_manual")
         ),
-        "created_at": FilterField(),
+        "created_at": FilterField("created_at__date"),
     }
 
     def _comparison_model(self) -> Type[Session]:
@@ -364,7 +364,7 @@ class PurchaseFilter(OperatorFilter):
     NOT: list[PurchaseFilter] = field(default_factory=list)
 
     name: StringCriterion | None = None
-    platform: ChoiceCriterion | None = None  # platform_id
+    platform: MultiCriterion | None = None  # platform_id (int FK)
     games: ChoiceCriterion | None = None  # games (M2M IDs)
     date_purchased: DateCriterion | None = None
     date_refunded: DateCriterion | None = None
@@ -375,8 +375,8 @@ class PurchaseFilter(OperatorFilter):
     num_purchases: IntCriterion | None = None
     ownership_type: ChoiceCriterion | None = None  # ph/di/du/re/bo/tr/de/pi
     type: ChoiceCriterion | None = None  # game/dlc/season_pass/battle_pass
-    created_at: StringCriterion | None = None
-    updated_at: StringCriterion | None = None
+    created_at: DateCriterion | None = None  # compared via __date
+    updated_at: DateCriterion | None = None  # compared via __date
 
     infinite: BoolCriterion | None = None
     needs_price_update: BoolCriterion | None = None
@@ -409,8 +409,8 @@ class PurchaseFilter(OperatorFilter):
         "num_purchases": FilterField(),
         "ownership_type": FilterField(),
         "type": FilterField(),
-        "created_at": FilterField(),
-        "updated_at": FilterField(),
+        "created_at": FilterField("created_at__date"),
+        "updated_at": FilterField("updated_at__date"),
         "infinite": FilterField(),
         "needs_price_update": FilterField(),
         "converted_currency": FilterField(),
@@ -540,7 +540,7 @@ class DeviceFilter(OperatorFilter):
 
     name: StringCriterion | None = None
     type: ChoiceCriterion | None = None
-    created_at: StringCriterion | None = None
+    created_at: DateCriterion | None = None  # compared via __date
 
     # Free-text search
     search: StringCriterion | None = None
@@ -553,7 +553,7 @@ class DeviceFilter(OperatorFilter):
     fields = {
         "name": FilterField(),
         "type": FilterField(),
-        "created_at": FilterField(),
+        "created_at": FilterField("created_at__date"),
     }
 
     def _comparison_model(self) -> Type[Device]:
@@ -595,7 +595,7 @@ class PlatformFilter(OperatorFilter):
     name: StringCriterion | None = None
     group: StringCriterion | None = None
     icon: StringCriterion | None = None
-    created_at: StringCriterion | None = None
+    created_at: DateCriterion | None = None  # compared via __date
 
     # Free-text search
     search: StringCriterion | None = None
@@ -610,7 +610,7 @@ class PlatformFilter(OperatorFilter):
         "name": FilterField(),
         "group": FilterField(),
         "icon": FilterField(),
-        "created_at": FilterField(),
+        "created_at": FilterField("created_at__date"),
     }
 
     def _comparison_model(self) -> Type[Platform]:
@@ -661,7 +661,7 @@ class PlayEventFilter(OperatorFilter):
     ended: DateCriterion | None = None  # DateField, bare lookup
     days_to_finish: IntCriterion | None = None
     note: StringCriterion | None = None
-    created_at: StringCriterion | None = None
+    created_at: DateCriterion | None = None  # compared via __date
 
     # Free-text search
     search: StringCriterion | None = None
@@ -677,7 +677,7 @@ class PlayEventFilter(OperatorFilter):
         "ended": FilterField(),
         "days_to_finish": FilterField(),
         "note": FilterField(),
-        "created_at": FilterField(),
+        "created_at": FilterField("created_at__date"),
     }
 
     def _comparison_model(self) -> Type[PlayEvent]:

--- a/tests/test_filter_where.py
+++ b/tests/test_filter_where.py
@@ -57,8 +57,16 @@ def test_bool_field_resolves_bool_criterion():
 
 
 def test_multi_field_resolves_multi_criterion():
-    assert GameFilter.where(platform_group=[1, 2]) == GameFilter(
-        platform_group=MultiCriterion(value=[1, 2], modifier=Modifier.INCLUDES)
+    # platform is a MultiCriterion over the int FK platform_id.
+    assert GameFilter.where(platform=[1, 2]) == GameFilter(
+        platform=MultiCriterion(value=[1, 2], modifier=Modifier.INCLUDES)
+    )
+
+
+def test_choice_field_resolves_choice_criterion():
+    # platform_group is a ChoiceCriterion over the str column platform__group.
+    assert GameFilter.where(platform_group=["Nintendo"]) == GameFilter(
+        platform_group=ChoiceCriterion(value=["Nintendo"], modifier=Modifier.INCLUDES)
     )
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -18,6 +18,7 @@ from common.criteria import (
     FieldComparisonCriterion,
     FilterError,
     FilterField,
+    FloatCriterion,
     IntCriterion,
     Modifier,
     MultiCriterion,
@@ -32,6 +33,7 @@ from common.criteria import (
     bool_nonzero_duration_handler,
     comparable_columns,
     duration_hours_handler,
+    filter_from_json,
     search_q,
 )
 from common.components import FilterBar
@@ -597,13 +599,15 @@ class TestGameFilterFromJson:
         assert gf.status is not None
         assert gf.status.modifier == Modifier.NOT_NULL
 
-    def test_platform_choice_criterion(self):
+    def test_platform_criterion_coerces_ids_to_int(self):
+        # platform is a MultiCriterion over the int FK platform_id; string ids
+        # from the widget are coerced to int at parse (issue #157).
         gf = GameFilter.from_json(
             {"platform": {"value": ["1", "3"], "modifier": "INCLUDES"}}
         )
         assert gf is not None
         assert gf.platform is not None
-        assert gf.platform.value == ["1", "3"]
+        assert gf.platform.value == [1, 3]
 
     def test_round_trip(self):
         data = {
@@ -1502,6 +1506,67 @@ class TestFilterErrorBoundary:
         result.to_q()  # does not raise
         assert result.session_filter is not None
         result.session_filter.to_q()  # the exact second call game.py makes
+
+
+# Wrong-typed value per coercible criterion class (issue #157). Criteria whose
+# value is a free string against a char column (String/Choice) or a bool never
+# 500 at the DB, so they are not in this map and are skipped by the matrix below.
+_WRONG_VALUE_BY_CRITERION = {
+    IntCriterion: "not-a-number",
+    FloatCriterion: "not-a-number",
+    AggregateCriterion: "not-a-number",
+    DateCriterion: "garbage",
+    MultiCriterion: ["not-an-int"],
+}
+
+_ALL_FILTERS = [
+    GameFilter,
+    SessionFilter,
+    PurchaseFilter,
+    DeviceFilter,
+    PlatformFilter,
+    PlayEventFilter,
+]
+
+
+def _coercible_field_cases():
+    """Every (filter, criterion field) whose value type the DB would reject at
+    query execution — derived from the criterion class via _criterion_class_for so
+    the matrix grows automatically as new fields/filters are added (e.g. #168)."""
+    cases = []
+    for filter_cls in _ALL_FILTERS:
+        for dataclass_field in dataclasses.fields(filter_cls):
+            criterion_cls = _criterion_class_for(filter_cls, dataclass_field.name)
+            if criterion_cls in _WRONG_VALUE_BY_CRITERION:
+                cases.append((filter_cls, dataclass_field.name, criterion_cls))
+    return cases
+
+
+class TestValueTypeBoundaryMatrix:
+    """Issue #157: a hand-edited ``?filter=`` carrying a value of the wrong type
+    for its column must raise ``FilterError`` at parse (caught by the web/API
+    boundary) rather than escaping to a query-execution 500. Covers every
+    coercible criterion field across every filter, so the boundary promise holds
+    as fields are added."""
+
+    @pytest.mark.parametrize(
+        "filter_cls,field_name,criterion_cls",
+        _coercible_field_cases(),
+        ids=lambda value: getattr(value, "__name__", value),
+    )
+    def test_wrong_typed_value_raises_filter_error(
+        self, filter_cls, field_name, criterion_cls
+    ):
+        bad_value = _WRONG_VALUE_BY_CRITERION[criterion_cls]
+        modifier = "INCLUDES" if criterion_cls is MultiCriterion else "EQUALS"
+        payload = json.dumps({field_name: {"value": bad_value, "modifier": modifier}})
+        with pytest.raises(FilterError):
+            filter_from_json(filter_cls, payload)
+
+    def test_matrix_is_non_empty(self):
+        # Guard against the derivation silently yielding nothing (e.g. annotation
+        # format change), which would make the parametrized test vacuously pass.
+        assert _coercible_field_cases()
 
 
 class TestFieldComparisonCriterion:
@@ -3178,3 +3243,30 @@ class TestSearchQHelper:
         assert search_q(
             StringCriterion(value="x", modifier=Modifier.EXCLUDES), "a", "b"
         ) == ~(Q(a__icontains="x") | Q(b__icontains="x"))
+
+
+class TestValueTypeBoundaryIntegration:
+    """End-to-end: a wrong-typed ``?filter=`` reaches a real list view / API
+    endpoint and degrades gracefully instead of 500-ing at query execution
+    (issue #157). Pre-fix these payloads built a Q fine and raised at eval."""
+
+    @pytest.fixture
+    def auth_client(self, client, django_user_model):
+        user = django_user_model.objects.create_user(username="u", password="p")
+        client.force_login(user)
+        return client
+
+    @pytest.mark.django_db
+    def test_web_list_view_warn_ignores_bad_value(self, auth_client):
+        from django.urls import reverse
+
+        bad = json.dumps({"year_released": {"modifier": "EQUALS", "value": "nope"}})
+        response = auth_client.get(reverse("games:list_games"), {"filter": bad})
+        # Boundary warns and ignores → the page still renders, never a 500.
+        assert response.status_code == 200
+
+    @pytest.mark.django_db
+    def test_api_list_returns_400_on_bad_value(self, auth_client):
+        bad = json.dumps({"timestamp_start": {"modifier": "EQUALS", "value": "nope"}})
+        response = auth_client.get("/api/session/", {"filter": bad})
+        assert response.status_code == 400

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -24,6 +24,7 @@ from common.criteria import (
     MultiCriterion,
     OperatorFilter,
     StringCriterion,
+    _ScalarCriterion,
     _allowed_comparison_modifiers,
     _comparison_group_for,
     _criterion_class_for,
@@ -1567,6 +1568,92 @@ class TestValueTypeBoundaryMatrix:
         # Guard against the derivation silently yielding nothing (e.g. annotation
         # format change), which would make the parametrized test vacuously pass.
         assert _coercible_field_cases()
+
+
+class TestValueTypeBoundaryEdges:
+    """Coercion paths the EQUALS/value-only matrix doesn't exercise (issue #157
+    review): value2/BETWEEN bounds, the excludes channel, an omitted date value,
+    silent-accept inputs (bool/non-integral float), nested criteria, and the
+    id-less set element. Each must raise FilterError at parse, not 500 at eval."""
+
+    def test_bad_value2_between_bound_raises(self):
+        # The upper BETWEEN bound goes through a separate coercion-loop iteration.
+        bad = json.dumps(
+            {"year_released": {"modifier": "BETWEEN", "value": 2000, "value2": "x"}}
+        )
+        with pytest.raises(FilterError):
+            parse_game_filter(bad)
+
+    def test_bad_excludes_element_raises(self):
+        # The excludes channel is coerced too, not just the include value list.
+        bad = json.dumps({"platform": {"modifier": "INCLUDES", "excludes": ["xyz"]}})
+        with pytest.raises(FilterError):
+            parse_game_filter(bad)
+
+    def test_omitted_date_value_with_value_using_modifier_raises(self):
+        # Finding #157: DateCriterion's "" default must still be rejected when the
+        # value key is absent (else Q(field='') 500s at eval, bypassing the
+        # boundary with a non-ValueError ValidationError).
+        bad = json.dumps({"created_at": {"modifier": "EQUALS"}})
+        with pytest.raises(FilterError):
+            parse_game_filter(bad)
+
+    def test_bool_value_rejected_for_int_field(self):
+        # int(True) == 1 would silently accept wrong-typed input; reject instead.
+        bad = json.dumps({"year_released": {"modifier": "EQUALS", "value": True}})
+        with pytest.raises(FilterError):
+            parse_game_filter(bad)
+
+    def test_non_integral_float_rejected_for_int_field(self):
+        # int(3.9) == 3 would silently truncate; reject instead.
+        bad = json.dumps({"year_released": {"modifier": "EQUALS", "value": 3.9}})
+        with pytest.raises(FilterError):
+            parse_game_filter(bad)
+
+    def test_integral_float_accepted_for_int_field(self):
+        good = json.dumps({"year_released": {"modifier": "EQUALS", "value": 2000.0}})
+        result = parse_game_filter(good)
+        assert result is not None and result.year_released is not None
+        assert result.year_released.value == 2000
+
+    def test_decimal_string_accepted_for_float_field(self):
+        good = json.dumps({"price": {"modifier": "EQUALS", "value": "3.5"}})
+        result = parse_purchase_filter(good)
+        assert result is not None and result.price is not None
+        assert result.price.value == 3.5
+
+    def test_bad_value_nested_in_operator_raises(self):
+        # The fix lives in criterion from_json, so it must hold under AND/OR/NOT.
+        bad = json.dumps(
+            {"AND": [{"year_released": {"modifier": "EQUALS", "value": "nope"}}]}
+        )
+        with pytest.raises(FilterError):
+            parse_game_filter(bad)
+
+    def test_bad_value_nested_in_relation_subfilter_raises(self):
+        bad = json.dumps(
+            {"session_filter": {"created_at": {"modifier": "EQUALS", "value": "nope"}}}
+        )
+        with pytest.raises(FilterError):
+            parse_game_filter(bad)
+
+    def test_set_element_dict_without_id_raises(self):
+        # A hand-edited {label-only} element must be a clean FilterError, not a
+        # boundary-bypassing KeyError.
+        bad = json.dumps(
+            {"platform": {"modifier": "INCLUDES", "value": [{"label": "PC"}]}}
+        )
+        with pytest.raises(FilterError):
+            parse_game_filter(bad)
+
+    def test_scalar_subclass_without_coercer_is_rejected_at_definition(self):
+        # _ScalarCriterion enforces that every scalar criterion declares a _coerce,
+        # so a future field type can't silently revert to the pre-#157 500 vector.
+        with pytest.raises(TypeError, match="_coerce"):
+
+            @dataclass
+            class _NoCoercer(_ScalarCriterion):
+                value: int = 0
 
 
 class TestFieldComparisonCriterion:
@@ -3270,3 +3357,23 @@ class TestValueTypeBoundaryIntegration:
         bad = json.dumps({"timestamp_start": {"modifier": "EQUALS", "value": "nope"}})
         response = auth_client.get("/api/session/", {"filter": bad})
         assert response.status_code == 400
+
+    @pytest.mark.django_db
+    def test_created_at_filter_is_date_granular(self):
+        # The temporal StringCriterion → DateCriterion + __date reclass must match
+        # a non-midnight created_at datetime by its calendar date (a regression
+        # dropping __date would make equality silently never match).
+        from datetime import datetime, timezone
+
+        from games.models import Game, Platform
+
+        platform = Platform.objects.create(name="PC")
+        game = Game.objects.create(name="Hades", platform=platform)
+        # auto_now_add can't be set on create; stamp an afternoon time directly.
+        moment = datetime(2024, 3, 14, 15, 9, 0, tzinfo=timezone.utc)
+        Game.objects.filter(pk=game.pk).update(created_at=moment)
+
+        good = json.dumps({"created_at": {"modifier": "EQUALS", "value": "2024-03-14"}})
+        parsed = parse_game_filter(good)
+        assert parsed is not None
+        assert Game.objects.filter(parsed.to_q()).filter(pk=game.pk).exists()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1622,6 +1622,21 @@ class TestValueTypeBoundaryEdges:
         assert result is not None and result.price is not None
         assert result.price.value == 3.5
 
+    def test_aggregate_integral_value_round_trips_as_int(self):
+        # A count bound stays int (5, not 5.0) so saved-filter JSON stays clean;
+        # a fractional sum/avg bound keeps its float.
+        result = parse_game_filter(
+            json.dumps({"session_count": {"modifier": "GREATER_THAN", "value": 5}})
+        )
+        assert result is not None and result.session_count is not None
+        assert result.session_count.value == 5
+        assert isinstance(result.session_count.value, int)
+        fractional = parse_game_filter(
+            json.dumps({"session_average": {"modifier": "GREATER_THAN", "value": 3.5}})
+        )
+        assert fractional is not None and fractional.session_average is not None
+        assert fractional.session_average.value == 3.5
+
     def test_bad_value_nested_in_operator_raises(self):
         # The fix lives in criterion from_json, so it must hold under AND/OR/NOT.
         bad = json.dumps(


### PR DESCRIPTION
Closes #157. Wave 1 of the #171 filter epic — backend criteria/`to_q` layer, future-proof through #168's recursive builder.

## Problem
PR #156 made every error raised while *building* a `Q` catchable, but a value of the wrong type for its column still escaped: it built a `Q` fine and only 500'd when the DB rejected it at query **execution** time, outside the boundary's `try`. Four hand-edit-only vectors:

- `year_released = "not-a-number"` (Int) → `ValueError` at eval
- `timestamp_start = "garbage"` (Date) → `ValidationError` at eval
- `platform = ["xyz"]` (int FK set) → DB type error at eval
- `created_at = "garbage"` — `StringCriterion` over a `DateTimeField` → `ValidationError` at eval

## Fix — criteria born valid
A `_coerce` hook coerces/validates each value against its field-column type at `from_json`, raising `FilterError` (caught: web warn-and-ignore, API 400) before the DB ever sees it. Validation lives at the criterion seam, so it composes through arbitrary AND/OR/NOT nesting.

- `_ScalarCriterion` coerces `value`/`value2` for `Int`/`Float`/`Date`/`Aggregate` (skips `IS_NULL`/`NOT_NULL`, whose placeholder `value:""` is meaningless).
- `_SetCriterion` coerces list elements for `MultiCriterion`.
- `games` (M2M) keeps its existing int coercion as the one intentional exception.

## Make the class truthfully encode value type
So `_criterion_class_for` becomes a correct per-field type source (consumed later by #168's add-criterion picker — see [comment on #168](https://github.com/KucharczykL/timetracker/issues/168#issuecomment-4826653185)):

- `platform` → `MultiCriterion` (int FK), `platform_group` → `ChoiceCriterion` (str)
- 9 temporal `created_at`/`updated_at` fields (`StringCriterion` over `DateTimeField`) → `DateCriterion` + `__date` lookup — validated *and* now date-granular

## Tests
- Self-growing boundary-wide param matrix (36 cases): every coercible filter/field rejects a wrong-typed value with `FilterError`.
- Web-200 (warn-ignore) + API-400 integration tests hitting real endpoints.

## Behavior note
Reclassing `created_at`/`updated_at` to `DateCriterion` drops `INCLUDES`/regex modifiers there (now EQ/NEQ/GT/LT/BETWEEN/NULL). Those were non-functional against datetime columns anyway; a legacy substring-on-timestamp preset would now warn-and-ignore.

## Verification
970 unit tests pass · mypy clean (144 files) · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)