### PR TITLE
Server-render free-text filter search input + exclude toggle (#153)

### DIFF
--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -9,6 +9,7 @@ from common.components.custom_elements import _FieldComparisonSet, _FilterBarEle
 from common.components.date_range_picker import DateRangePicker
 from common.components.primitives import (
     Button,
+    Checkbox,
     Div,
     FilterWidgetKind,
     FilterWidgetPath,
@@ -792,6 +793,37 @@ def _field_comparison_section(
     )
 
 
+def _filter_search_field(existing: dict) -> Node:
+    """The free-text search field: a text input plus an EXCLUDES toggle.
+
+    Shared chrome rendered once at the top of every bar (see
+    ``_FilterBarBase.render``). ``filter-bar.ts`` reads ``filter-search`` /
+    ``filter-search-exclude`` by name into the search criterion; this is the
+    server-rendered source of those controls (formerly built imperatively by
+    the deleted ``injectSearchInput``). ``INPUT_CLASS`` is imported here, not at
+    module top, because ``games.forms`` imports ``common.components`` — a module
+    import would be circular.
+    """
+    from games.forms import INPUT_CLASS
+
+    value, modifier = _string_from_field(existing.get("search", {}))
+    widget = Div(class_="mb-4")[
+        Input(
+            type="text",
+            name="filter-search",
+            value=value,
+            placeholder="Search…",
+            class_=INPUT_CLASS,
+        ),
+        Checkbox(
+            name="filter-search-exclude",
+            label="Exclude matches",
+            checked=(modifier == "EXCLUDES"),
+        ),
+    ]
+    return _filter_field("Search", widget)
+
+
 class _FilterBarBase(BaseComponent):
     """Shared collapsible filter-bar chrome.
 
@@ -859,6 +891,7 @@ class _FilterBarBase(BaseComponent):
                             # raw JSON passes through (no double-escape).
                             value=self.filter_json,
                         ),
+                        _filter_search_field(self.existing),
                         *self._body_fields(),
                         _filter_action_row(),
                     ],

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -799,8 +799,8 @@ def _filter_search_field(existing: dict) -> Node:
     Shared chrome rendered once at the top of every bar (see
     ``_FilterBarBase.render``). ``filter-bar.ts`` reads ``filter-search`` /
     ``filter-search-exclude`` by name into the search criterion; this is the
-    server-rendered source of those controls (formerly built imperatively by
-    the deleted ``injectSearchInput``). ``INPUT_CLASS`` is imported here, not at
+    server-rendered source of those controls (it replaces what was formerly
+    imperative TypeScript DOM construction). ``INPUT_CLASS`` is imported here, not at
     module top, because ``games.forms`` imports ``common.components`` — a module
     import would be circular.
     """

--- a/docs/superpowers/plans/2026-06-28-issue-153-server-render-filter-search.md
+++ b/docs/superpowers/plans/2026-06-28-issue-153-server-render-filter-search.md
@@ -1,0 +1,262 @@
+# Server-render free-text filter search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the free-text filter search input + its "Exclude matches" toggle from imperative TypeScript (`injectSearchInput`) to server-rendered Python components, restoring the single-source-of-truth pattern.
+
+**Architecture:** A new `_filter_search_field(existing)` helper in `common/components/filters.py` renders a labelled field (label + `Input` primitive + `Checkbox` primitive) using canonical classes. It is rendered once in the shared `_FilterBarBase.render()` (top of every bar's form). The TypeScript loses `injectSearchInput` entirely; its `buildFilterJSON` reader (which already reads the controls by `name`) is untouched.
+
+**Tech Stack:** Django, Python component system (`common/components`), TypeScript (`ts/elements`), pytest + Playwright (e2e).
+
+## Global Constraints
+
+- Build UI with Python components (`Div`, `Input`, `Checkbox`, …), never raw HTML strings or Python f-strings. (CLAUDE.md)
+- Builders take htpy form: static attrs as kwargs, children via `[]`; dynamic attrs via the single positional slot.
+- Elements carry their own classes (no styling-at-a-distance); reuse shared class constants, don't hand-roll.
+- `games.forms` ↔ `common.components` is an import cycle: any import of `games.forms` from `common/components/filters.py` MUST be **deferred (inside the function)**, mirroring `FieldComparisonSet`'s `from games.forms import SELECT_CLASS` at line 748.
+- Control names are a fixed contract with `ts/elements/filter-bar.ts`: text input `name="filter-search"`, checkbox `name="filter-search-exclude"`. Do not rename.
+- Name variables with complete words.
+- Spec: `docs/superpowers/specs/2026-06-28-issue-153-server-render-filter-search-design.md`.
+
+---
+
+### Task 1: Server-render the search field in Python (TDD)
+
+Add the component, wire it into the base bar, and pin the contract with unit tests. Single deliverable: the rendered bar HTML carries the search controls (prefilled), produced entirely by Python.
+
+**Files:**
+- Modify: `common/components/filters.py` (add `_filter_search_field`; call it in `_FilterBarBase.render`)
+- Test: `tests/test_filter_bars.py` (add methods to `FilterBarRenderingTest`)
+
+**Interfaces:**
+- Produces: `_filter_search_field(existing: dict) -> Node` (module-private helper in `common/components/filters.py`). Renders a `_filter_field("Search", widget)` whose widget is a `Div` (class `mb-4`) containing an `Input` (`type="text"`, `name="filter-search"`, `class_=INPUT_CLASS`, `placeholder="Search…"`, `value` from `existing["search"]`) and a `Checkbox` (`name="filter-search-exclude"`, `label="Exclude matches"`, `checked` when the search modifier is `EXCLUDES`).
+- Consumes: existing helpers `_filter_field` and `_string_from_field` (both already in the file); `Checkbox` from `common.components.primitives`; `INPUT_CLASS` from `games.forms` (deferred import).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add `Checkbox` to the existing primitives import in `common/components/filters.py` is NOT needed yet (that's Step 3) — these tests only touch `tests/test_filter_bars.py`. Add these three methods inside `class FilterBarRenderingTest`:
+
+```python
+    def test_filter_bar_renders_search_controls(self):
+        """The free-text search input + exclude toggle are server-rendered."""
+        html = str(
+            FilterBar(
+                preset_list_url="/presets/list",
+                preset_save_url="/presets/save",
+            )
+        )
+        self.assertIn('name="filter-search"', html)
+        self.assertIn('name="filter-search-exclude"', html)
+        self.assertIn("Exclude matches", html)
+        self.assertNoEscapedTags(html)
+
+    def test_filter_bar_search_prefills_value_and_exclude(self):
+        """A stored EXCLUDES search prefills the input value and checks the box."""
+        filter_json = json.dumps(
+            {"search": {"value": "Witcher", "modifier": "EXCLUDES"}}
+        )
+        html = str(FilterBar(filter_json=filter_json))
+        self.assertIn('value="Witcher"', html)
+        # The checkbox renders with a checked attribute (Checkbox uses checked="true").
+        self.assertIn('name="filter-search-exclude"', html)
+        self.assertIn('checked', html)
+
+    def test_filter_bar_search_includes_leaves_box_unchecked(self):
+        """An INCLUDES search prefills the value but does not check exclude."""
+        filter_json = json.dumps(
+            {"search": {"value": "Witcher", "modifier": "INCLUDES"}}
+        )
+        html = str(FilterBar(filter_json=filter_json))
+        self.assertIn('value="Witcher"', html)
+        # Isolate the exclude checkbox's own markup and assert it is unchecked.
+        marker = 'name="filter-search-exclude"'
+        start = html.index(marker)
+        fragment = html[start - 120 : start + 120]
+        self.assertNotIn("checked", fragment)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run --with pytest-django pytest tests/test_filter_bars.py -k search -v`
+Expected: 3 FAILs — `name="filter-search"` not found in the rendered HTML (the field is not server-rendered yet).
+
+- [ ] **Step 3: Add the `_filter_search_field` helper**
+
+In `common/components/filters.py`, add `Checkbox` to the existing import from `common.components.primitives` (the block starting `from common.components.primitives import (`), keeping the list alphabetised where it already is:
+
+```python
+    Checkbox,
+```
+
+Then add the helper just above `class _FilterBarBase` (after `_filter_action_row`):
+
+```python
+def _filter_search_field(existing: dict) -> Node:
+    """The free-text search field: a text input plus an EXCLUDES toggle.
+
+    Shared chrome rendered once at the top of every bar (see
+    ``_FilterBarBase.render``). ``filter-bar.ts`` reads ``filter-search`` /
+    ``filter-search-exclude`` by name into the search criterion; this is the
+    server-rendered source of those controls (formerly built imperatively by
+    the deleted ``injectSearchInput``). ``INPUT_CLASS`` is imported here, not at
+    module top, because ``games.forms`` imports ``common.components`` — a module
+    import would be circular.
+    """
+    from games.forms import INPUT_CLASS
+
+    value, modifier = _string_from_field(existing.get("search", {}))
+    widget = Div(class_="mb-4")[
+        Input(
+            type="text",
+            name="filter-search",
+            value=value,
+            placeholder="Search…",
+            class_=INPUT_CLASS,
+        ),
+        Checkbox(
+            name="filter-search-exclude",
+            label="Exclude matches",
+            checked=(modifier == "EXCLUDES"),
+        ),
+    ]
+    return _filter_field("Search", widget)
+```
+
+- [ ] **Step 4: Wire it into the base bar**
+
+In `_FilterBarBase.render`, insert the search field immediately after the hidden `filter` input inside the `Form`:
+
+```python
+                    Form(id_=_FILTER_FORM_ID)[
+                        Input(
+                            type="hidden",
+                            id_=_FILTER_INPUT_ID,
+                            name="filter",
+                            # NB: attribute values are escaped, so the
+                            # raw JSON passes through (no double-escape).
+                            value=self.filter_json,
+                        ),
+                        _filter_search_field(self.existing),
+                        *self._body_fields(),
+                        _filter_action_row(),
+                    ],
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `uv run --with pytest-django pytest tests/test_filter_bars.py -k search -v`
+Expected: 3 PASS.
+
+- [ ] **Step 6: Run the full filter-bar test file (no regressions)**
+
+Run: `uv run --with pytest-django pytest tests/test_filter_bars.py -v`
+Expected: all PASS (existing characterization tests + the 3 new ones).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add common/components/filters.py tests/test_filter_bars.py
+git commit -m "feat(filters): server-render free-text search input + exclude toggle (#153)"
+```
+
+---
+
+### Task 2: Remove the imperative TypeScript and recompile
+
+Delete `injectSearchInput` and its call; the server now owns the markup and prefill. The `buildFilterJSON` reader stays.
+
+**Files:**
+- Modify: `ts/elements/filter-bar.ts` (delete `injectSearchInput`; delete its call in `connectedCallback`)
+
+**Interfaces:**
+- Consumes: the server-rendered controls from Task 1 (`filter-search`, `filter-search-exclude`).
+- Produces: nothing new; `buildFilterJSON` (unchanged) continues to read those controls.
+
+- [ ] **Step 1: Delete the `injectSearchInput` function**
+
+In `ts/elements/filter-bar.ts`, remove the entire function (the block beginning `function injectSearchInput(form: HTMLElement): void {` through its closing `}` — currently lines 332–372).
+
+- [ ] **Step 2: Delete the call site**
+
+In `connectedCallback`, remove the line:
+
+```typescript
+    injectSearchInput(form);
+```
+
+- [ ] **Step 3: Confirm no references remain**
+
+Run: `grep -rn injectSearchInput ts/`
+Expected: no output.
+
+- [ ] **Step 4: Type-check and recompile**
+
+Run: `make ts-check`
+Expected: PASS (no `tsc` errors; no unused-symbol or missing-reference errors).
+
+Run: `make ts`
+Expected: recompiles `games/static/js/dist/` cleanly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ts/elements/filter-bar.ts
+git commit -m "refactor(filters): drop imperative injectSearchInput; search is server-rendered (#153)"
+```
+
+---
+
+### Task 3: End-to-end verification
+
+The existing e2e suite already asserts the full search behavior. It must pass unchanged against the server-rendered field; the prefill assertion now exercises the Python render path instead of TS.
+
+**Files:**
+- Verify only: `e2e/test_search_filter_e2e.py` (no edits expected)
+
+**Interfaces:**
+- Consumes: the compiled `dist/elements/filter-bar.js` from Task 2 and the server-rendered field from Task 1.
+
+- [ ] **Step 1: Run the search-filter e2e file**
+
+Run: `uv run --with pytest-django --with pytest-playwright pytest e2e/test_search_filter_e2e.py -v`
+Expected: all PASS —
+- `test_search_defaults_to_includes` (input present; empty exclude → INCLUDES),
+- `test_search_exclude_emits_excludes_modifier` (checked → EXCLUDES),
+- `test_search_exclude_prefills_from_filter_json` (now prefilled server-side),
+- `test_excluded_search_term_filters_game_list` (real-app list filter).
+
+If a browser is not installed: `uv run playwright install chromium` first (see `e2e/conftest.py`).
+
+- [ ] **Step 2: Full aggregate check**
+
+Run: `make check`
+Expected: lint + format check + mypy + ts-check + tests all PASS.
+
+- [ ] **Step 3: Commit (only if `make check` produced changes, e.g. formatting)**
+
+```bash
+git add -A
+git commit -m "chore(filters): verification fixups for #153"
+```
+
+If `make check` produced no changes, skip this commit.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- New `_filter_search_field` component (spec §1) → Task 1 Step 3.
+- Reuse `Input` + `Checkbox` primitives, `INPUT_CLASS`, deferred import (spec §1) → Task 1 Step 3.
+- `mb-4` spacing (spec §1) → Task 1 Step 3.
+- Prefill via `_string_from_field`, `checked` when EXCLUDES (spec §1) → Task 1 Step 3 + tests.
+- Render wiring in `_FilterBarBase.render` after hidden input (spec §2) → Task 1 Step 4.
+- Delete `injectSearchInput` + call; keep `buildFilterJSON`; recompile; grep clean (spec §3) → Task 2.
+- New Python unit assertions (spec Testing) → Task 1 Steps 1–6.
+- Existing e2e unchanged + `make check` + `make test-e2e` (spec Verification) → Task 3.
+
+No gaps.
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"/vague steps. All code steps show complete code.
+
+**Type consistency:** `_filter_search_field(existing: dict) -> Node` named identically in the interface block, helper definition, and call site (`_filter_search_field(self.existing)`). Control names `filter-search` / `filter-search-exclude` match the TS reader's selectors verbatim. `_string_from_field` and `_filter_field` used with their existing signatures.

--- a/docs/superpowers/specs/2026-06-28-issue-153-server-render-filter-search-design.md
+++ b/docs/superpowers/specs/2026-06-28-issue-153-server-render-filter-search-design.md
@@ -1,0 +1,117 @@
+# Issue #153 — Server-render free-text filter search (input + exclude toggle)
+
+## Problem
+
+The filter-bar body is server-rendered Python (`_FilterBarBase.render` →
+`build_fields()` in `common/components/filters.py`); every widget's markup and
+Tailwind classes live in Python components — **except** the free-text search
+input and its "Exclude matches" checkbox, which are hand-built imperatively in
+TypeScript by `injectSearchInput` (`ts/elements/filter-bar.ts`) with hardcoded
+class strings.
+
+This violates the project rule (CLAUDE.md: "Do NOT author HTML/JS as Python
+f-strings"; markup/classes live in Python components) and produces concrete
+debt introduced by #147:
+
+- **Class drift / no single source.** The exclude checkbox uses a hand-rolled
+  `className` instead of the `Checkbox` primitive, so it can drift from every
+  other checkbox.
+- **Missing disabled state.** The hardcoded string omits `DISABLED_CONTROL_CLASS`
+  that `Checkbox` stamps.
+
+## Goal
+
+Render the free-text search input **and** its exclude toggle server-side in the
+Python filter bar, reusing the `Input` + `Checkbox` primitives. Reduce the TS to
+wiring only (read input value + checkbox state for `buildFilterJSON`); delete the
+imperative DOM construction and the TS-side prefill. Single source of truth
+restored; Tailwind duplication, drift, and the disabled-state gap removed.
+
+## Constraints / findings
+
+- `SearchField` primitive is a full `<form>` — cannot nest inside the filter
+  `<form>`. So the text field uses the plain `Input` primitive, not `SearchField`.
+- `buildFilterJSON` (filter-bar.ts) already reads the controls by name
+  (`filter-search`, `filter-search-exclude`) and emits `{value, modifier}` with
+  `modifier` = `EXCLUDES` when checked else `INCLUDES`. The reader is agnostic to
+  who created the elements, so it needs no change.
+- The search field is shared chrome (injected for every bar today), so it belongs
+  in the base `_FilterBarBase.render()`, not per-entity `build_fields()`.
+- `self.existing` is cross-entity-canonicalized in `__init__`; `search` is a plain
+  top-level key, untouched by that fold.
+- Visual treatment (decided): align with the rest of the bar — a labelled
+  `_filter_field("Search", …)` block (uppercase "Search" label, input, exclude
+  checkbox below), rather than reproducing the current label-less look.
+
+## Design
+
+### 1. New component — `_filter_search_field(existing: dict) -> Node`
+
+In `common/components/filters.py`. Returns a labelled field built with the
+existing `_filter_field("Search", widget)` helper, where `widget` is a `Div`
+holding two primitive controls:
+
+- Text input: `Input(type="text", name="filter-search", value=value,
+  placeholder="Search…", class_=INPUT_CLASS)`.
+  - `INPUT_CLASS` imported from `games.forms` (canonical app-wide text-input
+    look; same import precedent as `SELECT_CLASS` used by `FieldComparisonSet`).
+- Exclude toggle: `Checkbox(name="filter-search-exclude",
+  label="Exclude matches", checked=(modifier == "EXCLUDES"))` — carries the
+  canonical checkbox classes including `DISABLED_CONTROL_CLASS`, closing the
+  drift + missing-disabled gap.
+- Prefill: `value, modifier = _string_from_field(existing.get("search", {}))`.
+
+Rendered shape:
+
+```
+SEARCH                              ← _FILTER_LABEL_CLASS (uppercase)
+[ Input  name=filter-search ]       ← Input primitive, INPUT_CLASS
+[x] Exclude matches                 ← Checkbox primitive, name=filter-search-exclude
+```
+
+### 2. Render wiring — `_FilterBarBase.render`
+
+Insert the search field once in the base, right after the hidden `filter` input:
+
+```python
+Form(id_=_FILTER_FORM_ID)[
+    Input(type="hidden", id_=_FILTER_INPUT_ID, name="filter", value=self.filter_json),
+    _filter_search_field(self.existing),     # new — top of every bar
+    *self._body_fields(),
+    _filter_action_row(),
+]
+```
+
+Same DOM position as today's injection (top of form, inside `#filter-bar-body`)
+→ identical collapse/visibility behavior. Applies to all six bars
+(Game / Session / Purchase / Device / Platform / PlayEvent) automatically.
+
+### 3. TS reduction — `ts/elements/filter-bar.ts`
+
+- **Delete** `injectSearchInput()` (the imperative DOM build + TS-side prefill).
+- **Delete** its call in `connectedCallback`.
+- **Keep** the `buildFilterJSON` search block unchanged (reads the now
+  server-rendered controls by name).
+- Recompile: `make ts` so `dist/` and e2e/local serving see the trimmed module.
+
+## Testing
+
+- **Existing e2e** (`e2e/test_search_filter_e2e.py`) — no changes expected; all
+  four assertions still hold (input present; empty → INCLUDES; checked →
+  EXCLUDES; prefill from filter JSON, now server-side; end-to-end list filter).
+- **New Python unit assertions** (`tests/test_filter_bars.py`): a rendered bar's
+  HTML contains `name="filter-search"` and `name="filter-search-exclude"`; a bar
+  built from `{"search": {"value": "x", "modifier": "EXCLUDES"}}` renders the
+  input value `x` and the checkbox `checked`. Locks the server-render contract
+  that the TS no longer guards.
+
+## Verification
+
+- `make check` (lint + format check + mypy + ts-check + tests).
+- `make test-e2e`.
+
+## Out of scope
+
+- The nested boolean filter builder (#168) and any change to `to_q` search
+  semantics. This is a pure source-of-truth relocation of existing behavior,
+  with one deliberate, approved visual alignment (labelled field).

--- a/docs/superpowers/specs/2026-06-28-issue-153-server-render-filter-search-design.md
+++ b/docs/superpowers/specs/2026-06-28-issue-153-server-render-filter-search-design.md
@@ -53,8 +53,13 @@ holding two primitive controls:
 
 - Text input: `Input(type="text", name="filter-search", value=value,
   placeholder="Search…", class_=INPUT_CLASS)`.
-  - `INPUT_CLASS` imported from `games.forms` (canonical app-wide text-input
-    look; same import precedent as `SELECT_CLASS` used by `FieldComparisonSet`).
+  - `INPUT_CLASS` imported from `games.forms` via a **deferred (in-function)
+    import** — `from games.forms import INPUT_CLASS` inside `_filter_search_field`,
+    NOT at module top. `games.forms` ↔ `common.components` is an import cycle;
+    `FieldComparisonSet` defers `SELECT_CLASS` the same way for the same reason. A
+    module-top import would crash on load.
+  - Wrap the labelled field's outer `Div` with `mb-4` (the injected wrapper had
+    it) so the search field keeps visual separation from the body grid below.
 - Exclude toggle: `Checkbox(name="filter-search-exclude",
   label="Exclude matches", checked=(modifier == "EXCLUDES"))` — carries the
   canonical checkbox classes including `DISABLED_CONTROL_CLASS`, closing the
@@ -82,9 +87,16 @@ Form(id_=_FILTER_FORM_ID)[
 ]
 ```
 
-Same DOM position as today's injection (top of form, inside `#filter-bar-body`)
-→ identical collapse/visibility behavior. Applies to all six bars
-(Game / Session / Purchase / Device / Platform / PlayEvent) automatically.
+Same DOM position as today's injection (top of form, inside `#filter-bar-body`).
+Applies to all six bars (Game / Session / Purchase / Device / Platform /
+PlayEvent) automatically.
+
+Note on e2e visibility: `test_search_defaults_to_includes` asserts the input is
+visible even though `#filter-bar-body` carries `hidden`. This passes because the
+synthetic `_bar_page` test harness loads **no stylesheet** (no base.css), so the
+`hidden` Tailwind class is inert there — visibility is independent of nesting
+depth. The real-app test (`test_excluded_search_term_filters_game_list`) clicks
+the collapse toggle before interacting. The move preserves both behaviors.
 
 ### 3. TS reduction — `ts/elements/filter-bar.ts`
 
@@ -93,6 +105,7 @@ Same DOM position as today's injection (top of form, inside `#filter-bar-body`)
 - **Keep** the `buildFilterJSON` search block unchanged (reads the now
   server-rendered controls by name).
 - Recompile: `make ts` so `dist/` and e2e/local serving see the trimmed module.
+- Confirm cleanup: `grep -rn injectSearchInput ts/` returns nothing.
 
 ## Testing
 

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -516,7 +516,6 @@ class FilterBarRenderingTest(TestCase):
         self.assertIn('value="true"', purchase_html)
         self.assertIn('value="false"', purchase_html)
 
-
     def test_filter_bar_renders_search_controls(self):
         """The free-text search input + exclude toggle are server-rendered."""
         html = str(
@@ -539,7 +538,7 @@ class FilterBarRenderingTest(TestCase):
         self.assertIn('value="Witcher"', html)
         # The checkbox renders with a checked attribute (Checkbox uses checked="true").
         self.assertIn('name="filter-search-exclude"', html)
-        self.assertIn('checked', html)
+        self.assertIn("checked", html)
 
     def test_filter_bar_search_includes_leaves_box_unchecked(self):
         """An INCLUDES search prefills the value but does not check exclude."""

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -21,6 +21,15 @@ from games.models import Device, Game, Platform
 _ESCAPED_TAG_MARKERS = ["&lt;div", "&lt;span", "&lt;button", "&lt;input", "&lt;a"]
 
 
+def _exclude_input_tag(html: str) -> str:
+    """Extract the <input> tag for the free-text exclude checkbox."""
+    marker = 'name="filter-search-exclude"'
+    position = html.index(marker)
+    start = html.rindex("<input", 0, position)
+    end = html.index(">", position)
+    return html[start : end + 1]
+
+
 class FilterBarRenderingTest(TestCase):
     def setUp(self):
         self.platform = Platform.objects.create(name="PC", icon="pc")
@@ -538,7 +547,7 @@ class FilterBarRenderingTest(TestCase):
         self.assertIn('value="Witcher"', html)
         # The checkbox renders with a checked attribute (Checkbox uses checked="true").
         self.assertIn('name="filter-search-exclude"', html)
-        self.assertIn("checked", html)
+        self.assertIn("checked", _exclude_input_tag(html))
 
     def test_filter_bar_search_includes_leaves_box_unchecked(self):
         """An INCLUDES search prefills the value but does not check exclude."""
@@ -548,10 +557,7 @@ class FilterBarRenderingTest(TestCase):
         html = str(FilterBar(filter_json=filter_json))
         self.assertIn('value="Witcher"', html)
         # Isolate the exclude checkbox's own markup and assert it is unchecked.
-        marker = 'name="filter-search-exclude"'
-        start = html.index(marker)
-        fragment = html[start - 120 : start + 120]
-        self.assertNotIn("checked", fragment)
+        self.assertNotIn("checked", _exclude_input_tag(html))
 
 
 class NumberFilterRenderTest(TestCase):

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -517,6 +517,44 @@ class FilterBarRenderingTest(TestCase):
         self.assertIn('value="false"', purchase_html)
 
 
+    def test_filter_bar_renders_search_controls(self):
+        """The free-text search input + exclude toggle are server-rendered."""
+        html = str(
+            FilterBar(
+                preset_list_url="/presets/list",
+                preset_save_url="/presets/save",
+            )
+        )
+        self.assertIn('name="filter-search"', html)
+        self.assertIn('name="filter-search-exclude"', html)
+        self.assertIn("Exclude matches", html)
+        self.assertNoEscapedTags(html)
+
+    def test_filter_bar_search_prefills_value_and_exclude(self):
+        """A stored EXCLUDES search prefills the input value and checks the box."""
+        filter_json = json.dumps(
+            {"search": {"value": "Witcher", "modifier": "EXCLUDES"}}
+        )
+        html = str(FilterBar(filter_json=filter_json))
+        self.assertIn('value="Witcher"', html)
+        # The checkbox renders with a checked attribute (Checkbox uses checked="true").
+        self.assertIn('name="filter-search-exclude"', html)
+        self.assertIn('checked', html)
+
+    def test_filter_bar_search_includes_leaves_box_unchecked(self):
+        """An INCLUDES search prefills the value but does not check exclude."""
+        filter_json = json.dumps(
+            {"search": {"value": "Witcher", "modifier": "INCLUDES"}}
+        )
+        html = str(FilterBar(filter_json=filter_json))
+        self.assertIn('value="Witcher"', html)
+        # Isolate the exclude checkbox's own markup and assert it is unchecked.
+        marker = 'name="filter-search-exclude"'
+        start = html.index(marker)
+        fragment = html[start - 120 : start + 120]
+        self.assertNotIn("checked", fragment)
+
+
 class NumberFilterRenderTest(TestCase):
     """Render-level contract for the Stash-style NumberFilter component."""
 

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -536,7 +536,35 @@ class FilterBarRenderingTest(TestCase):
         self.assertIn('name="filter-search"', html)
         self.assertIn('name="filter-search-exclude"', html)
         self.assertIn("Exclude matches", html)
+        # With no stored filter the exclude box must default to unchecked.
+        self.assertNotIn("checked", _exclude_input_tag(html))
         self.assertNoEscapedTags(html)
+
+    def test_search_controls_present_in_every_bar(self):
+        """The search field is shared chrome rendered by _FilterBarBase, so all
+        six bars carry both controls — guards against a render() override
+        dropping it (mirrors FieldComparisonWidgetTest.test_widget_present_in_every_bar)."""
+        from common.components import (
+            DeviceFilterBar,
+            FilterBar,
+            PlatformFilterBar,
+            PlayEventFilterBar,
+            PurchaseFilterBar,
+            SessionFilterBar,
+        )
+
+        bars = [
+            FilterBar,
+            SessionFilterBar,
+            PurchaseFilterBar,
+            DeviceFilterBar,
+            PlatformFilterBar,
+            PlayEventFilterBar,
+        ]
+        for bar in bars:
+            html = str(bar(filter_json=""))
+            self.assertIn('name="filter-search"', html, bar.__name__)
+            self.assertIn('name="filter-search-exclude"', html, bar.__name__)
 
     def test_filter_bar_search_prefills_value_and_exclude(self):
         """A stored EXCLUDES search prefills the input value and checks the box."""

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -329,47 +329,6 @@ function readRelationBoolWidget(
   return { [relationField]: relationNode };
 }
 
-function injectSearchInput(form: HTMLElement): void {
-  if (form.querySelector('[name="filter-search"]')) return;
-
-  const wrapper = document.createElement("div");
-  wrapper.className = "mb-4";
-
-  const input = document.createElement("input");
-  input.type = "text";
-  input.name = "filter-search";
-  input.placeholder = "Search…";
-  input.className =
-    "block w-full rounded-base border border-default-medium bg-neutral-secondary-medium text-sm text-heading p-2 focus:ring-brand focus:border-brand";
-
-  // Exclude toggle: surfaces the EXCLUDES modifier every *Filter.to_q already
-  // honours for free-text search (negates the OR-of-fields). Unchecked keeps the
-  // historical INCLUDES default; checked emits {value, modifier:"EXCLUDES"}.
-  const excludeLabel = document.createElement("label");
-  excludeLabel.className =
-    "flex items-center gap-2 mt-2 text-sm text-heading cursor-pointer";
-  const excludeCheckbox = document.createElement("input");
-  excludeCheckbox.type = "checkbox";
-  excludeCheckbox.name = "filter-search-exclude";
-  excludeCheckbox.className =
-    "rounded border-default-medium bg-neutral-secondary-medium text-brand focus:ring-brand";
-  excludeLabel.append(excludeCheckbox, document.createTextNode("Exclude matches"));
-
-  const hidden = form.querySelector<HTMLInputElement>('[name="filter"]');
-  if (hidden && hidden.parentNode) {
-    try {
-      const existing = JSON.parse(hidden.value || "{}");
-      if (existing.search && existing.search.value) {
-        input.value = existing.search.value;
-        excludeCheckbox.checked = existing.search.modifier === "EXCLUDES";
-      }
-    } catch {
-      // ignore malformed existing filter JSON
-    }
-    wrapper.append(input, excludeLabel);
-    hidden.parentNode.insertBefore(wrapper, hidden.nextSibling);
-  }
-}
 
 function setupDeselectableRadios(root: HTMLElement): void {
   root.querySelectorAll<DeselectableRadio>('input[type="radio"]').forEach((radio) => {
@@ -609,7 +568,6 @@ class FilterBarElement extends HTMLElement {
       savePreset(form, presetSaveUrl, presetListUrl, this);
     });
 
-    injectSearchInput(form);
     setupDeselectableRadios(this);
     setupStringFilters(this);
     setupNumberFilters(this);


### PR DESCRIPTION
Closes #153.

## Problem

Every filter-bar widget's markup + Tailwind classes live in Python components — **except** the free-text search input and its "Exclude matches" checkbox, which were hand-built imperatively in TypeScript (`injectSearchInput`) with hardcoded class strings. This violated the project's single-source-of-truth rule and, per #147, caused class drift (hand-rolled checkbox vs the `Checkbox` primitive) and a missing `disabled:` state.

## Change

- **New `_filter_search_field(existing)`** in `common/components/filters.py` — a labelled field (label + `Input` primitive + `Checkbox` primitive, `INPUT_CLASS`), rendered once in the shared `_FilterBarBase.render()` (top of every bar's form, after the hidden `filter` input). Applies to all six bars.
  - `INPUT_CLASS` imported deferred (in-function) to avoid the `games.forms`↔`common.components` import cycle — mirrors `FieldComparisonSet`.
  - Prefill: reads `existing["search"]` via `_string_from_field`; checkbox `checked` iff modifier == `EXCLUDES`.
- **Deleted** `injectSearchInput` + its call in `ts/elements/filter-bar.ts` (~42 lines). The `buildFilterJSON` reader (reads the controls by `name`) is unchanged — the contract is preserved.
- Fixes the drift + missing-disabled gap by routing through the `Checkbox` primitive.

## Behavior

No semantic change to the filter JSON round-trip. One deliberate visual change: the search box is now a labelled field consistent with the rest of the bar.

## Tests

- New unit assertions in `tests/test_filter_bars.py` lock the server-render contract (controls present; EXCLUDES prefills value + checks the box; INCLUDES leaves it unchecked) — scoped to the exclude `<input>` tag so they actually catch regressions.
- Existing e2e (`e2e/test_search_filter_e2e.py`, 4/4) passes unchanged.
- `make check` green (1150 tests; lint + format + mypy + ts-check + e2e).

Spec + plan: `docs/superpowers/specs/2026-06-28-issue-153-...md`, `docs/superpowers/plans/2026-06-28-issue-153-...md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)