### PR TITLE
docs(filters): nested filter builder UX design + adversarial review (#172)

### DIFF
--- a/docs/superpowers/specs/2026-06-28-nested-filter-builder-adversarial-review.md
+++ b/docs/superpowers/specs/2026-06-28-nested-filter-builder-adversarial-review.md
@@ -1,0 +1,127 @@
+# Nested Filter Builder — Adversarial Review
+
+**Reviews:** serialization round-trip, UX coherence, component/reuse feasibility (3 parallel
+adversarial agents) + empirical verification via Django shell.
+**Subject:** `2026-06-28-nested-filter-builder-design.md` (#172).
+**Date:** 2026-06-28
+
+Each finding: claim → verdict (verified against `common/criteria.py` + a live Django shell
+repro) → resolution folded into the spec.
+
+## Empirical verification (the decisive evidence)
+
+Ran the canonical and mixed forms through `GameFilter.to_q()` against the real DB (817 games):
+
+| JSON | resulting WHERE | count |
+|------|-----------------|-------|
+| `Q() \| Q(status="f")` | `(AND: status='f')` | 188 |
+| canonical `{"OR":[{status:f},{status:p}]}` | `(AND:(OR: status in[f], status in[p]))` | 271 |
+| wrapped `{"AND":[{"OR":[…]}]}` | identical | 271 |
+| mixed `{"name":"zzz","OR":[{status:f}]}` | `(OR: name='zzz', status in[f])` | — |
+
+**Key result:** the dreaded `Q() \| Q(x)` match-all poisoning **does not occur** — Django
+absorbs the empty `Q()` in an OR, so `Q() \| Q(x)` == `Q(x)`. The **canonical single-connective
+OR form evaluates identically to the OR-isolation-wrapper form** (both 271). So the design's
+canonical export is **correct**, and the transitional OR-isolation wrapper is genuinely
+droppable. The serialization reviewer's "fundamental architectural mismatch" verdict was wrong
+*for canonical output*; the real defect is narrower (import only) — below.
+
+## CONFIRMED defects → resolutions
+
+### 1. Import normalization was wrong (spec fix) — **HIGH**
+A mixed dict does **not** mean "implicit AND group." Per `_apply_operators` (criteria.py:1080)
++ verified: a node evaluates `criteria &= …`, then `&= AND_i`, then `|= OR_j`, then `&= ~NOT_k`
+left-to-right. So `{name, OR:[x]}` = `name OR x`, not `AND(name, x)`.
+**Resolution:** rewrite the import section — the importer must reproduce this exact left-assoc
+precedence as an explicit nested tree (build the `&`-part as an AND group, OR it under an
+OR group if `OR` present, then AND the negated `NOT` children). The builder's own *export* stays
+canonical (single-connective nodes); only *import of arbitrary/legacy JSON* needs the faithful
+reading. In practice the app never emits mixed nodes (the OR-isolation wrapper kept OR isolated),
+so this matters for hand-edited / shared URLs.
+
+### 2. NOT-group silent semantic shift → **make NOT unary in the UI** — **HIGH**
+Backend `{NOT:[a,b]}` = `~a AND ~b` ("none of"). A user adding a 2nd child to a NOT group
+silently changes its meaning with no cue.
+**Resolution:** in the builder a **NOT group wraps exactly one child** (a leaf or one AND/OR
+group), so `NOT[x]` = `~x`, unambiguous. "None of a, b" is expressed as `NOT[ OR[a,b] ]`
+(= `~a ∧ ~b`, verified). The NL summary renders it explicitly. Leaf-level "is-not" stays on the
+criterion modifier; to negate a whole group you wrap it in NOT. Backend contract unchanged.
+
+### 3. Missing unwrap/outdent restructuring — **MEDIUM**
+Spec listed `wrap in group` but no inverse, and `↑/↓` only reorder within a group.
+**Resolution:** add **unwrap/flatten** (dissolve a group, splice its children into the parent
+when connectives are compatible) to the per-node controls; define `wrap in group` to default the
+new wrapper to the parent's connective. Cross-branch move (leaf → non-sibling group two levels up)
+is an accepted limitation of the buttons-only model — done via remove + re-add; documented, not
+solved with DnD.
+
+### 4. Depth accounting undefined — **MEDIUM**
+"Soft cap 5" never said what counts.
+**Resolution:** the cap counts **group-nesting depth**; a relation-descent's child group is **+1
+level**. A criterion leaf is depth-0 (terminates). Document the budget (e.g. `games → ANY session
+→ OR[2 devices]` = depth 3). Cap stays 5 for readability; the *backend* guard (#9 below) is set
+higher and is the real safety bound.
+
+### 5. Leaf field-change behavior undefined — **MEDIUM**
+**Resolution:** on field change → reset modifier to the first valid one for the new criterion
+type, **clear** the value widget (no silent type-coercion), and mark the leaf incomplete until a
+value is entered. Replacing the value widget flushes old DOM (no stale hidden state).
+
+### 6. Live-count / NL-summary staleness — **MEDIUM**
+NL summary is live; count is debounced — they diverge mid-edit, and incomplete leaves muddy both.
+**Resolution:** incomplete leaves are **excluded** from both the count query and Apply (and
+rendered faded with an "incomplete" badge). The count badge shows a **"counting…"** state while
+debounced/in-flight, and an explicit **"count unavailable"** on endpoint error (never a bare 0).
+
+### 7. Component reuse reality — **MEDIUM**
+- `DateRangeFilter`, bool radio → **clean reuse** (pure DOM-read serialization, no preprocessing).
+- `FilterSelect` → **needs rework**: today it serializes via a global `readSearchSelect`
+  preprocessing pass (`filter-bar.ts:244`) that writes `data-*` then a flat read. In a recursive
+  tree there is no flat form — leaf widgets must **self-serialize** (write their value on change,
+  or expose a per-node serialize hook the group calls).
+- single field-comparison row → **needs a leaf variant**: the row depends on a `columns` array
+  supplied by the `FieldComparisonSet` container and on that container owning the AND/OR mode. As
+  a tree leaf it must embed its own `columns` and drop the mode toggle (the enclosing group owns
+  the connective now).
+
+### 8. Component 9 (field metadata) is ~40% there — **MEDIUM**
+`resolve_path_kind`, `_criterion_class_for`, `comparable_columns` exist; **missing**: a per-model
+field-list returning `{name, label, kind, nullable, choices, relations}`. This is exactly the
+field-metadata registry the #168 comment flagged. Component 9 must **build** it (cross-ref #161
+FilterField + #157 criterion-type metadata); it then also feeds #152.
+
+### 9. Backend has NO recursion/cycle guard — **HIGH (new backend prereq)**
+Relation fields cycle (`GameFilter.session_filter ↔ SessionFilter.game_filter`, confirmed) and
+`from_json`/`to_q` enforce no depth limit. A hand-edited / shared `?filter=` with a cycle
+infinite-loops → server DoS. Independent of the UI but made reachable by it.
+**Resolution:** add a parse-time depth/cycle guard in `OperatorFilter.from_json` (raise
+`FilterError` past a max depth, e.g. 10). **File as its own backend issue**, prerequisite to
+shipping the builder.
+
+### 10. Live-count endpoints don't exist — **LOW**
+Only `parse_*_filter` exist; component 8 must add per-model count views
+(`parse → to_q().count()`).
+
+## NON-defects (clarified, no change of substance)
+
+- **field_comparisons stored as a single array** (`{field_comparisons:[c1,c2]}`), not multiple
+  dicts. The homogeneous tree models each comparison as its own leaf → exports each as a single-key
+  `{field_comparisons:[c]}` child (AND-combined, equivalent). Import splits an N-element array into
+  N sibling comparison leaves.
+- **`match` coexisting with a connective on one sub-filter dict** is by design and unambiguous: a
+  relation node's child is exactly **one** canonical group, so its sub-filter dict carries `match`
+  + exactly one connective key. The builder never emits multiple operator families on a relation
+  sub-filter.
+- **Empty sub-filter** (`{session_filter:{match:NONE}}`) is a **feature**: "has zero related rows"
+  (NONE) / "has ≥1 related row" (ANY). Documented, not an error.
+- **Empty operator lists dropped on export** (`{AND:[]}`→`{}`): round-trip is **logical
+  equivalence**, not byte equality. Stated explicitly.
+
+## Net
+
+The design's spine — homogeneous tree + canonical single-connective serializer — is **verified
+sound** (the headline "breaks" was disproven empirically). The review's real yield: a corrected
+import rule, NOT-as-unary, an unwrap control, defined depth/field-change/staleness semantics, an
+honest component build-order (metadata + serializer are foundational; FilterSelect & the
+comparison row need rework), and one genuinely important new backend prereq — the recursion/cycle
+guard. All folded into the updated spec.

--- a/docs/superpowers/specs/2026-06-28-nested-filter-builder-adversarial-review.md
+++ b/docs/superpowers/specs/2026-06-28-nested-filter-builder-adversarial-review.md
@@ -39,13 +39,19 @@ canonical (single-connective nodes); only *import of arbitrary/legacy JSON* need
 reading. In practice the app never emits mixed nodes (the OR-isolation wrapper kept OR isolated),
 so this matters for hand-edited / shared URLs.
 
-### 2. NOT-group silent semantic shift → **make NOT unary in the UI** — **HIGH**
-Backend `{NOT:[a,b]}` = `~a AND ~b` ("none of"). A user adding a 2nd child to a NOT group
-silently changes its meaning with no cue.
-**Resolution:** in the builder a **NOT group wraps exactly one child** (a leaf or one AND/OR
-group), so `NOT[x]` = `~x`, unambiguous. "None of a, b" is expressed as `NOT[ OR[a,b] ]`
-(= `~a ∧ ~b`, verified). The NL summary renders it explicitly. Leaf-level "is-not" stays on the
-criterion modifier; to negate a whole group you wrap it in NOT. Backend contract unchanged.
+### 2. NOT-group silent semantic shift → **toggle-NOT model** — **HIGH**
+Backend `{NOT:[a,b]}` = `~a AND ~b` ("none of"). Modeling NOT as a *connective* (a list of
+children) makes a 2nd child silently change the group's meaning. A unary NOT group was the first
+fix considered; the chosen fix drops NOT-as-connective entirely.
+**Resolution (decided with the user):** **toggle-NOT** — connectives are only `AND`/`OR`; every
+node (group and leaf) carries an independent **`¬` flag** that inverts it (Qui's model). No NOT
+*group* exists, so the multi-child ambiguity is structurally impossible, and negation costs **0
+nesting depth** (a flag, not a wrapper node) — which also eases the depth cap. On export a `¬`-set
+node wraps as `{NOT:[node]}` (`¬OR[a,b]` → `{NOT:[{OR:[a,b]}]}` = `~a ∧ ~b`, verified). Import maps
+a backend `{NOT:[…]}` list to nodes with `¬` set (`{NOT:[{OR:[a,b]}]}` → an `OR[a,b]` node with
+`¬`; multi-child `{NOT:[a,b]}` → `AND[a¬, b¬]`). Leaf "is-not" modifier remains a harmless second
+route. Tradeoff accepted: every group shows two controls (connective + `¬`) — a tiny price vs the
+unary machinery (auto-wrap on switch, NOT-footer special-casing, extra nesting).
 
 ### 3. Missing unwrap/outdent restructuring — **MEDIUM**
 Spec listed `wrap in group` but no inverse, and `↑/↓` only reorder within a group.
@@ -121,7 +127,7 @@ Only `parse_*_filter` exist; component 8 must add per-model count views
 
 The design's spine — homogeneous tree + canonical single-connective serializer — is **verified
 sound** (the headline "breaks" was disproven empirically). The review's real yield: a corrected
-import rule, NOT-as-unary, an unwrap control, defined depth/field-change/staleness semantics, an
+import rule, toggle-NOT, an unwrap control, defined depth/field-change/staleness semantics, an
 honest component build-order (metadata + serializer are foundational; FilterSelect & the
 comparison row need rework), and one genuinely important new backend prereq — the recursion/cycle
 guard. All folded into the updated spec.

--- a/docs/superpowers/specs/2026-06-28-nested-filter-builder-design.md
+++ b/docs/superpowers/specs/2026-06-28-nested-filter-builder-design.md
@@ -1,0 +1,152 @@
+# Nested Filter Builder — UX Design
+
+**Issue:** #172 (phase 2a of #168, roadmap epic #171)
+**Status:** Design approved; output feeds 2b plan (#173) and 2c component issues.
+**Date:** 2026-06-28
+
+## Context
+
+The flat filter bar can only express a single AND-row of single-model criteria. The
+`OperatorFilter` algebra (`common/criteria.py`) **already** supports arbitrary nesting —
+n-ary `AND`/`OR`/`NOT` lists, typed cross-entity sub-filter fields (`session_filter`,
+`purchase_filter`, `playevent_filter`, `platform_filter`) each carrying a `match`
+quantifier (ANY/NONE/ALL via `relation_to_q`), and `field_comparisons`. What's missing is
+the **UI + a recursive serializer**. This is #168 (a phased sub-program); #172 is its
+brainstorm, whose output is this design doc **plus** a concrete prereq-component list
+(filed as 2c child issues). No code is written under #172.
+
+Research already done (#175): `docs/qui-filter-builder-case-study.md`,
+`docs/filter-forge-prototype-case-study.md`. This design borrows Qui's robust foundation
+(explicit schemas, discrete boundary states, no fragile nested-tree DnD) and Filter-Forge's
+relational model + UX (explicit relation-descent nodes, natural-language readout).
+
+## Two-tier filtering model
+
+Single source of truth is the `?filter=` JSON; both tiers read/write it and hit the same
+backend.
+
+1. **Quick bar** (per-list, single-model) — GitHub-style facet dropdowns
+   (`status: [▾] platform: [▾] …`), flat AND of a few leaf criteria. When the active
+   `?filter=` is too complex to round-trip losslessly (any OR/NOT, nesting, or relation
+   descent) it **degrades** to a read-only "Advanced filter active · [Edit in builder] ·
+   [Clear]" pill rather than mis-rendering controls.
+   → **Out of scope for #172**; filed as its own issue (single-model, no tree, ships
+   independently).
+2. **Advanced builder** (this spec) — the nested cross-model tree on a dedicated per-model
+   route (`/games/filter`, `/sessions/filter`, `/purchases/filter`, `/playevents/filter` —
+   one per list that has an `OperatorFilter` subclass). Apply navigates back to the list
+   with `?filter=`. Shareable URL state.
+
+## Node model & serialization contract
+
+The UI is a **homogeneous tree** of three node kinds. The serializer always emits canonical
+form, which kills the transitional OR-isolation wrapper and the flat `field-comparison`
+special-case (the #167 `TODO(nested-builder)` debt).
+
+- **Group** — connective ∈ {`AND`, `OR`, `NOT`} + ordered children (groups / leaves /
+  relations). → `{CONNECTIVE: [child_json, …]}`, each child its own single-key dict.
+- **Leaf (criterion)** — field + criterion (modifier + value[/value2]). →
+  `{field: {value, modifier, value2?}}`.
+- **Leaf (field comparison)** — left/right column + modifier (reuses the existing single
+  `field-comparison` row). → `{field_comparisons: [{left, right, modifier, granularity}]}`.
+- **Relation descent** — relation field + quantifier + one child group. →
+  `{rel_field: {match: Q?, …child-group-serialized}}`; `match` omitted when ANY (default).
+
+**Negation:** `NOT` is a third group connective, not a per-node toggle. A `NOT` group with
+multiple children means "none of these" (`~a AND ~b`, backend's existing list semantics);
+`NOT(a AND b)` is a `NOT` group wrapping one `AND` group. Leaf-level "is-not" stays on each
+criterion's own modifier (orthogonal).
+
+**Import normalization (the crux of prefill round-trip):** an `OperatorFilter` dict may mix
+keyed criterion fields + `AND`/`OR`/`NOT` lists + `field_comparisons` + sub-filter fields at
+one level. The importer treats each dict as an **implicit AND group** whose children are:
+each keyed criterion → a criterion leaf; each `field_comparisons` entry → a comparison leaf;
+each sub-filter field → a relation node (recurse into its child); the `AND` list → merged as
+sibling children; the `OR` list → an `OR` group child; the `NOT` list → a `NOT` group child.
+Export re-emits canonical form. Round-trip is logically equivalent (may canonicalize shape).
+Reuse server metadata — `resolve_path_kind()`, `_criterion_class_for()`,
+`comparable_columns()` — so the client never duplicates per-field type tables.
+
+## UX / visual spec
+
+- **Group rendering:** nested bordered cards; connective chip (`[AND ▾]`) in each card
+  header; nesting = cards-within-cards with **alternating depth background** (Qui pattern,
+  ~3–4 shade cycle).
+- **Relation descent:** inline **accent block** among the group's children —
+  `↳ [ANY ▾] of [sessions ▾] where` header (relation pick + quantifier) wrapping a nested
+  group built from the **target model's** fields (makes the Game→Session model switch
+  explicit, Filter-Forge `↳ INTO` pattern).
+- **Restructuring: buttons only, no drag-and-drop.** Per-node: `remove`, `duplicate`,
+  `wrap in group`; reorder within a group via `↑`/`↓`; group footer:
+  `[+ condition] [+ group] [+ relation]`; connective changed in place. Covers all real
+  restructuring with vanilla DOM, robust on touch (both case studies warned nested-tree DnD
+  is fragile).
+- **Depth: soft cap at 5.** `Add group`/`Add relation` disabled past depth 5 with a
+  "max nesting reached" hint.
+- **Add-condition / leaf flow:** `+ condition` inserts a row `[field ▾ searchable, grouped]
+  [modifier ▾ valid-for-type] [value widget]`. Field-first; on field pick the modifier list
+  + value widget derive from the criterion class. Reuse existing leaf widgets: `FilterSelect`
+  (id/enum sets), `DateRangeFilter`, number input, bool radio, single `field-comparison` row.
+- **Empty / initial state:** root is always an `AND` group, pre-seeded with one empty leaf
+  row (field picker open) + footer buttons.
+- **Validation:** client pre-validates (no field chosen, missing value, incomplete BETWEEN
+  bounds) → mark leaf invalid + disable Apply. Backend `apply_structured_filter` fail-open on
+  parse error remains the safety net.
+- **Natural-language summary:** read-only English readout at top, recomputed on every edit by
+  a pure client-side tree walk (no server call). e.g. "Games where status is Finished and any
+  session has device Handheld and duration ≥ 2h."
+- **Live result count:** debounced + cancellable **top-level total** count badge
+  ("≈ 142 games"). One count query per settled edit via a small per-model count endpoint
+  (`parse_*_filter` → `to_q().count()`). Per-group counts are NOT built (Filter-Forge faked
+  them) — possible later enhancement.
+- **Presets:** toolbar `[Load preset ▾]` (prefills tree from a `FilterPreset`'s JSON — same
+  code path as loading any `?filter=`) and `[Save as preset…]` (serializes the tree). Reuse
+  existing `preset_list_url` / `preset_save_url`.
+- **Mobile:** cards stack; reduced left padding per depth; accent relation block full-width;
+  no horizontal scroll; buttons-only model works on touch.
+
+## Prereq components → 2c child issues (the required #172 output)
+
+Each built + unit-tested in isolation:
+
+1. **Recursive group shell** custom element — group card, connective chip, ordered children,
+   footer buttons, depth coloring, soft cap 5, buttons-only restructuring
+   (remove/duplicate/wrap/unwrap/↑/↓). Recursion is the core.
+2. **Connective selector** — AND/OR/NOT chip dropdown.
+3. **Add-criterion field picker** — searchable/grouped field combobox reading per-model field
+   metadata (name, label, criterion kind, choices); inserts a leaf row.
+4. **Leaf row** — field/modifier/value; derives modifier list + value widget from criterion
+   class; mounts existing `FilterSelect` / date / number / bool / single `field-comparison`
+   widgets.
+5. **Relation-descent + quantifier picker** — relation select (typed sub-filter fields of the
+   model) + quantifier (ANY/NONE/ALL) + nested child group, rendered as the accent block.
+6. **Recursive serializer/deserializer** — node tree ↔ `OperatorFilter` JSON: canonical
+   export + import normalization (above). TS module, contract-tested against backend
+   round-trip.
+7. **Natural-language summary** — client-side tree → English walker.
+8. **Live count** — per-model count endpoint + debounced/cancellable badge.
+9. **Server field-metadata exposure** — per-model field list (name, label, criterion kind,
+   choices, available relations) for the picker, from `resolve_path_kind` /
+   `_criterion_class_for` / `comparable_columns` (#161 + #157 feed this; possibly the
+   field-metadata registry the #168 comment flagged).
+10. **Builder page shell** — per-model `/…/filter` route + `render_page` view; toolbar
+    (presets, Apply, Clear); mounts root group + NL summary + count.
+
+Exact split may merge/refine during 2b (#173) planning, but this is the component set.
+
+## Follow-up issues to file
+
+- **GitHub-style quick bar** (single-model facet dropdowns + degrade-to-"Advanced active").
+- **Per-group live count** (deferred enhancement on the advanced builder).
+- Confirm whether the #168-comment **field-metadata registry** is folded into component 9 or
+  filed separately — decide in 2b.
+
+## Verification (of the eventual build, for 2b/2d — not #172)
+
+- Round-trip property test: arbitrary nested `?filter=` JSON → import → export ≡ logically
+  equivalent (`to_q()` produces identical results); cover OR, NOT-as-none-of, relation +
+  each quantifier, field comparison, mixed-shape import normalization.
+- Component unit tests per 2c item (render + serialize in isolation).
+- e2e (Playwright, `e2e/`): build a cross-model filter on `/games/filter`, Apply, assert the
+  list narrows; load a preset; confirm NL summary + count update; confirm quick bar degrades
+  to "Advanced active" for a complex filter.

--- a/docs/superpowers/specs/2026-06-28-nested-filter-builder-design.md
+++ b/docs/superpowers/specs/2026-06-28-nested-filter-builder-design.md
@@ -43,30 +43,35 @@ The UI is a **homogeneous tree** of three node kinds. The serializer always emit
 form, which kills the transitional OR-isolation wrapper and the flat `field-comparison`
 special-case (the #167 `TODO(nested-builder)` debt).
 
-- **Group** — connective ∈ {`AND`, `OR`, `NOT`} + ordered children (groups / leaves /
-  relations). → `{CONNECTIVE: [child_json, …]}`, each child its own single-key dict.
-- **Leaf (criterion)** — field + criterion (modifier + value[/value2]). →
-  `{field: {value, modifier, value2?}}`.
-- **Leaf (field comparison)** — left/right column + modifier (reuses the existing single
-  `field-comparison` row). → `{field_comparisons: [{left, right, modifier, granularity}]}`.
-- **Relation descent** — relation field + quantifier + one child group. →
+- **Group** — connective ∈ {`AND`, `OR`} + optional `¬` negate flag + ordered children (groups
+  / leaves / relations). → `{CONNECTIVE: [child_json, …]}`, wrapped in `{NOT:[…]}` when `¬` is
+  set; each child its own single-key dict.
+- **Leaf (criterion)** — field + criterion (modifier + value[/value2]) + optional `¬` flag. →
+  `{field: {value, modifier, value2?}}`, wrapped in `{NOT:[…]}` when `¬` is set.
+- **Leaf (field comparison)** — left/right column + modifier + optional `¬` (reuses the existing
+  single `field-comparison` row). → `{field_comparisons: [{left, right, modifier, granularity}]}`.
+- **Relation descent** — relation field + quantifier + one child group + optional `¬`. →
   `{rel_field: {match: Q?, …child-group-serialized}}`; `match` omitted when ANY (default).
 
-**Negation:** `NOT` is a third group connective, but in the builder a **NOT group wraps
-exactly one child** (a leaf or a single AND/OR group), so `NOT[x]` = `~x` — unambiguous. "None
-of a, b" is `NOT[ OR[a,b] ]` (= `~a AND ~b`, verified). This avoids the silent meaning-shift a
-multi-child NOT would cause (`{NOT:[a,b]}` = `~a AND ~b` per backend, which reads as "none of"
-but surprises users mid-edit). Leaf-level "is-not" stays on each criterion's own modifier; to
-negate a whole group, wrap it in NOT. Backend contract (`{NOT:[single]}`) unchanged.
+**Negation (toggle model):** negation is **not** a connective — connectives are only `AND`/`OR`.
+Every node carries an independent **`¬` toggle** that inverts it (Qui's model). `¬` on a group
+inverts the whole group; `¬` on a leaf inverts that condition. This avoids the multi-child-NOT
+ambiguity entirely (there is no NOT *group*, so no "is it `~a∧~b` or `~(a∧b)`?" question) and
+spends **zero extra nesting depth** per negation — important against the depth cap, since a
+NOT-as-connective would burn a level for every negated group. On export, a node with `¬` set
+serializes wrapped as `{NOT:[node]}` (e.g. `¬OR[a,b]` → `{NOT:[{OR:[a,b]}]}` = `~a ∧ ~b`,
+verified). Leaf-level "is-not" via the criterion's own modifier (`NOT_EQUALS`, `EXCLUDES`, …)
+remains available too — `¬` and the modifier are two harmless routes to the same result;
+guidance favors the modifier for a single criterion, `¬` for groups.
 
 **Canonical export (verified correct):** each group exports to exactly one connective key
-(`{AND:[…]}` / `{OR:[…]}` / `{NOT:[one]}`), each child a single-key dict; a leaf →
-`{field:{…}}`; a relation → `{rel_field:{match?, <one canonical group>}}`. The builder **never
-emits a mixed node** (keyed fields + operator lists at one level). A live `to_q()` check
-confirmed canonical top-level `OR` evaluates identically to the old OR-isolation-wrapper form
-(empty `Q()` is absorbed in Django ORs — no match-all poisoning), so the transitional wrapper
-is genuinely droppable. Empty operator lists are dropped on export (`{AND:[]}`→`{}`); round-trip
-is **logical equivalence**, not byte equality.
+(`{AND:[…]}` / `{OR:[…]}`), each child a single-key dict; a leaf → `{field:{…}}`; a relation →
+`{rel_field:{match?, <one canonical group>}}`; any `¬`-set node is wrapped in `{NOT:[…]}`. The
+builder **never emits a mixed node** (keyed fields + operator lists at one level). A live
+`to_q()` check confirmed canonical top-level `OR` evaluates identically to the old
+OR-isolation-wrapper form (empty `Q()` is absorbed in Django ORs — no match-all poisoning), so
+the transitional wrapper is genuinely droppable. Empty operator lists are dropped on export
+(`{AND:[]}`→`{}`); round-trip is **logical equivalence**, not byte equality.
 
 **Import normalization (prefill from arbitrary/legacy JSON):** an `OperatorFilter` dict may mix
 keyed criterion fields + `AND`/`OR`/`NOT` lists + `field_comparisons` + sub-filter fields at one
@@ -77,7 +82,10 @@ The importer must **reproduce that precedence faithfully**, not assume an implic
    entry as its own comparison leaf, each sub-filter field as a relation node, each `AND`
    sub-filter imported recursively].
 2. If `OR` present: `P` becomes `OR[ P, …each OR sub-filter imported ]`.
-3. If `NOT` present: result becomes `AND[ (P-or-OR), …NOT[each NOT sub-filter] ]` (each `&= ~`).
+3. If `NOT` present: result becomes `AND[ (P-or-OR), …(each NOT sub-filter imported as a node
+   with its `¬` flag set) ]` (each `&= ~`). A single-child `AND[…]` collapses to its child, so
+   `{NOT:[{OR:[a,b]}]}` imports as an `OR[a,b]` node with `¬` set; a multi-child `{NOT:[a,b]}`
+   imports as `AND[ a¬, b¬ ]`.
 
 So `{name, OR:[x]}` correctly imports as `OR[name, x]` (= `name OR x`), **not** `AND(name, x)`.
 Re-export canonicalizes the shape; the tree's `to_q()` equals the original's. Reuse server
@@ -85,7 +93,8 @@ metadata — `resolve_path_kind()`, `_criterion_class_for()`, `comparable_column
 client never duplicates per-field type tables.
 
 **Relation / sub-filter notes:** a relation node's child is exactly **one** canonical group, so
-its sub-filter dict carries `match` + exactly one connective key (no ambiguity). An **empty**
+its sub-filter dict carries `match` + one connective key (or a `{NOT:[…]}` wrapper when the child
+group is negated) — no ambiguity. An **empty**
 relation child is a feature: `ANY`+empty = "has ≥1 related row", `NONE`+empty = "has 0 related
 rows". Cross-model relation fields can cycle (`game→session→game`), and the backend has **no
 recursion guard** today (see Open items) — a hand-edited cyclic `?filter=` would infinite-loop,
@@ -93,9 +102,10 @@ so a parse-time depth guard is a prerequisite.
 
 ## UX / visual spec
 
-- **Group rendering:** nested bordered cards; connective chip (`[AND ▾]`) in each card
-  header; nesting = cards-within-cards with **alternating depth background** (Qui pattern,
-  ~3–4 shade cycle).
+- **Group rendering:** nested bordered cards; header carries an `AND`/`OR` connective chip
+  plus a `¬` negate toggle (lit = whole group inverted); nesting = cards-within-cards with
+  **alternating depth background** (Qui pattern, ~3–4 shade cycle). Leaves carry the same `¬`
+  toggle.
 - **Relation descent:** inline **accent block** among the group's children —
   `↳ [ANY ▾] of [sessions ▾] where` header (relation pick + quantifier) wrapping a nested
   group built from the **target model's** fields (makes the Game→Session model switch
@@ -108,9 +118,10 @@ so a parse-time depth guard is a prerequisite.
   not a cross-branch move (vanilla DOM, robust on touch; both case studies warned nested-tree DnD
   is fragile).
 - **Depth: soft cap at 5.** The cap counts **group-nesting depth**; a relation-descent's child
-  group is **+1 level**; a criterion leaf is depth-0 (terminates). `Add group`/`Add relation`
-  disabled past depth 5 with a "max nesting reached" hint. (The backend recursion guard — Open
-  items — is set higher and is the real safety bound.)
+  group is **+1 level**; a criterion leaf is depth-0 (terminates); a `¬` toggle costs **0 levels**
+  (it's a flag, not a wrapper node). `Add group`/`Add relation` disabled past depth 5 with a
+  "max nesting reached" hint. (The backend recursion guard — Open items — is set higher and is the
+  real safety bound.)
 - **Add-condition / leaf flow:** `+ condition` inserts a row `[field ▾ searchable, grouped]
   [modifier ▾ valid-for-type] [value widget]`. Field-first; on field pick the modifier list +
   value widget derive from the criterion class. **On field change:** reset modifier to the first
@@ -161,12 +172,13 @@ foundational** and the rest depend on them. Build order: **0 → 9 → 6 → (1�
    `OperatorFilter` JSON: canonical export + the faithful import normalization (above). Replaces
    the flat `filter-bar.ts` `setPath`/`appendAnd`/`data-kind`-switch glue. Must serialize a tree
    recursively (per-group, not one global form pass). TS module, contract-tested against backend
-   round-trip (`to_q()` equality across OR / NOT-as-unary / relation×quantifier / field
+   round-trip (`to_q()` equality across OR / `¬`-negated group + leaf / relation×quantifier / field
    comparison / mixed-shape import).
 1. **Recursive group shell** custom element — group card, connective chip, ordered children,
    footer buttons, depth coloring, soft cap 5, buttons-only restructuring
    (remove/duplicate/wrap/**unwrap**/↑/↓). Recursion is the core.
-2. **Connective selector** — AND/OR/NOT chip dropdown (NOT = unary wrapper).
+2. **Connective selector + negate toggle** — `AND`/`OR` chip dropdown plus a per-node `¬` toggle
+   (groups and leaves); `¬` serializes as a `{NOT:[…]}` wrapper.
 3. **Add-criterion field picker** — searchable/grouped field combobox reading component 9's
    metadata; inserts a leaf row; defines on-field-change reset behavior.
 4. **Leaf row + leaf widgets** — field/modifier/value; derives modifier list + value widget from
@@ -197,7 +209,7 @@ Exact split may merge/refine during 2b (#173) planning, but this is the componen
 ## Verification (of the eventual build, for 2b/2d — not #172)
 
 - Round-trip property test: arbitrary nested `?filter=` JSON → import → export ≡ logically
-  equivalent (`to_q()` produces identical results); cover OR, NOT-as-none-of, relation +
+  equivalent (`to_q()` produces identical results); cover OR, `¬`-negated nodes, relation +
   each quantifier, field comparison, mixed-shape import normalization.
 - Component unit tests per 2c item (render + serialize in isolation).
 - e2e (Playwright, `e2e/`): build a cross-model filter on `/games/filter`, Apply, assert the

--- a/docs/superpowers/specs/2026-06-28-nested-filter-builder-design.md
+++ b/docs/superpowers/specs/2026-06-28-nested-filter-builder-design.md
@@ -52,20 +52,44 @@ special-case (the #167 `TODO(nested-builder)` debt).
 - **Relation descent** — relation field + quantifier + one child group. →
   `{rel_field: {match: Q?, …child-group-serialized}}`; `match` omitted when ANY (default).
 
-**Negation:** `NOT` is a third group connective, not a per-node toggle. A `NOT` group with
-multiple children means "none of these" (`~a AND ~b`, backend's existing list semantics);
-`NOT(a AND b)` is a `NOT` group wrapping one `AND` group. Leaf-level "is-not" stays on each
-criterion's own modifier (orthogonal).
+**Negation:** `NOT` is a third group connective, but in the builder a **NOT group wraps
+exactly one child** (a leaf or a single AND/OR group), so `NOT[x]` = `~x` — unambiguous. "None
+of a, b" is `NOT[ OR[a,b] ]` (= `~a AND ~b`, verified). This avoids the silent meaning-shift a
+multi-child NOT would cause (`{NOT:[a,b]}` = `~a AND ~b` per backend, which reads as "none of"
+but surprises users mid-edit). Leaf-level "is-not" stays on each criterion's own modifier; to
+negate a whole group, wrap it in NOT. Backend contract (`{NOT:[single]}`) unchanged.
 
-**Import normalization (the crux of prefill round-trip):** an `OperatorFilter` dict may mix
-keyed criterion fields + `AND`/`OR`/`NOT` lists + `field_comparisons` + sub-filter fields at
-one level. The importer treats each dict as an **implicit AND group** whose children are:
-each keyed criterion → a criterion leaf; each `field_comparisons` entry → a comparison leaf;
-each sub-filter field → a relation node (recurse into its child); the `AND` list → merged as
-sibling children; the `OR` list → an `OR` group child; the `NOT` list → a `NOT` group child.
-Export re-emits canonical form. Round-trip is logically equivalent (may canonicalize shape).
-Reuse server metadata — `resolve_path_kind()`, `_criterion_class_for()`,
-`comparable_columns()` — so the client never duplicates per-field type tables.
+**Canonical export (verified correct):** each group exports to exactly one connective key
+(`{AND:[…]}` / `{OR:[…]}` / `{NOT:[one]}`), each child a single-key dict; a leaf →
+`{field:{…}}`; a relation → `{rel_field:{match?, <one canonical group>}}`. The builder **never
+emits a mixed node** (keyed fields + operator lists at one level). A live `to_q()` check
+confirmed canonical top-level `OR` evaluates identically to the old OR-isolation-wrapper form
+(empty `Q()` is absorbed in Django ORs — no match-all poisoning), so the transitional wrapper
+is genuinely droppable. Empty operator lists are dropped on export (`{AND:[]}`→`{}`); round-trip
+is **logical equivalence**, not byte equality.
+
+**Import normalization (prefill from arbitrary/legacy JSON):** an `OperatorFilter` dict may mix
+keyed criterion fields + `AND`/`OR`/`NOT` lists + `field_comparisons` + sub-filter fields at one
+level, and the backend evaluates these in a fixed left-to-right order — `criteria &= …`, then
+`&= each AND`, then `|= each OR`, then `&= ~each NOT` (`_apply_operators`, criteria.py:1080).
+The importer must **reproduce that precedence faithfully**, not assume an implicit AND:
+1. Build the `&`-part `P` = an AND group of [each keyed criterion leaf, each `field_comparisons`
+   entry as its own comparison leaf, each sub-filter field as a relation node, each `AND`
+   sub-filter imported recursively].
+2. If `OR` present: `P` becomes `OR[ P, …each OR sub-filter imported ]`.
+3. If `NOT` present: result becomes `AND[ (P-or-OR), …NOT[each NOT sub-filter] ]` (each `&= ~`).
+
+So `{name, OR:[x]}` correctly imports as `OR[name, x]` (= `name OR x`), **not** `AND(name, x)`.
+Re-export canonicalizes the shape; the tree's `to_q()` equals the original's. Reuse server
+metadata — `resolve_path_kind()`, `_criterion_class_for()`, `comparable_columns()` — so the
+client never duplicates per-field type tables.
+
+**Relation / sub-filter notes:** a relation node's child is exactly **one** canonical group, so
+its sub-filter dict carries `match` + exactly one connective key (no ambiguity). An **empty**
+relation child is a feature: `ANY`+empty = "has ≥1 related row", `NONE`+empty = "has 0 related
+rows". Cross-model relation fields can cycle (`game→session→game`), and the backend has **no
+recursion guard** today (see Open items) — a hand-edited cyclic `?filter=` would infinite-loop,
+so a parse-time depth guard is a prerequisite.
 
 ## UX / visual spec
 
@@ -77,28 +101,40 @@ Reuse server metadata — `resolve_path_kind()`, `_criterion_class_for()`,
   group built from the **target model's** fields (makes the Game→Session model switch
   explicit, Filter-Forge `↳ INTO` pattern).
 - **Restructuring: buttons only, no drag-and-drop.** Per-node: `remove`, `duplicate`,
-  `wrap in group`; reorder within a group via `↑`/`↓`; group footer:
-  `[+ condition] [+ group] [+ relation]`; connective changed in place. Covers all real
-  restructuring with vanilla DOM, robust on touch (both case studies warned nested-tree DnD
+  `wrap in group` (new wrapper defaults to the parent's connective), `unwrap/flatten` (dissolve
+  a group, splice its children into the parent); reorder within a group via `↑`/`↓`; group
+  footer: `[+ condition] [+ group] [+ relation]`; connective changed in place. **Accepted
+  limitation:** moving a leaf to a non-sibling group two levels away is done via remove + re-add,
+  not a cross-branch move (vanilla DOM, robust on touch; both case studies warned nested-tree DnD
   is fragile).
-- **Depth: soft cap at 5.** `Add group`/`Add relation` disabled past depth 5 with a
-  "max nesting reached" hint.
+- **Depth: soft cap at 5.** The cap counts **group-nesting depth**; a relation-descent's child
+  group is **+1 level**; a criterion leaf is depth-0 (terminates). `Add group`/`Add relation`
+  disabled past depth 5 with a "max nesting reached" hint. (The backend recursion guard — Open
+  items — is set higher and is the real safety bound.)
 - **Add-condition / leaf flow:** `+ condition` inserts a row `[field ▾ searchable, grouped]
-  [modifier ▾ valid-for-type] [value widget]`. Field-first; on field pick the modifier list
-  + value widget derive from the criterion class. Reuse existing leaf widgets: `FilterSelect`
-  (id/enum sets), `DateRangeFilter`, number input, bool radio, single `field-comparison` row.
+  [modifier ▾ valid-for-type] [value widget]`. Field-first; on field pick the modifier list +
+  value widget derive from the criterion class. **On field change:** reset modifier to the first
+  valid one for the new type, **clear** the value (no silent type-coercion), mark the leaf
+  incomplete until filled; replacing the value widget flushes old DOM. Reuse existing leaf
+  widgets: `DateRangeFilter` + bool radio drop in clean; `FilterSelect` needs a **self-serialize**
+  rework (today it depends on a global `readSearchSelect` preprocessing pass — see components);
+  the single `field-comparison` row needs a **leaf variant** embedding its own `columns` and
+  dropping the AND/OR mode toggle (the enclosing group owns the connective).
 - **Empty / initial state:** root is always an `AND` group, pre-seeded with one empty leaf
   row (field picker open) + footer buttons.
 - **Validation:** client pre-validates (no field chosen, missing value, incomplete BETWEEN
-  bounds) → mark leaf invalid + disable Apply. Backend `apply_structured_filter` fail-open on
-  parse error remains the safety net.
+  bounds) → mark leaf **incomplete** (faded + badge), **exclude it from both the count query and
+  Apply**, and disable Apply while any leaf is incomplete. Backend `apply_structured_filter`
+  fail-open on parse error remains the safety net.
 - **Natural-language summary:** read-only English readout at top, recomputed on every edit by
   a pure client-side tree walk (no server call). e.g. "Games where status is Finished and any
   session has device Handheld and duration ≥ 2h."
 - **Live result count:** debounced + cancellable **top-level total** count badge
-  ("≈ 142 games"). One count query per settled edit via a small per-model count endpoint
-  (`parse_*_filter` → `to_q().count()`). Per-group counts are NOT built (Filter-Forge faked
-  them) — possible later enhancement.
+  ("≈ 142 games"). One count query per settled edit via a small per-model count endpoint (new —
+  `parse_*_filter` → `to_q().count()`). Badge shows **"counting…"** while debounced/in-flight and
+  **"count unavailable"** on endpoint error (never a bare 0). Incomplete leaves are excluded from
+  the query. Per-group counts are NOT built (Filter-Forge faked them) — possible later
+  enhancement.
 - **Presets:** toolbar `[Load preset ▾]` (prefills tree from a `FilterPreset`'s JSON — same
   code path as loading any `?filter=`) and `[Save as preset…]` (serializes the tree). Reuse
   existing `preset_list_url` / `preset_save_url`.
@@ -107,39 +143,56 @@ Reuse server metadata — `resolve_path_kind()`, `_criterion_class_for()`,
 
 ## Prereq components → 2c child issues (the required #172 output)
 
-Each built + unit-tested in isolation:
+The adversarial review corrected the naive "all built in isolation" framing: **two are
+foundational** and the rest depend on them. Build order: **0 → 9 → 6 → (1–5 in parallel) → 7,8 →
+10.**
 
+0. **Backend recursion/cycle guard** (NEW prereq) — relation fields cycle
+   (`game→session→game`) and `OperatorFilter.from_json`/`to_q` enforce no depth limit today, so a
+   hand-edited cyclic `?filter=` infinite-loops the server. Add a parse-time depth guard in
+   `from_json` (raise `FilterError` past a max depth, e.g. 10). Independent of the UI but a
+   security prerequisite the shareable-URL builder makes reachable. **File as a backend issue.**
+9. **Server field-metadata registry** (foundational) — a per-model field list returning
+   `{name, label, kind, nullable, choices, relations}`. `resolve_path_kind` /
+   `_criterion_class_for` / `comparable_columns` exist (~40%); the **label / choices / nullable /
+   relation enumeration is missing and must be built**. This is the field-metadata registry the
+   #168 comment flagged; cross-ref #161 (FilterField) + #157 (criterion types); later feeds #152.
+6. **Recursive serializer/deserializer** (foundational — blocks 1–5,7,8) — node tree ↔
+   `OperatorFilter` JSON: canonical export + the faithful import normalization (above). Replaces
+   the flat `filter-bar.ts` `setPath`/`appendAnd`/`data-kind`-switch glue. Must serialize a tree
+   recursively (per-group, not one global form pass). TS module, contract-tested against backend
+   round-trip (`to_q()` equality across OR / NOT-as-unary / relation×quantifier / field
+   comparison / mixed-shape import).
 1. **Recursive group shell** custom element — group card, connective chip, ordered children,
    footer buttons, depth coloring, soft cap 5, buttons-only restructuring
-   (remove/duplicate/wrap/unwrap/↑/↓). Recursion is the core.
-2. **Connective selector** — AND/OR/NOT chip dropdown.
-3. **Add-criterion field picker** — searchable/grouped field combobox reading per-model field
-   metadata (name, label, criterion kind, choices); inserts a leaf row.
-4. **Leaf row** — field/modifier/value; derives modifier list + value widget from criterion
-   class; mounts existing `FilterSelect` / date / number / bool / single `field-comparison`
-   widgets.
-5. **Relation-descent + quantifier picker** — relation select (typed sub-filter fields of the
-   model) + quantifier (ANY/NONE/ALL) + nested child group, rendered as the accent block.
-6. **Recursive serializer/deserializer** — node tree ↔ `OperatorFilter` JSON: canonical
-   export + import normalization (above). TS module, contract-tested against backend
-   round-trip.
-7. **Natural-language summary** — client-side tree → English walker.
-8. **Live count** — per-model count endpoint + debounced/cancellable badge.
-9. **Server field-metadata exposure** — per-model field list (name, label, criterion kind,
-   choices, available relations) for the picker, from `resolve_path_kind` /
-   `_criterion_class_for` / `comparable_columns` (#161 + #157 feed this; possibly the
-   field-metadata registry the #168 comment flagged).
+   (remove/duplicate/wrap/**unwrap**/↑/↓). Recursion is the core.
+2. **Connective selector** — AND/OR/NOT chip dropdown (NOT = unary wrapper).
+3. **Add-criterion field picker** — searchable/grouped field combobox reading component 9's
+   metadata; inserts a leaf row; defines on-field-change reset behavior.
+4. **Leaf row + leaf widgets** — field/modifier/value; derives modifier list + value widget from
+   criterion class. `DateRange` + bool reuse clean; **`FilterSelect` reworked to self-serialize**
+   (drop the global `readSearchSelect` preprocessing dependency); **new single-row
+   `field-comparison` leaf** embedding its own `columns`, no mode toggle.
+5. **Relation-descent + quantifier picker** — relation select (component 9's relation list) +
+   quantifier (ANY/NONE/ALL) + nested child group, rendered as the accent block.
+7. **Natural-language summary** — client-side tree → English walker (independent; decorative).
+8. **Live count** — NEW per-model count endpoint + debounced/cancellable badge with
+   counting/unavailable states.
 10. **Builder page shell** — per-model `/…/filter` route + `render_page` view; toolbar
-    (presets, Apply, Clear); mounts root group + NL summary + count.
+    (presets, Apply, Clear); mounts root group + NL summary + count; reads/writes `?filter=`.
 
 Exact split may merge/refine during 2b (#173) planning, but this is the component set.
 
-## Follow-up issues to file
+## Open items / follow-up issues to file
 
-- **GitHub-style quick bar** (single-model facet dropdowns + degrade-to-"Advanced active").
+- **Backend recursion/cycle guard** (component 0) — file as a backend issue; prerequisite to
+  shipping the builder (DoS via cyclic hand-edited `?filter=`).
+- **GitHub-style quick bar** (single-model facet dropdowns + degrade-to-"Advanced active"). Its
+  degrade predicate must account for canonicalization (a quick-bar filter, exported and reloaded,
+  must round-trip back to editable, not flip to "advanced") — pin in that issue.
 - **Per-group live count** (deferred enhancement on the advanced builder).
-- Confirm whether the #168-comment **field-metadata registry** is folded into component 9 or
-  filed separately — decide in 2b.
+- The #168-comment **field-metadata registry** is folded into component 9 (decided here, not
+  deferred).
 
 ## Verification (of the eventual build, for 2b/2d — not #172)
 


### PR DESCRIPTION
Phase 2a of #168 (closes #172): brainstorm output for the nested filter builder.

Docs-only — two specs under `docs/superpowers/specs/`:
- `2026-06-28-nested-filter-builder-design.md` — the design
- `2026-06-28-nested-filter-builder-adversarial-review.md` — 3-agent adversarial review + empirical `to_q()` verification

### Decisions
- **Two-tier:** single-model quick bar (#197) + cross-model advanced builder, one shared `?filter=` JSON.
- **Homogeneous node tree** + canonical single-connective serializer (OR-isolation wrapper droppable, verified `to_q()`-equivalent).
- **Toggle-NOT:** AND/OR + per-node `¬` flag (`{NOT:[node]}`), 0 nesting depth per negation.
- Inline relation-descent accent block + ANY/NONE/ALL; buttons-only restructuring; soft depth cap 5 (relation child = +1), backend recursion guard 10; NL summary + live count + presets; per-model `/…/filter` page.

### Prereq components → 2c sub-issues of #168
#186 backend cycle-guard · #187 field-metadata registry · #188 recursive serializer · #189 group shell · #190 connective+negate toggle · #191 add-criterion picker · #192 leaf row+widgets · #193 relation+quantifier picker · #194 NL summary · #195 live count · #196 page shell.
Follow-ups: #197 quick bar, #198 per-group counts.

Next: 2b plan (#173).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
