### PR TITLE
fix(filters): backend recursion/cycle guard for OperatorFilter.from_json (#186)

### DIFF
--- a/common/criteria.py
+++ b/common/criteria.py
@@ -756,11 +756,13 @@ _COMPARISON_FIELD = "field_comparisons"
 
 # Max OperatorFilter nesting depth accepted from a hand-edited/shared ``?filter=``.
 # Each from_json frame (one AND/OR/NOT level OR one relation descent) = one unit, so
-# this aligns ~1:1 with the builder's group-nesting depth. The builder's UI soft cap
-# is 5; this 10 keeps headroom so no legitimately built filter is ever rejected, while
-# a pathologically deep / cyclic blob (relation fields cycle, e.g. GameFilter.session_filter
-# <-> SessionFilter.game_filter) raises FilterError at parse instead of recursing into a
-# RecursionError/500 or a runaway nested-subquery build (DoS). See issue #186.
+# this counts the same nesting the builder bounds with its UI soft cap of 5. Both
+# operator groups and relation descents draw from this single budget, so this 10 is
+# 2x headroom over that cap — a filter built within the UI's nesting limit is not
+# rejected in practice — while a pathologically deep / cyclic blob (relation fields
+# cycle, e.g. GameFilter.session_filter <-> SessionFilter.game_filter) raises
+# FilterError at parse instead of recursing into a RecursionError/500 or a runaway
+# nested-subquery build (DoS). See issue #186.
 MAX_FILTER_DEPTH = 10
 
 
@@ -1155,7 +1157,8 @@ class OperatorFilter:
             return None
         # Cap nesting before recursing: a hand-edited/shared cyclic ``?filter=`` would
         # otherwise parse into an unbounded tree and DoS the server (see MAX_FILTER_DEPTH).
-        # ``_depth`` is incremented only at the two operator-filter recursion sites below.
+        # ``_depth`` is incremented at the two recursion sites below: the AND/OR/NOT
+        # operator list and the cross-entity relation descent (both consume the budget).
         if _depth > MAX_FILTER_DEPTH:
             raise FilterError(f"Filter nesting too deep (max {MAX_FILTER_DEPTH})")
         # Resolve criterion class names to actual types
@@ -1317,6 +1320,14 @@ def filter_from_json(cls: type[FilterType], json_str: str) -> FilterType | None:
         data = json.loads(json_str)
     except json.JSONDecodeError as exc:
         raise FilterError(f"Filter is not valid JSON: {exc}") from exc
+    except RecursionError as exc:
+        # ``json.loads`` recurses per nesting level and overflows the C stack on a
+        # deeply-nested blob *before* OperatorFilter.from_json's MAX_FILTER_DEPTH
+        # guard can run. Reclassify to FilterError so the same deep/cyclic ``?filter=``
+        # DoS (issue #186) is caught here too, not just post-parse — otherwise this
+        # RecursionError escapes the view's FilterError boundary and 500s. Reachable
+        # un-capped via a stored FilterPreset blob (URL-length limits don't apply).
+        raise FilterError("Filter nesting too deep") from exc
     result = cls.from_json(data)
     if result is None:
         return None

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -754,6 +754,15 @@ _OPERATOR_FIELDS: tuple[str, str, str] = ("AND", "OR", "NOT")
 # logic is untouched; the from_json/to_json/apply paths branch on this name.
 _COMPARISON_FIELD = "field_comparisons"
 
+# Max OperatorFilter nesting depth accepted from a hand-edited/shared ``?filter=``.
+# Each from_json frame (one AND/OR/NOT level OR one relation descent) = one unit, so
+# this aligns ~1:1 with the builder's group-nesting depth. The builder's UI soft cap
+# is 5; this 10 keeps headroom so no legitimately built filter is ever rejected, while
+# a pathologically deep / cyclic blob (relation fields cycle, e.g. GameFilter.session_filter
+# <-> SessionFilter.game_filter) raises FilterError at parse instead of recursing into a
+# RecursionError/500 or a runaway nested-subquery build (DoS). See issue #186.
+MAX_FILTER_DEPTH = 10
+
 
 def _criterion_class_for(
     cls: type["OperatorFilter"], field_name: str
@@ -1141,9 +1150,14 @@ class OperatorFilter:
         return Q()
 
     @classmethod
-    def from_json(cls, data: dict[str, Any] | None) -> Self | None:
+    def from_json(cls, data: dict[str, Any] | None, *, _depth: int = 0) -> Self | None:
         if data is None or not isinstance(data, dict):
             return None
+        # Cap nesting before recursing: a hand-edited/shared cyclic ``?filter=`` would
+        # otherwise parse into an unbounded tree and DoS the server (see MAX_FILTER_DEPTH).
+        # ``_depth`` is incremented only at the two operator-filter recursion sites below.
+        if _depth > MAX_FILTER_DEPTH:
+            raise FilterError(f"Filter nesting too deep (max {MAX_FILTER_DEPTH})")
         # Resolve criterion class names to actual types
         criterion_types = _CRITERION_TYPES
         kwargs: dict[str, Any] = {}
@@ -1195,7 +1209,7 @@ class OperatorFilter:
                     kwargs[f.name] = []
                     continue
                 items = raw if isinstance(raw, list) else [raw]
-                parsed = [cls.from_json(item) for item in items]
+                parsed = [cls.from_json(item, _depth=_depth + 1) for item in items]
                 kwargs[f.name] = [sub for sub in parsed if sub is not None]
                 continue
             if raw is None:
@@ -1220,7 +1234,9 @@ class OperatorFilter:
             elif isinstance(f_type, str) and f_type in _FILTER_TYPES:
                 filter_cls = _FILTER_TYPES[f_type]
                 kwargs[f.name] = (
-                    filter_cls.from_json(raw) if isinstance(raw, dict) else None
+                    filter_cls.from_json(raw, _depth=_depth + 1)
+                    if isinstance(raw, dict)
+                    else None
                 )
         return cls(**kwargs)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1504,8 +1504,8 @@ def _nest_relation(levels: int) -> dict:
     GameFilter (parse_game_filter), so position 0 must be a key GameFilter accepts
     (session_filter); SessionFilter at position 1 accepts game_filter; and so on.
     Each nested dict is one from_json frame, so ``levels`` == the recursion depth
-    the guard counts. Empty innermost filter keeps the chain valid (a bare relation
-    is "has any related row" — to_q never raises)."""
+    the guard counts. The empty innermost filter keeps the chain valid — an empty
+    sub-filter parses and its to_q() does not raise."""
     node: dict = {}
     for position in range(levels - 1, -1, -1):
         key = "session_filter" if position % 2 == 0 else "game_filter"
@@ -1520,6 +1520,15 @@ def _nest_operator(levels: int) -> dict:
     for _ in range(levels):
         node = {"AND": [node]}
     return node
+
+
+def _deep_json_string(levels: int) -> str:
+    """A ``levels``-deep nested-``AND`` blob built as a raw string, NOT via
+    json.dumps — dumping a dict this deep would itself overflow and die in the
+    harness, masking the point. ``json.loads`` of this overflows the C stack
+    (RecursionError) before OperatorFilter.from_json's depth guard can run, so it
+    exercises the pre-parse vector (issue #186)."""
+    return '{"AND":[' * levels + "{}" + "]}" * levels
 
 
 class TestFilterDepthGuard:
@@ -1538,12 +1547,22 @@ class TestFilterDepthGuard:
         with pytest.raises(FilterError, match="too deep"):
             parse_game_filter(bad)
 
-    def test_depth_guard_raises_filter_error_not_recursion_error(self):
-        """An extreme depth must surface as a catchable FilterError (a ValueError
-        subclass the views already handle), never an uncaught RecursionError that
-        would 500 the list view."""
+    def test_post_parse_depth_raises_filter_error(self):
+        """A well-formed but deep blob (json.loads succeeds) must be cut by the
+        from_json depth guard as a catchable FilterError, never an uncaught
+        RecursionError that would 500 the list view."""
         bad = json.dumps(_nest_relation(500))
-        with pytest.raises(FilterError):
+        with pytest.raises(FilterError, match="too deep"):
+            parse_game_filter(bad)
+
+    def test_json_loads_recursion_raises_filter_error_not_500(self):
+        """A blob deep enough that json.loads itself overflows the C stack
+        (RecursionError, raised *before* the from_json guard runs) must still
+        surface as a catchable FilterError — otherwise it escapes the view's
+        FilterError boundary and 500s. Reachable un-capped via a stored
+        FilterPreset blob (issue #186)."""
+        bad = _deep_json_string(100_000)
+        with pytest.raises(FilterError, match="too deep"):
             parse_game_filter(bad)
 
     def test_nesting_within_cap_parses(self):
@@ -1567,6 +1586,30 @@ class TestFilterDepthGuard:
         result = parse_game_filter(good)
         assert result is not None
         result.to_q()  # does not raise
+
+    def test_mixed_operator_and_relation_share_one_depth_budget(self):
+        """Both recursion sites increment the same ``_depth``, so a tree alternating
+        AND groups with relation descents sums their frames against one budget — each
+        kind does not get its own cap. Build the chain outer->inner tracking the
+        current entity so every key is valid (AND preserves the entity; session_filter
+        descends game->session, game_filter descends session->game), then a
+        combined-deep-but-modest-per-kind blob raises."""
+        entity = "game"
+        keys: list[str] = []
+        for index in range(MAX_FILTER_DEPTH + 4):
+            if index % 2 == 0:
+                keys.append("AND")
+            elif entity == "game":
+                keys.append("session_filter")
+                entity = "session"
+            else:
+                keys.append("game_filter")
+                entity = "game"
+        node: dict = {}
+        for key in reversed(keys):
+            node = {"AND": [node]} if key == "AND" else {key: node}
+        with pytest.raises(FilterError, match="too deep"):
+            parse_game_filter(json.dumps(node))
 
     def test_valid_nested_relation_filter_parses_and_reusable(self):
         """A valid cross-entity sub-filter survives eager validation and its

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -19,6 +19,7 @@ from common.criteria import (
     FilterError,
     FilterField,
     FloatCriterion,
+    MAX_FILTER_DEPTH,
     IntCriterion,
     Modifier,
     MultiCriterion,
@@ -1492,6 +1493,77 @@ class TestFilterErrorBoundary:
 
     def test_valid_filter_still_parses(self):
         good = json.dumps({"name": {"modifier": "INCLUDES", "value": "halo"}})
+        result = parse_game_filter(good)
+        assert result is not None
+        result.to_q()  # does not raise
+
+
+def _nest_relation(levels: int) -> dict:
+    """Build ``levels`` deep of alternating session_filter <-> game_filter relation
+    descent (the cyclic DoS vector named in issue #186). The outermost class is
+    GameFilter (parse_game_filter), so position 0 must be a key GameFilter accepts
+    (session_filter); SessionFilter at position 1 accepts game_filter; and so on.
+    Each nested dict is one from_json frame, so ``levels`` == the recursion depth
+    the guard counts. Empty innermost filter keeps the chain valid (a bare relation
+    is "has any related row" — to_q never raises)."""
+    node: dict = {}
+    for position in range(levels - 1, -1, -1):
+        key = "session_filter" if position % 2 == 0 else "game_filter"
+        node = {key: node}
+    return node
+
+
+def _nest_operator(levels: int) -> dict:
+    """Build ``levels`` deep of nested ``AND`` operator groups (the same-entity
+    recursion site). Each AND-list element is one from_json frame."""
+    node: dict = {"name": {"modifier": "INCLUDES", "value": "x"}}
+    for _ in range(levels):
+        node = {"AND": [node]}
+    return node
+
+
+class TestFilterDepthGuard:
+    """Issue #186: a hand-edited / shared cyclic or pathologically deep ``?filter=``
+    must raise FilterError at parse, never recurse into a RecursionError/500 or a
+    runaway nested-subquery build (DoS). The guard lives in OperatorFilter.from_json
+    and bounds both recursion sites (AND/OR/NOT and cross-entity relation descent)."""
+
+    def test_relation_nesting_past_cap_raises(self):
+        bad = json.dumps(_nest_relation(MAX_FILTER_DEPTH + 5))
+        with pytest.raises(FilterError, match="too deep"):
+            parse_game_filter(bad)
+
+    def test_operator_nesting_past_cap_raises(self):
+        bad = json.dumps(_nest_operator(MAX_FILTER_DEPTH + 5))
+        with pytest.raises(FilterError, match="too deep"):
+            parse_game_filter(bad)
+
+    def test_depth_guard_raises_filter_error_not_recursion_error(self):
+        """An extreme depth must surface as a catchable FilterError (a ValueError
+        subclass the views already handle), never an uncaught RecursionError that
+        would 500 the list view."""
+        bad = json.dumps(_nest_relation(500))
+        with pytest.raises(FilterError):
+            parse_game_filter(bad)
+
+    def test_nesting_within_cap_parses(self):
+        """A filter nested below the cap (covers the builder's <=5 soft cap with
+        headroom) parses and builds its Q without raising — guards against an
+        off-by-one that would reject legitimately built filters."""
+        good = json.dumps(_nest_relation(MAX_FILTER_DEPTH - 1))
+        result = parse_game_filter(good)
+        assert result is not None
+        result.to_q()  # does not raise
+
+    def test_nesting_at_cap_parses(self):
+        """Exactly at the cap is accepted (the guard rejects only *past* the cap)."""
+        good = json.dumps(_nest_relation(MAX_FILTER_DEPTH))
+        result = parse_game_filter(good)
+        assert result is not None
+        result.to_q()  # does not raise
+
+    def test_operator_nesting_within_cap_parses(self):
+        good = json.dumps(_nest_operator(MAX_FILTER_DEPTH - 1))
         result = parse_game_filter(good)
         assert result is not None
         result.to_q()  # does not raise


### PR DESCRIPTION
## Context

Filter relation fields form cycles — `GameFilter.session_filter` ↔ `SessionFilter.game_filter`, plus `game ↔ purchase/playevent/platform` and `session ↔ device`. `OperatorFilter.from_json`/`to_q` enforced **no depth limit**, so a hand-edited or shared cyclic/deep `?filter=` blob parsed into an unbounded tree, then `to_q()` built a deeply-nested chain of EXISTS subqueries → Python `RecursionError` (uncaught → HTTP 500) or a pathologically expensive query = **server DoS**.

Closes #186. Foundational prerequisite (phase 2c) for the nested filter builder, epic #168.

## Change

- `common/criteria.py`: new `MAX_FILTER_DEPTH = 10`; `OperatorFilter.from_json` gains keyword-only `_depth`, raising `FilterError("Filter nesting too deep (max 10)")` past the cap. `_depth + 1` threaded into the **two** recursion sites — the `AND/OR/NOT` operator loop and the cross-entity relation descent (both draw from one budget). Leaf `_Criterion.from_json` calls untouched.
- `filter_from_json`: also catch `RecursionError` around `json.loads` → `FilterError`. `json.loads` is itself recursive and overflows the C stack (~64k deep) **before** the `from_json` guard runs; that path is reachable un-capped via a stored `FilterPreset` blob. Without this, the same deep blob 500s — defeating the guard's purpose.
- Backend cap (10) ≥ builder UI soft cap (5) with ~2x headroom, so no filter built within the UI's nesting limit is rejected while pathological/cyclic input dies at parse. Views already catch `FilterError` and warn-and-ignore (fail-open); no view/API change.

## Tests

`TestFilterDepthGuard` in `tests/test_filters.py`: past-cap raises (operator nesting, relation cycle, mixed), at-cap/under-cap parse + `to_q()` clean (off-by-one + UI-cap-5 headroom), and a string-built 100k-deep blob proving the `json.loads` C-stack overflow surfaces as `FilterError`, not a 500.

## Verification

- `tests/test_filters.py`: 332 passed; `test_filter_helpers` + `test_filter_bars`: 49 passed.
- `mypy` clean, `ruff check` clean, `ruff format --check` clean.

## Follow-ups filed (out of scope here)

- #203 — log `FilterError` rejections server-side (observability at the security boundary; applies to all rejections).
- #204 — bound filter **breadth** (wide sibling/value lists), not just depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)