### PR TITLE
feat(filters): log FilterError rejections server-side (#203)

### DIFF
--- a/games/api.py
+++ b/games/api.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import date, datetime
 from typing import List
 
@@ -19,6 +20,8 @@ from games.sorting import (
     apply_sort,
     parse_find_filter,
 )
+
+logger = logging.getLogger("games")
 
 api = NinjaAPI(auth=django_auth)
 playevent_router = Router()
@@ -222,6 +225,12 @@ def list_sessions_api(request, filter: str = "", sort: str = "", page: int = 1):
         try:
             session_filter = parse_session_filter(filter)
         except FilterError as exc:
+            logger.warning(
+                "rejected invalid filter (entity=session, user=%s, path=%s): %s",
+                request.user,
+                request.path,
+                exc,
+            )
             raise HttpError(400, f"Invalid filter: {exc}") from exc
         if session_filter is not None:
             sessions = sessions.filter(session_filter.to_q())

--- a/games/views/filtering.py
+++ b/games/views/filtering.py
@@ -10,12 +10,15 @@ mirroring the unknown-sort-field UX: drop the bad filter, warn, render unfiltere
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 
 from django.contrib import messages
 from django.http import HttpRequest
 
 from common.criteria import FilterError, FilterType
+
+logger = logging.getLogger("games")
 
 
 def apply_structured_filter(
@@ -45,5 +48,13 @@ def apply_structured_filter(
     try:
         return parse(filter_json)
     except FilterError as exc:
+        entity = parse.__name__.removeprefix("parse_").removesuffix("_filter")
+        logger.warning(
+            "rejected invalid filter (entity=%s, user=%s, path=%s): %s",
+            entity,
+            request.user,
+            request.path,
+            exc,
+        )
         messages.warning(request, f"Ignored invalid filter: {exc}")
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import contextlib
+import logging
+
+import pytest
+
+
+@pytest.fixture
+def capture_games_logger(caplog):
+    """Context manager that wires ``caplog`` to the ``games`` logger.
+
+    The ``games`` logger sets ``propagate=False`` in settings
+    (``timetracker/settings.py``), so caplog's root handler never sees its
+    records. This attaches caplog's handler to the ``games`` logger directly for
+    the duration of the block. Use as ``with capture_games_logger(): ...`` and
+    then assert against ``caplog.records``.
+    """
+
+    @contextlib.contextmanager
+    def _capture():
+        games_logger = logging.getLogger("games")
+        games_logger.addHandler(caplog.handler)
+        caplog.set_level(logging.WARNING, logger="games")
+        try:
+            yield caplog
+        finally:
+            games_logger.removeHandler(caplog.handler)
+
+    return _capture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -198,26 +198,22 @@ def test_session_list_invalid_filter_semantics_rejected(auth_client):
     assert response.status_code == 400
 
 
-def test_session_list_malformed_filter_logged(auth_client, caplog):
+def test_session_list_malformed_filter_logged(auth_client, capture_games_logger):
     # Issue #203: a rejected filter must leave a server-side warning so operators
-    # can spot DoS-probing, in addition to the 400 the client sees. The "games"
-    # logger has propagate=False, so caplog's root handler never sees its records
-    # — attach caplog's handler to the games logger directly.
-    games_logger = logging.getLogger("games")
-    games_logger.addHandler(caplog.handler)
-    caplog.set_level(logging.WARNING, logger="games")
-    try:
+    # can spot DoS-probing, in addition to the 400 the client sees.
+    with capture_games_logger() as caplog:
         response = auth_client.get("/api/session/?filter=not-json")
-    finally:
-        games_logger.removeHandler(caplog.handler)
 
     assert response.status_code == 400
-    records = [r for r in caplog.records if r.name == "games"]
+    records = [record for record in caplog.records if record.name == "games"]
+    # Assert each labelled field so a swapped/dropped positional arg is caught.
     assert any(
-        r.levelno == logging.WARNING
-        and "rejected invalid filter" in r.getMessage()
-        and "entity=session" in r.getMessage()
-        for r in records
+        record.levelno == logging.WARNING
+        and "rejected invalid filter" in record.getMessage()
+        and "entity=session" in record.getMessage()
+        and "user=tester" in record.getMessage()
+        and "path=/api/session/" in record.getMessage()
+        for record in records
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from datetime import datetime, timedelta, timezone as dt_timezone
 
 import pytest
@@ -195,6 +196,29 @@ def test_session_list_invalid_filter_semantics_rejected(auth_client):
     bad = json.dumps({"duration_total_hours": {"modifier": "BETWEEN", "value": 1}})
     response = auth_client.get(f"/api/session/?filter={bad}")
     assert response.status_code == 400
+
+
+def test_session_list_malformed_filter_logged(auth_client, caplog):
+    # Issue #203: a rejected filter must leave a server-side warning so operators
+    # can spot DoS-probing, in addition to the 400 the client sees. The "games"
+    # logger has propagate=False, so caplog's root handler never sees its records
+    # — attach caplog's handler to the games logger directly.
+    games_logger = logging.getLogger("games")
+    games_logger.addHandler(caplog.handler)
+    caplog.set_level(logging.WARNING, logger="games")
+    try:
+        response = auth_client.get("/api/session/?filter=not-json")
+    finally:
+        games_logger.removeHandler(caplog.handler)
+
+    assert response.status_code == 400
+    records = [r for r in caplog.records if r.name == "games"]
+    assert any(
+        r.levelno == logging.WARNING
+        and "rejected invalid filter" in r.getMessage()
+        and "entity=session" in r.getMessage()
+        for r in records
+    )
 
 
 def _patch_session(client, session_id, body):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,7 +1,9 @@
 """Tests for the filtering system."""
 
+import contextlib
 import dataclasses
 import json
+import logging
 from dataclasses import dataclass
 from dataclasses import field as dc_field
 
@@ -1496,6 +1498,67 @@ class TestFilterErrorBoundary:
         result = parse_game_filter(good)
         assert result is not None
         result.to_q()  # does not raise
+
+
+@contextlib.contextmanager
+def _capture_games_logger(caplog):
+    """Wire caplog to the ``games`` logger, which sets ``propagate=False`` in
+    settings — so caplog's root handler never sees its records. Attach caplog's
+    handler directly for the duration of the block."""
+    games_logger = logging.getLogger("games")
+    games_logger.addHandler(caplog.handler)
+    caplog.set_level(logging.WARNING, logger="games")
+    try:
+        yield
+    finally:
+        games_logger.removeHandler(caplog.handler)
+
+
+class TestFilterErrorLogging:
+    """Issue #203: ``apply_structured_filter`` must log a server-side warning
+    (entity/user/path/exc) when it drops an invalid ``?filter=``, so operators
+    can spot DoS-probing — without changing the fail-open toast/None UX."""
+
+    def _request(self):
+        from django.contrib.auth.models import AnonymousUser
+        from django.contrib.messages.storage.cookie import CookieStorage
+        from django.test import RequestFactory
+
+        request = RequestFactory().get("/game/")
+        request.user = AnonymousUser()
+        # apply_structured_filter queues messages.warning, which needs storage.
+        # CookieStorage needs no session middleware (FallbackStorage would).
+        setattr(request, "_messages", CookieStorage(request))
+        return request
+
+    def test_invalid_filter_logs_warning_and_fails_open(self, caplog):
+        from games.views.filtering import apply_structured_filter
+
+        request = self._request()
+        bad = json.dumps({"name": {"modifier": "BOGUS", "value": "x"}})
+        with _capture_games_logger(caplog):
+            result = apply_structured_filter(request, parse_game_filter, bad)
+
+        assert result is None  # fail-open unchanged
+        records = [r for r in caplog.records if r.name == "games"]
+        assert any(
+            r.levelno == logging.WARNING
+            and "rejected invalid filter" in r.getMessage()
+            and "entity=game" in r.getMessage()
+            and "/game/" in r.getMessage()
+            for r in records
+        )
+
+    def test_valid_filter_logs_nothing(self, caplog):
+        from games.views.filtering import apply_structured_filter
+
+        request = self._request()
+        good = json.dumps({"name": {"modifier": "INCLUDES", "value": "halo"}})
+        with _capture_games_logger(caplog):
+            result = apply_structured_filter(request, parse_game_filter, good)
+
+        assert result is not None
+        assert not [r for r in caplog.records if r.name == "games"]
 
 
 def _nest_relation(levels: int) -> dict:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,6 +1,5 @@
 """Tests for the filtering system."""
 
-import contextlib
 import dataclasses
 import json
 import logging
@@ -48,7 +47,10 @@ from games.filters import (
     PlayEventFilter,
     PurchaseFilter,
     SessionFilter,
+    parse_device_filter,
     parse_game_filter,
+    parse_platform_filter,
+    parse_playevent_filter,
     parse_purchase_filter,
     parse_session_filter,
 )
@@ -1500,65 +1502,89 @@ class TestFilterErrorBoundary:
         result.to_q()  # does not raise
 
 
-@contextlib.contextmanager
-def _capture_games_logger(caplog):
-    """Wire caplog to the ``games`` logger, which sets ``propagate=False`` in
-    settings — so caplog's root handler never sees its records. Attach caplog's
-    handler directly for the duration of the block."""
-    games_logger = logging.getLogger("games")
-    games_logger.addHandler(caplog.handler)
-    caplog.set_level(logging.WARNING, logger="games")
-    try:
-        yield
-    finally:
-        games_logger.removeHandler(caplog.handler)
-
-
 class TestFilterErrorLogging:
     """Issue #203: ``apply_structured_filter`` must log a server-side warning
     (entity/user/path/exc) when it drops an invalid ``?filter=``, so operators
     can spot DoS-probing — without changing the fail-open toast/None UX."""
 
-    def _request(self):
+    def _request(self, path="/game/"):
         from django.contrib.auth.models import AnonymousUser
         from django.contrib.messages.storage.cookie import CookieStorage
         from django.test import RequestFactory
 
-        request = RequestFactory().get("/game/")
+        request = RequestFactory().get(path)
         request.user = AnonymousUser()
         # apply_structured_filter queues messages.warning, which needs storage.
         # CookieStorage needs no session middleware (FallbackStorage would).
         setattr(request, "_messages", CookieStorage(request))
         return request
 
-    def test_invalid_filter_logs_warning_and_fails_open(self, caplog):
+    def test_invalid_filter_logs_warning_and_fails_open(self, capture_games_logger):
         from games.views.filtering import apply_structured_filter
 
         request = self._request()
         bad = json.dumps({"name": {"modifier": "BOGUS", "value": "x"}})
-        with _capture_games_logger(caplog):
+        with capture_games_logger() as caplog:
             result = apply_structured_filter(request, parse_game_filter, bad)
 
         assert result is None  # fail-open unchanged
-        records = [r for r in caplog.records if r.name == "games"]
+        records = [record for record in caplog.records if record.name == "games"]
+        # Assert each interpolated field by its labelled token so a swapped or
+        # dropped positional arg (entity/user/path/exc) is caught, not just the
+        # message prefix.
         assert any(
-            r.levelno == logging.WARNING
-            and "rejected invalid filter" in r.getMessage()
-            and "entity=game" in r.getMessage()
-            and "/game/" in r.getMessage()
-            for r in records
+            record.levelno == logging.WARNING
+            and "rejected invalid filter" in record.getMessage()
+            and "entity=game" in record.getMessage()
+            and "user=AnonymousUser" in record.getMessage()
+            and "path=/game/" in record.getMessage()
+            and "Unknown filter modifier" in record.getMessage()  # the exc detail
+            for record in records
         )
 
-    def test_valid_filter_logs_nothing(self, caplog):
+    @pytest.mark.parametrize(
+        "parse, expected_entity",
+        [
+            (parse_game_filter, "game"),
+            (parse_session_filter, "session"),
+            (parse_purchase_filter, "purchase"),
+            (parse_device_filter, "device"),
+            (parse_platform_filter, "platform"),
+            (parse_playevent_filter, "playevent"),
+        ],
+    )
+    def test_entity_label_derived_for_every_parser(
+        self, parse, expected_entity, capture_games_logger
+    ):
+        """The log line's ``entity=`` token is derived from ``parse.__name__``;
+        verify the derivation for all six ``parse_*_filter`` callers, not just
+        ``game`` — a parser renamed off-convention would silently mislabel."""
+        from games.views.filtering import apply_structured_filter
+
+        request = self._request()
+        # Malformed JSON raises FilterError in every parser regardless of which
+        # fields that entity's filter declares, so the same input exercises all
+        # six derivation cases.
+        bad = "{not json"
+        with capture_games_logger() as caplog:
+            result = apply_structured_filter(request, parse, bad)
+
+        assert result is None
+        records = [record for record in caplog.records if record.name == "games"]
+        assert any(
+            f"entity={expected_entity}" in record.getMessage() for record in records
+        )
+
+    def test_valid_filter_logs_nothing(self, capture_games_logger):
         from games.views.filtering import apply_structured_filter
 
         request = self._request()
         good = json.dumps({"name": {"modifier": "INCLUDES", "value": "halo"}})
-        with _capture_games_logger(caplog):
+        with capture_games_logger() as caplog:
             result = apply_structured_filter(request, parse_game_filter, good)
 
         assert result is not None
-        assert not [r for r in caplog.records if r.name == "games"]
+        assert not [record for record in caplog.records if record.name == "games"]
 
 
 def _nest_relation(levels: int) -> dict:


### PR DESCRIPTION
Closes #203.

## Problem

The `?filter=` parse boundary is documented as **attacker-controllable** (`games/views/filtering.py` docstring), yet both rejection paths failed silently server-side:

- `apply_structured_filter` (`games/views/filtering.py`) emitted only a per-request `messages.warning` toast — nothing logged.
- `list_sessions_api` (`games/api.py`) raised a 400 with no log line.

A DoS-probing pattern (repeated deep/cyclic/invalid `?filter=`) was invisible to operators — no signal distinguished a fat-fingered hand-edited URL from someone hammering the parse path.

## Change

Log every rejected `FilterError` at `warning` on the `games` logger with context — **entity/mode, user, request path, exception message** — keeping the user-facing toast/400 **unchanged**.

- View boundary: entity derived from the `parse` callable's name (`parse_game_filter` → `game`, …), so **zero call-site churn**.
- API boundary: `entity=session` (the sole API `?filter=` site).

Mirrors the existing `logging.getLogger("games")` pattern in `games/signals.py` / `games/tasks.py`; the `games` logger already routes to console at INFO.

## Tests

Cover both boundaries. Since the `games` logger sets `propagate=False`, the tests attach `caplog`'s handler to it directly rather than relying on root propagation.

## Verification

`make check` green — lint + mypy + ts-check + 1162 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)