### PR TITLE
fix(filters): harden FilterPreset endpoints — validation, XSS, IDOR, CSRF (#206)

### DIFF
--- a/games/migrations/0021_filterpreset_user.py
+++ b/games/migrations/0021_filterpreset_user.py
@@ -1,0 +1,26 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("games", "0020_remove_purchase_related_purchase_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="filterpreset",
+            name="user",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="filter_presets",
+                to=settings.AUTH_USER_MODEL,
+            ),
+            # Non-null with no default is safe: the FilterPreset table has no rows
+            # (feature still in-dev). preserve_default=False keeps the field
+            # definition free of a phantom default.
+            preserve_default=False,
+        ),
+    ]

--- a/games/models.py
+++ b/games/models.py
@@ -505,6 +505,11 @@ class FilterPreset(models.Model):
         ("platforms", "Platforms"),
     ]
 
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="filter_presets",
+    )
     name = models.CharField(max_length=255)
     mode = models.CharField(max_length=50, choices=MODE_CHOICES, default="games")
     find_filter = models.JSONField(default=dict, blank=True)

--- a/games/urls.py
+++ b/games/urls.py
@@ -165,7 +165,7 @@ urlpatterns = [
     path("filter/presets/list", filter_presets.list_presets, name="list_presets"),
     path("filter/presets/save", filter_presets.save_preset, name="save_preset"),
     path(
-        "filter/presets/<int:preset_id>/delete",
+        "filter/presets/<int:preset_id>",
         filter_presets.delete_preset,
         name="delete_preset",
     ),

--- a/games/views/filter_presets.py
+++ b/games/views/filter_presets.py
@@ -104,10 +104,25 @@ def save_preset(request: HttpRequest) -> HttpResponse:
             )
             messages.error(request, f"Invalid filter: {exc}")
             return HttpResponse(status=400)
-        # parse() returns None for empty/null/non-object JSON; store {} then so a
-        # scalar/null is never persisted into the dict-typed field. After a
-        # successful parse(), json.loads cannot raise (parse() already loaded it).
-        object_filter = json.loads(filter_json_str) if parsed is not None else {}
+        if parsed is not None:
+            # A non-None parse means the payload was a filter object; re-loading
+            # it cannot raise (parse() already loaded + validated the JSON).
+            object_filter = json.loads(filter_json_str)
+        else:
+            # parse() returns None for any non-object JSON. `null` legitimately
+            # means "no filter" -> {}. A scalar/array is a malformed payload, not
+            # an empty filter: reject it like bad JSON rather than silently saving
+            # a match-everything preset behind a success toast (issue #206).
+            if json.loads(filter_json_str) is not None:
+                logger.warning(
+                    "rejected preset save (mode=%s, user=%s, path=%s): "
+                    "filter is not an object",
+                    mode,
+                    request.user,
+                    request.path,
+                )
+                messages.error(request, "Invalid filter: expected a filter object.")
+                return HttpResponse(status=400)
 
     FilterPreset.objects.create(
         name=name,

--- a/games/views/filter_presets.py
+++ b/games/views/filter_presets.py
@@ -1,6 +1,7 @@
 """Views for managing saved filter presets (FilterPreset model)."""
 
 import json
+import logging
 from urllib.parse import quote
 
 from django.contrib import messages
@@ -9,7 +10,29 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 
+from common.criteria import FilterError
+from games.filters import (
+    parse_device_filter,
+    parse_game_filter,
+    parse_platform_filter,
+    parse_playevent_filter,
+    parse_purchase_filter,
+    parse_session_filter,
+)
 from games.models import FilterPreset
+
+logger = logging.getLogger("games")
+
+# Maps a FilterPreset.mode to the parser that validates that mode's filter JSON.
+# Keys must stay in sync with FilterPreset.MODE_CHOICES (games/models.py).
+MODE_PARSERS = {
+    "games": parse_game_filter,
+    "sessions": parse_session_filter,
+    "purchases": parse_purchase_filter,
+    "playevents": parse_playevent_filter,
+    "devices": parse_device_filter,
+    "platforms": parse_platform_filter,
+}
 
 
 @login_required
@@ -56,12 +79,35 @@ def save_preset(request: HttpRequest) -> HttpResponse:
         messages.error(request, "Preset name is required.")
         return HttpResponse(status=400)
 
+    parse = MODE_PARSERS.get(mode)
+    if parse is None:
+        logger.warning(
+            "rejected preset save (user=%s, path=%s): unknown mode %r",
+            request.user,
+            request.path,
+            mode,
+        )
+        messages.error(request, f"Unknown preset mode '{mode}'.")
+        return HttpResponse(status=400)
+
     object_filter: dict = {}
     if filter_json_str:
         try:
-            object_filter = json.loads(filter_json_str)
-        except json.JSONDecodeError:
-            pass
+            parsed = parse(filter_json_str)  # raises FilterError on bad JSON/semantics
+        except FilterError as exc:
+            logger.warning(
+                "rejected preset save (mode=%s, user=%s, path=%s): %s",
+                mode,
+                request.user,
+                request.path,
+                exc,
+            )
+            messages.error(request, f"Invalid filter: {exc}")
+            return HttpResponse(status=400)
+        # parse() returns None for empty/null/non-object JSON; store {} then so a
+        # scalar/null is never persisted into the dict-typed field. After a
+        # successful parse(), json.loads cannot raise (parse() already loaded it).
+        object_filter = json.loads(filter_json_str) if parsed is not None else {}
 
     FilterPreset.objects.create(
         name=name,

--- a/games/views/filter_presets.py
+++ b/games/views/filter_presets.py
@@ -2,14 +2,18 @@
 
 import json
 import logging
+from typing import cast
 from urllib.parse import quote
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
+from django.views.decorators.http import require_http_methods
 
+from common.components import A, Li, Node, Span, Ul
 from common.criteria import FilterError
 from games.filters import (
     parse_device_filter,
@@ -35,34 +39,53 @@ MODE_PARSERS = {
 }
 
 
+ITEM_CLASS = (
+    "flex justify-between items-center px-4 py-2 text-sm "
+    "text-heading hover:bg-neutral-secondary-medium"
+)
+DELETE_CLASS = "text-red-500 hover:text-red-700 cursor-pointer ml-4"
+EMPTY_CLASS = "px-4 py-2 text-sm text-body italic"
+
+
 @login_required
 def list_presets(request: HttpRequest) -> HttpResponse:
-    """Return a preset dropdown as an HTML fragment."""
+    """Return the current user's preset dropdown as an HTML fragment."""
     mode = request.GET.get("mode", "games")
-    presets = FilterPreset.objects.filter(mode=mode).order_by("name")
+    # `mode` is interpolated into reverse(f"games:list_{mode}") below; an unknown
+    # value would raise NoReverseMatch (500). Reject it up front (mirrors
+    # save_preset). MODE_PARSERS keys == FilterPreset.MODE_CHOICES (parity-tested).
+    if mode not in MODE_PARSERS:
+        return HttpResponse(status=400)
 
-    items: list[str] = []
+    # @login_required guarantees an authenticated User (never AnonymousUser).
+    user = cast(User, request.user)
+    presets = FilterPreset.objects.filter(mode=mode, user=user).order_by("name")
+
+    # Built with the component node layer (not f-strings) so user-controlled
+    # preset.name is auto-escaped — the string child and every attribute value
+    # pass through escape() (fixes the stored-XSS in the old raw-HTML build).
+    items: list[Node] = []
     for preset in presets:
         filter_json = json.dumps(preset.object_filter) if preset.object_filter else ""
         list_url = reverse(f"games:list_{mode}")
         delete_url = reverse("games:delete_preset", args=[preset.id])
-
         items.append(
-            f"<li>"
-            f'<a href="{list_url}?filter={quote(filter_json)}" '
-            f'class="flex justify-between items-center px-4 py-2 text-sm '
-            f'text-heading hover:bg-neutral-secondary-medium">'
-            f"<span>{preset.name}</span>"
-            f'<span class="text-red-500 hover:text-red-700 cursor-pointer ml-4" '
-            f'data-delete-preset="{preset.id}" '
-            f'href="{delete_url}">x</span>'
-            f"</a></li>"
+            Li()[
+                A(href=f"{list_url}?filter={quote(filter_json)}", class_=ITEM_CLASS)[
+                    Span()[preset.name],
+                    Span(
+                        class_=DELETE_CLASS,
+                        data_delete_preset=str(preset.id),
+                        href=delete_url,
+                    )["x"],
+                ]
+            ]
         )
 
     if not items:
-        items = ['<li class="px-4 py-2 text-sm text-body italic">No saved presets</li>']
+        items = [Li(class_=EMPTY_CLASS)["No saved presets"]]
 
-    return HttpResponse(f'<ul class="py-1">{"".join(items)}</ul>')
+    return HttpResponse(Ul(class_="py-1")[items])
 
 
 @login_required
@@ -125,6 +148,7 @@ def save_preset(request: HttpRequest) -> HttpResponse:
                 return HttpResponse(status=400)
 
     FilterPreset.objects.create(
+        user=cast(User, request.user),
         name=name,
         mode=mode,
         object_filter=object_filter,
@@ -134,9 +158,16 @@ def save_preset(request: HttpRequest) -> HttpResponse:
 
 
 @login_required
+@require_http_methods(["DELETE"])
 def delete_preset(request: HttpRequest, preset_id: int) -> HttpResponse:
-    """Delete a saved filter preset."""
-    preset = get_object_or_404(FilterPreset, id=preset_id)
+    """Delete one of the current user's filter presets.
+
+    DELETE-only: a destructive action must not be reachable by GET, or a
+    cross-site `<img src=.../>` would delete the victim's preset (CSRF only
+    guards unsafe methods). Scoped to request.user so it cannot touch another
+    user's preset (404 instead).
+    """
+    preset = get_object_or_404(FilterPreset, id=preset_id, user=request.user)
     name = preset.name
     preset.delete()
     messages.success(request, f'Preset "{name}" deleted.')
@@ -145,8 +176,8 @@ def delete_preset(request: HttpRequest, preset_id: int) -> HttpResponse:
 
 @login_required
 def load_preset(request: HttpRequest, preset_id: int) -> HttpResponse:
-    """Load a preset and redirect to the appropriate list view."""
-    preset = get_object_or_404(FilterPreset, id=preset_id)
+    """Load one of the current user's presets and redirect to its list view."""
+    preset = get_object_or_404(FilterPreset, id=preset_id, user=request.user)
     filter_json = json.dumps(preset.object_filter) if preset.object_filter else ""
     return redirect(
         f"{reverse(f'games:list_{preset.mode}')}?filter={quote(filter_json)}"

--- a/games/views/filter_presets.py
+++ b/games/views/filter_presets.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections.abc import Callable
 from typing import cast
 from urllib.parse import quote
 
@@ -14,7 +15,7 @@ from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 
 from common.components import A, Li, Node, Span, Ul
-from common.criteria import FilterError
+from common.criteria import FilterError, OperatorFilter
 from games.filters import (
     parse_device_filter,
     parse_game_filter,
@@ -27,9 +28,12 @@ from games.models import FilterPreset
 
 logger = logging.getLogger("games")
 
+# Validates a mode's ``?filter=`` JSON, raising FilterError or returning None.
+type FilterParser = Callable[[str], OperatorFilter | None]
+
 # Maps a FilterPreset.mode to the parser that validates that mode's filter JSON.
 # Keys must stay in sync with FilterPreset.MODE_CHOICES (games/models.py).
-MODE_PARSERS = {
+MODE_PARSERS: dict[str, FilterParser] = {
     "games": parse_game_filter,
     "sessions": parse_session_filter,
     "purchases": parse_purchase_filter,

--- a/tests/test_filter_presets.py
+++ b/tests/test_filter_presets.py
@@ -81,6 +81,29 @@ def test_semantically_invalid_filter_rejected(auth_client, capture_games_logger)
         for record in caplog.records
         if record.name == "games"
     )
+    assert any("Invalid filter" in message for message in _messages(response))
+
+
+def test_null_filter_creates_empty_preset(auth_client):
+    # JSON `null` legitimately means "no filter" -> empty object_filter + 201.
+    response = _save(auth_client, name="Null", mode="games", filter="null")
+    assert response.status_code == 201
+    assert FilterPreset.objects.get().object_filter == {}
+
+
+def test_non_object_filter_rejected(auth_client, capture_games_logger):
+    # Valid JSON that is not a filter object (scalar/array) is a malformed
+    # payload, not "no filter": reject it rather than silently saving {} + 201.
+    for payload in ("[1, 2]", "5"):
+        with capture_games_logger() as caplog:
+            response = _save(auth_client, name="X", mode="games", filter=payload)
+        assert response.status_code == 400, payload
+        assert not FilterPreset.objects.exists()
+        assert any(
+            "not an object" in record.getMessage()
+            for record in caplog.records
+            if record.name == "games"
+        ), payload
 
 
 def test_unknown_mode_rejected(auth_client, capture_games_logger):
@@ -95,6 +118,27 @@ def test_unknown_mode_rejected(auth_client, capture_games_logger):
         for record in caplog.records
         if record.name == "games"
     )
+
+
+def test_valid_non_games_mode_round_trips(auth_client):
+    # A non-`games` mode must resolve to its parser and store the filter — guards
+    # against a missing/mistyped MODE_PARSERS key rejecting a legitimate mode.
+    sessions_filter = json.dumps({"note": {"modifier": "INCLUDES", "value": "boss"}})
+    response = _save(
+        auth_client, name="Sessions", mode="sessions", filter=sessions_filter
+    )
+    assert response.status_code == 201
+    preset = FilterPreset.objects.get()
+    assert preset.mode == "sessions"
+    assert preset.object_filter == {"note": {"modifier": "INCLUDES", "value": "boss"}}
+
+
+def test_mode_parsers_cover_every_mode_choice():
+    # MODE_PARSERS is the source of truth for which modes save_preset accepts;
+    # it must stay in sync with the model's choices or a valid mode 400s.
+    from games.views.filter_presets import MODE_PARSERS
+
+    assert set(MODE_PARSERS) == {value for value, _label in FilterPreset.MODE_CHOICES}
 
 
 def test_missing_name_rejected(auth_client):

--- a/tests/test_filter_presets.py
+++ b/tests/test_filter_presets.py
@@ -1,6 +1,13 @@
-"""Issue #206: save_preset must reject malformed/invalid filter JSON and unknown
-modes with a server-side warning log + user-facing error + non-201, instead of
-silently storing a match-everything filter behind a success toast."""
+"""Tests for the FilterPreset endpoints (games/views/filter_presets.py):
+
+- #206: save_preset rejects malformed/invalid filter JSON + unknown modes with a
+  server-side warning log + user-facing error + non-201 (no silent match-everything).
+- #209: list_presets renders via the component layer, escaping user-controlled
+  preset.name (stored-XSS fix).
+- list_presets validates `mode` (no NoReverseMatch 500).
+- Per-user ownership: presets are scoped to their creator (no IDOR across users).
+- delete_preset is DELETE-only (no CSRF-via-GET self-deletion).
+"""
 
 import json
 import logging
@@ -25,6 +32,18 @@ def auth_client(user):
     return client
 
 
+@pytest.fixture
+def second_user(db):
+    return get_user_model().objects.create_user(username="other", password="pw")
+
+
+@pytest.fixture
+def second_auth_client(second_user):
+    client = Client()
+    client.force_login(second_user)
+    return client
+
+
 def _save(client, **data):
     return client.post(reverse("games:save_preset"), data)
 
@@ -34,7 +53,7 @@ def _messages(response):
 
 
 def test_valid_filter_creates_preset_and_logs_nothing(
-    auth_client, capture_games_logger
+    user, auth_client, capture_games_logger
 ):
     valid = json.dumps({"name": {"modifier": "INCLUDES", "value": "halo"}})
     with capture_games_logger() as caplog:
@@ -43,6 +62,7 @@ def test_valid_filter_creates_preset_and_logs_nothing(
     assert response.status_code == 201
     preset = FilterPreset.objects.get()
     assert preset.object_filter == {"name": {"modifier": "INCLUDES", "value": "halo"}}
+    assert preset.user == user  # owner is set
     assert not [record for record in caplog.records if record.name == "games"]
 
 
@@ -145,3 +165,91 @@ def test_missing_name_rejected(auth_client):
     response = _save(auth_client, name="", mode="games", filter="")
     assert response.status_code == 400
     assert not FilterPreset.objects.exists()
+
+
+# --- list_presets: escaping, mode validation ---------------------------------
+
+
+def _list(client, mode="games"):
+    return client.get(reverse("games:list_presets"), {"mode": mode})
+
+
+def test_list_presets_escapes_preset_name(auth_client):
+    # #209: a malicious name must be HTML-escaped, not rendered as live markup.
+    _save(
+        auth_client,
+        name="<img src=x onerror=alert(1)>",
+        mode="games",
+        filter="",
+    )
+    body = _list(auth_client).content
+    assert b"<img src=x onerror" not in body  # not raw (would execute)
+    assert b"&lt;img" in body  # escaped (proves escape, not strip)
+
+
+def test_list_presets_escapes_filter_in_href(auth_client):
+    # The object_filter is serialized into the row's href; a `"` in it must not
+    # break out of the attribute. It is quote()-encoded (-> %22), so no raw `"`
+    # from the filter appears unencoded in the link.
+    quoted = json.dumps({"name": {"modifier": "INCLUDES", "value": 'a"b'}})
+    _save(auth_client, name="Quote", mode="games", filter=quoted)
+    body = _list(auth_client).content.decode()
+    href = body[body.index("?filter=") : body.index('"', body.index("?filter="))]
+    assert '"' not in href
+    assert "%22" in href
+
+
+def test_list_presets_rejects_unknown_mode(auth_client):
+    # Unknown mode used to 500 via reverse(f"games:list_{mode}"); now a clean 400.
+    assert _list(auth_client, mode="bogus").status_code == 400
+
+
+def test_list_presets_empty_state(auth_client):
+    assert b"No saved presets" in _list(auth_client).content
+
+
+# --- per-user ownership (IDOR) + delete method guard -------------------------
+
+
+def _make_preset(client, name="P"):
+    valid = json.dumps({"name": {"modifier": "INCLUDES", "value": "x"}})
+    _save(client, name=name, mode="games", filter=valid)
+    return FilterPreset.objects.get(name=name)
+
+
+def test_list_presets_only_returns_own(auth_client, second_auth_client):
+    _make_preset(auth_client, name="MineAlone")
+    assert b"MineAlone" not in _list(second_auth_client).content
+
+
+def test_delete_preset_requires_ownership(auth_client, second_auth_client):
+    preset = _make_preset(auth_client)
+    response = second_auth_client.delete(
+        reverse("games:delete_preset", args=[preset.id])
+    )
+    assert response.status_code == 404
+    assert FilterPreset.objects.filter(id=preset.id).exists()  # not deleted
+
+
+def test_load_preset_requires_ownership(auth_client, second_auth_client):
+    preset = _make_preset(auth_client)
+    response = second_auth_client.get(reverse("games:load_preset", args=[preset.id]))
+    assert response.status_code == 404
+
+
+def test_owner_can_delete_via_delete_method(auth_client):
+    preset = _make_preset(auth_client)
+    response = auth_client.delete(reverse("games:delete_preset", args=[preset.id]))
+    assert response.status_code == 200
+    assert not FilterPreset.objects.filter(id=preset.id).exists()
+
+
+@pytest.mark.parametrize("method", ["get", "post"])
+def test_delete_preset_rejects_non_delete_methods(auth_client, method):
+    # DELETE-only: a GET (e.g. <img src=.../>) must not delete (CSRF-via-GET).
+    preset = _make_preset(auth_client)
+    response = getattr(auth_client, method)(
+        reverse("games:delete_preset", args=[preset.id])
+    )
+    assert response.status_code == 405
+    assert FilterPreset.objects.filter(id=preset.id).exists()

--- a/tests/test_filter_presets.py
+++ b/tests/test_filter_presets.py
@@ -208,6 +208,21 @@ def test_list_presets_empty_state(auth_client):
     assert b"No saved presets" in _list(auth_client).content
 
 
+def test_list_presets_renders_row_wiring(auth_client):
+    # The row must carry the JS delete contract (data-delete-preset="{id}") and a
+    # ?filter= link, both tied to the preset — rename/drop would break the client.
+    preset = _make_preset(auth_client, name="Wired")
+    body = _list(auth_client).content.decode()
+    assert f'data-delete-preset="{preset.id}"' in body
+    assert "?filter=" in body
+    assert "Wired" in body
+
+
+def test_save_preset_rejects_non_post(auth_client):
+    response = auth_client.get(reverse("games:save_preset"))
+    assert response.status_code == 405
+
+
 # --- per-user ownership (IDOR) + delete method guard -------------------------
 
 
@@ -219,7 +234,11 @@ def _make_preset(client, name="P"):
 
 def test_list_presets_only_returns_own(auth_client, second_auth_client):
     _make_preset(auth_client, name="MineAlone")
-    assert b"MineAlone" not in _list(second_auth_client).content
+    _make_preset(second_auth_client, name="TheirOwn")
+    response = _list(second_auth_client)
+    assert response.status_code == 200
+    assert b"TheirOwn" in response.content  # positive anchor: B sees own preset
+    assert b"MineAlone" not in response.content  # but not A's
 
 
 def test_delete_preset_requires_ownership(auth_client, second_auth_client):
@@ -235,6 +254,15 @@ def test_load_preset_requires_ownership(auth_client, second_auth_client):
     preset = _make_preset(auth_client)
     response = second_auth_client.get(reverse("games:load_preset", args=[preset.id]))
     assert response.status_code == 404
+
+
+def test_load_preset_owner_redirects_to_list(auth_client):
+    preset = _make_preset(auth_client, name="Load")
+    response = auth_client.get(reverse("games:load_preset", args=[preset.id]))
+    assert response.status_code == 302
+    location = response.headers["Location"]
+    assert location.startswith(reverse("games:list_games"))
+    assert "?filter=" in location
 
 
 def test_owner_can_delete_via_delete_method(auth_client):

--- a/tests/test_filter_presets.py
+++ b/tests/test_filter_presets.py
@@ -1,0 +1,103 @@
+"""Issue #206: save_preset must reject malformed/invalid filter JSON and unknown
+modes with a server-side warning log + user-facing error + non-201, instead of
+silently storing a match-everything filter behind a success toast."""
+
+import json
+import logging
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+
+from games.models import FilterPreset
+
+
+@pytest.fixture
+def user(db):
+    return get_user_model().objects.create_user(username="tester", password="pw")
+
+
+@pytest.fixture
+def auth_client(user):
+    client = Client()
+    client.force_login(user)
+    return client
+
+
+def _save(client, **data):
+    return client.post(reverse("games:save_preset"), data)
+
+
+def _messages(response):
+    return [str(message) for message in response.wsgi_request._messages]
+
+
+def test_valid_filter_creates_preset_and_logs_nothing(
+    auth_client, capture_games_logger
+):
+    valid = json.dumps({"name": {"modifier": "INCLUDES", "value": "halo"}})
+    with capture_games_logger() as caplog:
+        response = _save(auth_client, name="My preset", mode="games", filter=valid)
+
+    assert response.status_code == 201
+    preset = FilterPreset.objects.get()
+    assert preset.object_filter == {"name": {"modifier": "INCLUDES", "value": "halo"}}
+    assert not [record for record in caplog.records if record.name == "games"]
+
+
+def test_empty_filter_creates_preset_with_empty_object_filter(auth_client):
+    response = _save(auth_client, name="Empty", mode="games", filter="")
+    assert response.status_code == 201
+    assert FilterPreset.objects.get().object_filter == {}
+
+
+def test_malformed_json_rejected_logged_and_no_row(auth_client, capture_games_logger):
+    with capture_games_logger() as caplog:
+        response = _save(auth_client, name="Bad", mode="games", filter="{not json")
+
+    assert response.status_code == 400
+    assert not FilterPreset.objects.exists()
+    records = [record for record in caplog.records if record.name == "games"]
+    assert any(
+        record.levelno == logging.WARNING
+        and "rejected preset save" in record.getMessage()
+        and "mode=games" in record.getMessage()
+        for record in records
+    )
+    assert any("Invalid filter" in message for message in _messages(response))
+
+
+def test_semantically_invalid_filter_rejected(auth_client, capture_games_logger):
+    # Parseable JSON, build-time-invalid filter (BETWEEN without value2).
+    bad = json.dumps({"year_released": {"modifier": "BETWEEN", "value": 2000}})
+    with capture_games_logger() as caplog:
+        response = _save(auth_client, name="Bad", mode="games", filter=bad)
+
+    assert response.status_code == 400
+    assert not FilterPreset.objects.exists()
+    assert any(
+        "rejected preset save" in record.getMessage()
+        for record in caplog.records
+        if record.name == "games"
+    )
+
+
+def test_unknown_mode_rejected(auth_client, capture_games_logger):
+    valid = json.dumps({"name": {"modifier": "INCLUDES", "value": "halo"}})
+    with capture_games_logger() as caplog:
+        response = _save(auth_client, name="X", mode="bogus", filter=valid)
+
+    assert response.status_code == 400
+    assert not FilterPreset.objects.exists()
+    assert any(
+        "unknown mode" in record.getMessage()
+        for record in caplog.records
+        if record.name == "games"
+    )
+
+
+def test_missing_name_rejected(auth_client):
+    response = _save(auth_client, name="", mode="games", filter="")
+    assert response.status_code == 400
+    assert not FilterPreset.objects.exists()

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -426,7 +426,7 @@ function setupPresetDeleteHandlers(container: HTMLElement): void {
       if (!deleteUrl) return;
       if (!confirm("Delete this preset?")) return;
       fetch(deleteUrl, {
-        method: "POST",
+        method: "DELETE",
         credentials: "same-origin",
         headers: { "X-CSRFToken": getCsrfToken() },
       })

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -425,12 +425,17 @@ function setupPresetDeleteHandlers(container: HTMLElement): void {
       const deleteUrl = link.getAttribute("href");
       if (!deleteUrl) return;
       if (!confirm("Delete this preset?")) return;
-      fetch(deleteUrl, {
-        method: "DELETE",
-        credentials: "same-origin",
-        headers: { "X-CSRFToken": getCsrfToken() },
-      })
-        .then(() => {
+      // fetchWithHtmxTriggers so the server's delete success/error toast surfaces;
+      // only remove the row when the server actually deleted it (response.ok),
+      // otherwise a 404/405/500 would desync the UI from the DB.
+      window
+        .fetchWithHtmxTriggers(deleteUrl, {
+          method: "DELETE",
+          credentials: "same-origin",
+          headers: { "X-CSRFToken": getCsrfToken() },
+        })
+        .then((response) => {
+          if (!response.ok) return; // server rejected; its toast already fired
           const listItem = link.closest("li");
           if (listItem) listItem.remove();
           const list = container.querySelector("ul");
@@ -440,7 +445,9 @@ function setupPresetDeleteHandlers(container: HTMLElement): void {
           }
         })
         .catch((error) => {
+          // Transport failure only (no Response, no HX-Trigger) — surface a toast.
           console.error("Delete failed:", error);
+          window.toast("Failed to delete preset.", "error");
         });
     });
   });

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -501,15 +501,19 @@ function savePreset(
   body.append("mode", presetMode());
   body.append("filter", JSON.stringify(filterObject));
 
-  fetch(presetSaveUrl, {
-    method: "POST",
-    credentials: "same-origin",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      "X-CSRFToken": getCsrfToken(),
-    },
-    body: body.toString(),
-  })
+  // fetchWithHtmxTriggers (not plain fetch) so the server's messages — the
+  // error toast on a rejected filter/mode, and the success toast — surface via
+  // the HX-Trigger header the toast middleware sets.
+  window
+    .fetchWithHtmxTriggers(presetSaveUrl, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-CSRFToken": getCsrfToken(),
+      },
+      body: body.toString(),
+    })
     .then((response) => {
       if (!response.ok) throw new Error("Save failed");
       if (input) {

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -501,9 +501,10 @@ function savePreset(
   body.append("mode", presetMode());
   body.append("filter", JSON.stringify(filterObject));
 
-  // fetchWithHtmxTriggers (not plain fetch) so the server's messages — the
-  // error toast on a rejected filter/mode, and the success toast — surface via
-  // the HX-Trigger header the toast middleware sets.
+  // fetchWithHtmxTriggers (not plain fetch) so the server's messages — the error
+  // toast on a rejected filter/mode, and the success toast — surface via the
+  // HX-Trigger header the toast middleware sets, for any response that carries a
+  // Django message.
   window
     .fetchWithHtmxTriggers(presetSaveUrl, {
       method: "POST",
@@ -515,7 +516,9 @@ function savePreset(
       body: body.toString(),
     })
     .then((response) => {
-      if (!response.ok) throw new Error("Save failed");
+      // A non-ok response already fired its error toast via the wrapper; leave
+      // the confirm-save UI in place so the user can correct and retry.
+      if (!response.ok) return;
       if (input) {
         input.value = "";
         input.classList.add("hidden");
@@ -528,7 +531,10 @@ function savePreset(
       loadPresets(root, presetListUrl);
     })
     .catch((error) => {
+      // Reached only on a transport failure (no Response, so no HX-Trigger and no
+      // toast fired). Surface one here so the failure is never invisible.
       console.error("Failed to save preset:", error);
+      window.toast("Failed to save preset.", "error");
     });
 }
 


### PR DESCRIPTION
Closes #206, #209, #210, #211.

Started as the #206 fix (save_preset validation); two rounds of adversarial review surfaced a cluster of related defects on the same `@login_required`, attacker-reachable boundary (`games/views/filter_presets.py`). All fixed together.

## Defects fixed

| # | Severity | Issue |
|---|----------|-------|
| #206 | — | `save_preset` swallowed malformed/invalid filter JSON + unknown modes, storing a silent match-everything preset behind a success toast. Now: structured validation (mode's `parse_*_filter`), `warning` log, error toast, non-201. Non-object JSON (scalar/array) rejected; `null`/empty → `{}`. |
| #209 | XSS | `list_presets` f-string-interpolated user-controlled `preset.name` into raw HTML (stored XSS). Rebuilt with `common.components` node builders — string children + attribute values auto-escaped. DOM/behavior unchanged. |
| #210 | IDOR | `FilterPreset` had no owner; any user could list/load/delete others' presets. Added non-null `user` FK + migration; scoped all four views to `request.user` (404, no disclosure). |
| #211 | CSRF | `delete_preset` had no method guard → cross-site `<img src=.../>` GET deleted the victim's preset. Made `DELETE`-only (`@require_http_methods`), client `fetch` → `DELETE`, dropped redundant `/delete` URL suffix. |
| — | 500 | `list_presets` 500'd (`NoReverseMatch`) on `?mode=bogus`. Now validated against `MODE_PARSERS` → 400. |

## Frontend

`ts/elements/filter-bar.ts`: `savePreset` uses `fetchWithHtmxTriggers` so server error/success toasts surface (transport failures toast via `.catch`); delete `fetch` method `POST` → `DELETE`.

## Migration

`0021_filterpreset_user.py` — non-null `user` FK. Table is empty in-dev, no backfill / no nullable phase.

## Tests

`tests/test_filter_presets.py` (new in this PR): save validation (malformed/invalid/non-object/null/empty/unknown-mode/missing-name), `MODE_PARSERS`↔`MODE_CHOICES` parity, XSS escaping (name text + filter href), mode-400, per-user isolation (list/delete/load across two users), DELETE method guard (GET/POST → 405), owner-set.

## Verification

`make migrate` + `make ts` + `make check` green — ruff + mypy + ts-check + 1188 tests.

## Review

Two adversarial review rounds (claims-vs-code, design-defects, security adequacy) folded before submit: corrected builder call-syntax, `list[Node]` annotation, attribute-sink test, non-null-FK migration strategy, DELETE-verb for CSRF, per-user isolation tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)