### PR TITLE
fix(sorting): log unknown-sort-field rejections (views + API) (#207)

### DIFF
--- a/games/api.py
+++ b/games/api.py
@@ -235,10 +235,20 @@ def list_sessions_api(request, filter: str = "", sort: str = "", page: int = 1):
         if session_filter is not None:
             sessions = sessions.filter(session_filter.to_q())
     # `sort` is read from request.GET by parse_find_filter; declared above so it
-    # appears in the OpenAPI schema. Unknown sort keys are silently ignored.
+    # appears in the OpenAPI schema. Unknown sort keys are rejected (not silently
+    # dropped) for parity with the filter rejection above — silently-wrong ordering
+    # is worse than an explicit error for an API consumer.
     sort_result = apply_sort(
         sessions, parse_find_filter(request), SESSION_SORTS, SESSION_DEFAULT_SORT
     )
+    if sort_result.unknown:
+        logger.warning(
+            "rejected unknown sort field(s) (entity=session, user=%s, path=%s): %s",
+            request.user,
+            request.path,
+            ", ".join(sort_result.unknown),
+        )
+        raise HttpError(400, f"Invalid sort: {', '.join(sort_result.unknown)}")
     paginator = Paginator(sort_result.queryset, PAGE_SIZE)
     page_obj = paginator.get_page(page)
     return {

--- a/games/api.py
+++ b/games/api.py
@@ -242,11 +242,13 @@ def list_sessions_api(request, filter: str = "", sort: str = "", page: int = 1):
         sessions, parse_find_filter(request), SESSION_SORTS, SESSION_DEFAULT_SORT
     )
     if sort_result.unknown:
+        # repr() the raw keys: parse_sort_terms only strips outer whitespace, so an
+        # embedded newline would otherwise forge log lines (CWE-117).
         logger.warning(
             "rejected unknown sort field(s) (entity=session, user=%s, path=%s): %s",
             request.user,
             request.path,
-            ", ".join(sort_result.unknown),
+            ", ".join(repr(key) for key in sort_result.unknown),
         )
         raise HttpError(400, f"Invalid sort: {', '.join(sort_result.unknown)}")
     paginator = Paginator(sort_result.queryset, PAGE_SIZE)

--- a/games/views/filtering.py
+++ b/games/views/filtering.py
@@ -66,11 +66,16 @@ def warn_unknown_sort(
 ) -> None:
     """Log + toast unknown ``?sort=`` keys, mirroring ``apply_structured_filter``.
 
-    ``?sort=`` is attacker-controllable like ``?filter=``; an unknown key is
-    dropped (the queryset falls back to the trusted default sort) and a warning is
-    both logged on the ``games`` logger — so operators can spot probing — and
-    queued as a user-facing toast. ``entity`` is the singular noun
+    ``?sort=`` is attacker-controllable like ``?filter=``; each unknown key is
+    dropped and the queryset orders by whatever valid keys remain (falling back to
+    the trusted default sort only when none remain). A warning is both logged on
+    the ``games`` logger — so operators can spot probing — and queued as a
+    user-facing toast. ``entity`` is the singular noun
     (``"game"``/``"session"``/``"purchase"``), matching the filter log convention.
+
+    The keys are ``repr()``-ed in the log message: they are raw user input and
+    ``parse_sort_terms`` only strips outer whitespace, so an embedded newline would
+    otherwise forge log lines (CWE-117).
     """
     if not unknown:
         return
@@ -79,7 +84,7 @@ def warn_unknown_sort(
         entity,
         request.user,
         request.path,
-        ", ".join(unknown),
+        ", ".join(repr(key) for key in unknown),
     )
     for key in unknown:
         messages.warning(request, f"Unknown sort field '{key}' was ignored.")

--- a/games/views/filtering.py
+++ b/games/views/filtering.py
@@ -17,6 +17,7 @@ from django.contrib import messages
 from django.http import HttpRequest
 
 from common.criteria import FilterError, FilterType
+from games.sorting import SortKey
 
 logger = logging.getLogger("games")
 
@@ -58,3 +59,27 @@ def apply_structured_filter(
         )
         messages.warning(request, f"Ignored invalid filter: {exc}")
         return None
+
+
+def warn_unknown_sort(
+    request: HttpRequest, unknown: list[SortKey], *, entity: str
+) -> None:
+    """Log + toast unknown ``?sort=`` keys, mirroring ``apply_structured_filter``.
+
+    ``?sort=`` is attacker-controllable like ``?filter=``; an unknown key is
+    dropped (the queryset falls back to the trusted default sort) and a warning is
+    both logged on the ``games`` logger — so operators can spot probing — and
+    queued as a user-facing toast. ``entity`` is the singular noun
+    (``"game"``/``"session"``/``"purchase"``), matching the filter log convention.
+    """
+    if not unknown:
+        return
+    logger.warning(
+        "rejected unknown sort field(s) (entity=%s, user=%s, path=%s): %s",
+        entity,
+        request.user,
+        request.path,
+        ", ".join(unknown),
+    )
+    for key in unknown:
+        messages.warning(request, f"Unknown sort field '{key}' was ignored.")

--- a/games/views/game.py
+++ b/games/views/game.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 from typing import Any
 
-from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models import F, OuterRef, Q, QuerySet, Subquery, Sum
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -62,7 +61,7 @@ from games.formatting import session_time_range
 from games.forms import GameForm
 from games.models import Game, GameStatusChange, Session
 from games.sorting import GAME_DEFAULT_SORT, GAME_SORTS, apply_sort, parse_find_filter
-from games.views.filtering import apply_structured_filter
+from games.views.filtering import apply_structured_filter, warn_unknown_sort
 from games.views.general import use_custom_redirect
 from games.views.playevent import create_playevent_tabledata
 
@@ -119,8 +118,7 @@ def list_games(request: HttpRequest, search_string: str = "") -> HttpResponse:
 
     sort = apply_sort(games, parse_find_filter(request), GAME_SORTS, GAME_DEFAULT_SORT)
     games = sort.queryset
-    for key in sort.unknown:
-        messages.warning(request, f"Unknown sort field '{key}' was ignored.")
+    warn_unknown_sort(request, sort.unknown, entity="game")
 
     games, page_obj, elided_page_range = paginate(request, games)
 

--- a/games/views/purchase.py
+++ b/games/views/purchase.py
@@ -58,6 +58,7 @@ from games.sorting import (
     apply_sort,
     parse_find_filter,
 )
+from games.views.filtering import warn_unknown_sort
 from games.views.general import use_custom_redirect
 
 
@@ -163,8 +164,7 @@ def list_purchases(request: HttpRequest) -> HttpResponse:
         purchases, parse_find_filter(request), PURCHASE_SORTS, PURCHASE_DEFAULT_SORT
     )
     purchases = sort.queryset
-    for key in sort.unknown:
-        messages.warning(request, f"Unknown sort field '{key}' was ignored.")
+    warn_unknown_sort(request, sort.unknown, entity="purchase")
 
     purchases, page_obj, elided_page_range = paginate(request, purchases)
 

--- a/games/views/session.py
+++ b/games/views/session.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models import Q, QuerySet
 from django.http import HttpRequest, HttpResponse
@@ -48,6 +47,7 @@ from games.sorting import (
     apply_sort,
     parse_find_filter,
 )
+from games.views.filtering import warn_unknown_sort
 
 
 def session_row_data(session: Session, device_list, csrf_token: str) -> TableRowData:
@@ -102,8 +102,7 @@ def list_sessions(request: HttpRequest, search_string: str = "") -> HttpResponse
         sessions, parse_find_filter(request), SESSION_SORTS, SESSION_DEFAULT_SORT
     )
     sessions = sort.queryset
-    for key in sort.unknown:
-        messages.warning(request, f"Unknown sort field '{key}' was ignored.")
+    warn_unknown_sort(request, sort.unknown, entity="session")
     sessions, page_obj, elided_page_range = paginate(request, sessions)
     csrf_token = get_token(request)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -217,6 +217,42 @@ def test_session_list_malformed_filter_logged(auth_client, capture_games_logger)
     )
 
 
+def test_session_list_unknown_sort_rejected(auth_client):
+    # Issue #207: an unknown ?sort= key must 400 (parity with the filter rejection
+    # in the same handler) instead of silently returning default-sorted data.
+    _make_session()
+    response = auth_client.get("/api/session/?sort=bogusfield")
+    assert response.status_code == 400
+    assert "Invalid sort" in response.json()["detail"]
+
+
+def test_session_list_unknown_sort_logged(auth_client, capture_games_logger):
+    # Issue #207: the rejection must also leave a server-side warning, mirroring
+    # the filter path, so ?sort=<garbage> probing is visible to operators.
+    _make_session()
+    with capture_games_logger() as caplog:
+        response = auth_client.get("/api/session/?sort=bogusfield")
+
+    assert response.status_code == 400
+    records = [record for record in caplog.records if record.name == "games"]
+    assert any(
+        record.levelno == logging.WARNING
+        and "rejected unknown sort field(s)" in record.getMessage()
+        and "entity=session" in record.getMessage()
+        and "user=tester" in record.getMessage()
+        and "path=/api/session/" in record.getMessage()
+        and "bogusfield" in record.getMessage()
+        for record in records
+    )
+
+
+def test_session_list_valid_sort_still_ok(auth_client):
+    # Regression: a valid ?sort= key is unaffected by the unknown-sort rejection.
+    _make_session()
+    response = auth_client.get("/api/session/?sort=-date")
+    assert response.status_code == 200
+
+
 def _patch_session(client, session_id, body):
     return client.patch(
         f"/api/session/{session_id}",

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1587,6 +1587,56 @@ class TestFilterErrorLogging:
         assert not [record for record in caplog.records if record.name == "games"]
 
 
+class TestUnknownSortLogging:
+    """Issue #207: ``warn_unknown_sort`` must log a server-side warning
+    (entity/user/path/keys) when it drops an unknown ``?sort=`` key, mirroring the
+    #203 filter boundary — while keeping the existing per-key toast UX."""
+
+    def _request(self, path="/game/"):
+        from django.contrib.auth.models import AnonymousUser
+        from django.contrib.messages.storage.cookie import CookieStorage
+        from django.test import RequestFactory
+
+        request = RequestFactory().get(path)
+        request.user = AnonymousUser()
+        setattr(request, "_messages", CookieStorage(request))
+        return request
+
+    def test_unknown_sort_logs_warning_and_toasts(self, capture_games_logger):
+        from games.views.filtering import warn_unknown_sort
+
+        request = self._request()
+        with capture_games_logger() as caplog:
+            warn_unknown_sort(request, ["bogus", "alsobad"], entity="game")
+
+        records = [record for record in caplog.records if record.name == "games"]
+        # Assert each interpolated field by its labelled token, matching the filter
+        # test, so a swapped/dropped positional arg is caught.
+        assert any(
+            record.levelno == logging.WARNING
+            and "rejected unknown sort field(s)" in record.getMessage()
+            and "entity=game" in record.getMessage()
+            and "user=AnonymousUser" in record.getMessage()
+            and "path=/game/" in record.getMessage()
+            and "bogus" in record.getMessage()
+            and "alsobad" in record.getMessage()
+            for record in records
+        )
+        # Existing per-key toast UX is preserved (one message per unknown key).
+        messages = list(request._messages)  # type: ignore[attr-defined]
+        assert len(messages) == 2
+
+    def test_no_unknown_logs_nothing(self, capture_games_logger):
+        from games.views.filtering import warn_unknown_sort
+
+        request = self._request()
+        with capture_games_logger() as caplog:
+            warn_unknown_sort(request, [], entity="game")
+
+        assert not [record for record in caplog.records if record.name == "games"]
+        assert not list(request._messages)  # type: ignore[attr-defined]
+
+
 def _nest_relation(levels: int) -> dict:
     """Build ``levels`` deep of alternating session_filter <-> game_filter relation
     descent (the cyclic DoS vector named in issue #186). The outermost class is

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1636,6 +1636,24 @@ class TestUnknownSortLogging:
         assert not [record for record in caplog.records if record.name == "games"]
         assert not list(request._messages)  # type: ignore[attr-defined]
 
+    def test_newline_in_key_does_not_forge_log_line(self, capture_games_logger):
+        """CWE-117: ``parse_sort_terms`` only strips outer whitespace, so an
+        embedded newline reaches ``unknown`` verbatim. The log message must
+        ``repr()`` the key so the newline is escaped, not emitted raw — otherwise
+        an attacker could forge log lines via ``?sort=a%0Afake``."""
+        from games.views.filtering import warn_unknown_sort
+
+        request = self._request()
+        with capture_games_logger() as caplog:
+            warn_unknown_sort(request, ["a\nFORGED"], entity="game")
+
+        records = [record for record in caplog.records if record.name == "games"]
+        assert records
+        message = records[0].getMessage()
+        assert "\n" not in message  # the raw newline must not survive into the line
+        assert "\\n" in message  # repr escaped it
+        assert "FORGED" in message
+
 
 def _nest_relation(levels: int) -> dict:
     """Build ``levels`` deep of alternating session_filter <-> game_filter relation

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -1,5 +1,6 @@
 """Tests for the list-view sorting system (games/sorting.py)."""
 
+import logging
 import re
 from datetime import datetime
 from zoneinfo import ZoneInfo
@@ -170,11 +171,23 @@ class TestListGamesSort:
         ascending_body = ascending.content.decode()
         assert ascending_body.index("Alpha") < ascending_body.index("Beta")
 
-    def test_unknown_sort_emits_warning_message(self, logged_client, two_games):
-        response = logged_client.get(reverse("games:list_games"), {"sort": "bogus"})
+    def test_unknown_sort_emits_warning_message(
+        self, logged_client, two_games, capture_games_logger
+    ):
+        with capture_games_logger() as caplog:
+            response = logged_client.get(reverse("games:list_games"), {"sort": "bogus"})
         assert response.status_code == 200
         warnings = [str(m) for m in get_messages(response.wsgi_request)]
         assert any("bogus" in w for w in warnings)
+        # The view's own entity="game" literal is load-bearing for operator log
+        # triage but invisible in the toast/fallback behavior, so assert it here.
+        assert any(
+            record.levelno == logging.WARNING
+            and "entity=game" in record.getMessage()
+            and "bogus" in record.getMessage()
+            for record in caplog.records
+            if record.name == "games"
+        )
 
     def test_valid_sort_emits_no_warning(self, logged_client, two_games):
         response = logged_client.get(reverse("games:list_games"), {"sort": "name"})
@@ -213,10 +226,20 @@ class TestListSessionsSort:
             "Beta"
         )  # longer session first, despite earlier date
 
-    def test_unknown_sort_emits_warning(self, logged_client, two_games):
-        response = logged_client.get(reverse("games:list_sessions"), {"sort": "nope"})
+    def test_unknown_sort_emits_warning(
+        self, logged_client, two_games, capture_games_logger
+    ):
+        with capture_games_logger() as caplog:
+            response = logged_client.get(
+                reverse("games:list_sessions"), {"sort": "nope"}
+            )
         warnings = [str(m) for m in get_messages(response.wsgi_request)]
         assert any("nope" in w for w in warnings)
+        assert any(
+            "entity=session" in record.getMessage() and "nope" in record.getMessage()
+            for record in caplog.records
+            if record.name == "games"
+        )
 
 
 class TestListPurchasesSort:
@@ -264,10 +287,20 @@ class TestListPurchasesSort:
         body = response.content.decode()
         assert body.count("purchase-row-") == 2  # exactly two purchase rows
 
-    def test_unknown_sort_emits_warning(self, logged_client, two_purchases):
-        response = logged_client.get(reverse("games:list_purchases"), {"sort": "nope"})
+    def test_unknown_sort_emits_warning(
+        self, logged_client, two_purchases, capture_games_logger
+    ):
+        with capture_games_logger() as caplog:
+            response = logged_client.get(
+                reverse("games:list_purchases"), {"sort": "nope"}
+            )
         warnings = [str(m) for m in get_messages(response.wsgi_request)]
         assert any("nope" in w for w in warnings)
+        assert any(
+            "entity=purchase" in record.getMessage() and "nope" in record.getMessage()
+            for record in caplog.records
+            if record.name == "games"
+        )
 
 
 class TestDefaultOrderUnchanged:


### PR DESCRIPTION
Closes #207.

## Problem

PR #203 added server-side `warning` logging when an invalid `?filter=` is rejected, so operators can spot malformed-input / DoS-probing. The parallel **unknown-sort-field** path — which the filter boundary's own docstring says it "mirrors" — was left unlogged:

- **Views** (`game.py`, `session.py`, `purchase.py`): toasted the user but logged nothing. `?sort=<garbage>` probing invisible to operators.
- **API** (`list_sessions_api`): `sort_result.unknown` discarded entirely — `200` with silently default-sorted data. `?sort=typo` → silently-wrong ordering, strictly worse than the filter path which already `400`s.

## Change

- Add `warn_unknown_sort(request, unknown, *, entity)` to `games/views/filtering.py` (the existing attacker-controllable-list-input boundary). Logs a `WARNING` on the `games` logger (`entity`/`user`/`path`/`keys`) in the same format as the #203 filter rejection, then queues the existing per-key toast. The three list views call it instead of the inline loop.
- `games/api.py` `list_sessions_api` now logs **and** raises `HttpError(400, "Invalid sort: ...")` on an unknown sort key, for full parity with its filter rejection in the same handler.

Entity uses the singular noun (`game`/`session`/`purchase`), matching the filter log convention. No change to `games/sorting.py` — the `SortResult.unknown` channel already carried the data.

## Tests

- View-side (`test_filters.py::TestUnknownSortLogging`): log fields + toast preserved; empty `unknown` logs nothing.
- API (`test_api.py`): unknown sort → `400` + log; valid `?sort=-date` still `200`.
- `pytest` (test_api + test_filters + smoke views + sort_toggle) green; `ruff check` + `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)