### PR TITLE
feat(filters): per-model field-metadata registry (#187)

### DIFF
--- a/common/criteria.py
+++ b/common/criteria.py
@@ -726,6 +726,10 @@ class FilterField:
 
     lookup: ORMLookup | None = None
     handler: FieldHandler | None = None
+    # Human label for the field-metadata registry (``field_metadata``). Optional;
+    # declared last so existing positional ``FilterField("lookup")`` calls are
+    # unaffected. When None, the registry falls back to a title-cased field name.
+    label: str | None = None
 
     def __post_init__(self) -> None:
         if self.lookup is not None and self.handler is not None:
@@ -1046,6 +1050,14 @@ class OperatorFilter:
     # plus the aggregate-typed fields partitions every criterion field.
     _IMPERATIVE_CRITERIA: ClassVar[set[str]] = {"search"}
 
+    # Human labels for the field-metadata registry, keyed by field name. A home for
+    # labels of fields outside ``fields`` (aggregates, the M2M ``games``) without
+    # touching the field-partition invariant; ``fields`` entries carry their own
+    # ``FilterField.label``. Empty by default — ``field_metadata`` falls back to a
+    # title-cased field name. Populated with exact strings when the field picker
+    # (issue #168) is built. Subclasses override per field.
+    labels: ClassVar[dict[AttrName, str]] = {}
+
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         # Register concrete filter classes so from_json can resolve a
@@ -1099,11 +1111,15 @@ class OperatorFilter:
             field_criteria[field_name] = criterion_class(**criterion_arguments)
         return cls(**field_criteria)
 
-    def _comparison_model(self) -> type[models.Model] | None:
+    @classmethod
+    def _comparison_model(cls) -> type[models.Model] | None:
         """The Django model whose columns ``field_comparisons`` reference.
 
         Returns None (this filter does not support field comparisons). Concrete
         filter subclasses override this to return their primary model — see T4.
+        A classmethod so the field-metadata registry can resolve filter→model
+        without instantiating (``field_metadata``); ``self``-call sites are
+        unaffected (classmethods are callable on instances).
         """
         return None
 
@@ -1584,6 +1600,177 @@ def comparable_columns(model: type[models.Model]) -> list[ComparableColumn]:
         )
     columns.sort(key=lambda entry: entry["label"].lower())
     return columns
+
+
+# ── Field-metadata registry (issue #187) ───────────────────────────────────
+# The per-model source of truth the nested filter builder's add-criterion field
+# picker, leaf widget, and relation-descent picker read (issue #168). Builds on
+# the existing resolvers (``_criterion_class_for``, ``_filter_class_for``,
+# ``criterion_kind``) and adds the missing label / choices / nullable / relation
+# enumeration. Pure Python — JSON/codegen exposure is deferred to #152.
+
+type FieldMetaKind = LeafWidgetKind | Literal["relation"]
+type ModelName = str  # a Django model class name, e.g. "Session"
+type FilterClassName = str  # an OperatorFilter subclass name, e.g. "SessionFilter"
+
+
+class ChoiceMeta(TypedDict):
+    """One static-enum option for a filter field (status, ownership_type, …)."""
+
+    value: str  # stored value, e.g. "f"
+    label: str  # human label, e.g. "Finished"
+
+
+class RelationTarget(TypedDict):
+    """The target a relation-descent field points at, for the relation picker."""
+
+    field: AttrName  # the sub-filter attr, e.g. "session_filter"
+    filter: FilterClassName  # target filter class name, e.g. "SessionFilter"
+    model: ModelName  # target model name, e.g. "Session"
+
+
+class FieldMeta(TypedDict):
+    """Everything a picker needs to render one filterable field. ``choices`` is
+    populated only for static-enum fields; ``relations`` only for relation
+    descents (``kind == "relation"``)."""
+
+    name: AttrName
+    label: str
+    kind: FieldMetaKind
+    nullable: bool
+    choices: list[ChoiceMeta]
+    relations: list[RelationTarget]
+
+
+def _resolve_model_field(
+    model: type[models.Model], lookup: ORMLookup
+) -> models.Field | None:
+    """Resolve a filter field's ORM ``lookup`` to its terminal concrete model field.
+
+    Walks ``__``-separated segments, descending into the related model at each
+    relation segment, and stops at the first non-relation field — so a trailing
+    transform such as ``created_at__date`` returns the ``created_at`` field and a
+    relation hop such as ``platform__group`` returns ``Platform.group``. A
+    single-segment FK attname (``platform_id``) resolves directly (Django accepts
+    attnames). Returns None for any segment that does not resolve — handler-mapped
+    or aggregate fields, whose lookup names no column.
+    """
+    current = model
+    segments = lookup.split("__")
+    for index, segment in enumerate(segments):
+        try:
+            model_field = current._meta.get_field(segment)
+        except FieldDoesNotExist:
+            return None
+        is_last = index == len(segments) - 1
+        if model_field.is_relation and not is_last:
+            related = model_field.related_model
+            if related is None:
+                return None
+            current = related
+            continue
+        # First non-relation field, or a terminal relation/FK: this is the field.
+        # Any remaining segments are transforms (e.g. ``__date``) and are ignored.
+        return model_field if isinstance(model_field, models.Field) else None
+    return None
+
+
+def _static_choices(model_field: models.Field | None) -> list[ChoiceMeta]:
+    """Static enum ``(value, label)`` pairs for a model field, or ``[]``.
+
+    Only fields with declared ``choices`` (status, ownership_type, type) yield
+    entries; FK/M2M/free-text fields have no choices and are left to the dynamic
+    relation picker.
+    """
+    choices = getattr(model_field, "choices", None)
+    if not choices:
+        return []
+    return [ChoiceMeta(value=str(value), label=str(label)) for value, label in choices]
+
+
+def _field_label(filter_cls: type["OperatorFilter"], name: AttrName) -> str:
+    """Human label for a filter field: explicit ``FilterField.label`` →
+    ``filter_cls.labels`` override → title-cased field name.
+
+    ``verbose_name`` is deliberately not consulted: a nested lookup like
+    ``platform_group`` would surface ``Platform.group``'s verbose_name ("group"),
+    losing the relation context, whereas the field name gives "Platform Group".
+    The field name is the stable identifier; exact display strings are filled in
+    on ``FilterField.label`` / ``labels`` as the field picker (issue #168) lands.
+    """
+    field_spec = filter_cls.fields.get(name)
+    if field_spec is not None and field_spec.label is not None:
+        return field_spec.label
+    override = filter_cls.labels.get(name)
+    if override is not None:
+        return override
+    return name.replace("_", " ").title()
+
+
+def field_metadata(filter_cls: type["OperatorFilter"]) -> list[FieldMeta]:
+    """Per-field filter metadata for ``filter_cls`` — the source of truth the
+    add-criterion field picker, leaf widget, and relation-descent picker read.
+
+    One ``FieldMeta`` per filterable field: leaf criteria and aggregates as value
+    fields (``kind`` from the criterion type), each cross-entity sub-filter as a
+    ``kind="relation"`` entry naming its target. The ``search`` free-text field is
+    excluded — it is served by ``FindFilter.q`` / ``?search_string=`` (TODO #216
+    removes the dead field). Non-recursive: a relation entry names its target
+    only; callers descend by calling ``field_metadata`` on the target filter
+    class, which bounds the ``GameFilter`` ↔ ``SessionFilter`` relation cycle.
+    """
+    model = filter_cls._comparison_model()
+    entries: list[FieldMeta] = []
+    for dataclass_field in dc_fields(filter_cls):
+        name = dataclass_field.name
+        if name == "search":
+            continue  # TODO(#216): drop the ``search`` field entirely
+        criterion_cls = _criterion_class_for(filter_cls, name)
+        if criterion_cls is not None:
+            field_spec = filter_cls.fields.get(name)
+            has_handler = field_spec is not None and field_spec.handler is not None
+            model_field = (
+                _resolve_model_field(
+                    model, field_spec.lookup or name if field_spec else name
+                )
+                if model is not None and not has_handler
+                else None
+            )
+            is_aggregate = issubclass(criterion_cls, AggregateCriterion)
+            entries.append(
+                FieldMeta(
+                    name=name,
+                    label=_field_label(filter_cls, name),
+                    # Aggregates set kind directly: ``criterion_kind``'s exact-class
+                    # dict lookup would KeyError on a future AggregateCriterion
+                    # subclass, whereas the value shape is always "number".
+                    kind="number" if is_aggregate else criterion_kind(criterion_cls),
+                    nullable=bool(getattr(model_field, "null", False)),
+                    choices=_static_choices(model_field),
+                    relations=[],
+                )
+            )
+            continue
+        sub_filter_cls = _filter_class_for(filter_cls, name)
+        if sub_filter_cls is not None:
+            target_model = sub_filter_cls._comparison_model()
+            entries.append(
+                FieldMeta(
+                    name=name,
+                    label=_field_label(filter_cls, name),
+                    kind="relation",
+                    nullable=False,
+                    choices=[],
+                    relations=[
+                        RelationTarget(
+                            field=name,
+                            filter=sub_filter_cls.__name__,
+                            model=target_model.__name__ if target_model else "",
+                        )
+                    ],
+                )
+            )
+    return entries
 
 
 def _allowed_comparison_modifiers(group: ComparisonGroup) -> list[Modifier]:

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -1631,8 +1631,10 @@ class RelationTarget(TypedDict):
 
 class FieldMeta(TypedDict):
     """Everything a picker needs to render one filterable field. ``choices`` is
-    populated only for static-enum fields; ``relations`` only for relation
-    descents (``kind == "relation"``)."""
+    populated only for static-enum fields; ``relations`` is non-empty (a single
+    entry) iff ``kind == "relation"``, and a relation entry always has empty
+    ``choices`` and ``nullable=False``. These cross-field invariants are enforced
+    by ``field_metadata`` (the sole producer), not by the type."""
 
     name: AttrName
     label: str
@@ -1652,8 +1654,11 @@ def _resolve_model_field(
     transform such as ``created_at__date`` returns the ``created_at`` field and a
     relation hop such as ``platform__group`` returns ``Platform.group``. A
     single-segment FK attname (``platform_id``) resolves directly (Django accepts
-    attnames). Returns None for any segment that does not resolve — handler-mapped
-    or aggregate fields, whose lookup names no column.
+    attnames). Returns None when a segment does not resolve (e.g. a mis-typed
+    lookup, or an aggregate field name that is no column); the caller decides
+    whether that None is expected (columnless field) or a misconfiguration to
+    raise on. Handler-mapped fields never reach here — ``field_metadata`` skips
+    them upstream.
     """
     current = model
     segments = lookup.split("__")
@@ -1727,23 +1732,38 @@ def field_metadata(filter_cls: type["OperatorFilter"]) -> list[FieldMeta]:
             continue  # TODO(#216): drop the ``search`` field entirely
         criterion_cls = _criterion_class_for(filter_cls, name)
         if criterion_cls is not None:
+            # Only a field declared in ``fields`` with a plain lookup (no handler)
+            # maps to a single model column. Aggregates (not in ``fields``),
+            # handler-mapped fields, and imperatively-applied criteria (the M2M
+            # ``games``) name no single column, so they carry no choices and are
+            # not nullable — they skip the resolver entirely. Resolving *only* the
+            # column-backed fields means a mis-typed ``FilterField`` lookup raises
+            # here (matching ``criterion_kind`` / ``resolve_path_kind``'s
+            # loud-failure contract) instead of silently degrading to an empty
+            # picker, while the legitimately-columnless fields never hit the None.
+            model_field: models.Field | None = None
             field_spec = filter_cls.fields.get(name)
-            has_handler = field_spec is not None and field_spec.handler is not None
-            model_field = (
-                _resolve_model_field(
-                    model, field_spec.lookup or name if field_spec else name
-                )
-                if model is not None and not has_handler
-                else None
-            )
+            if (
+                field_spec is not None
+                and field_spec.handler is None
+                and model is not None
+            ):
+                lookup = field_spec.lookup or name
+                model_field = _resolve_model_field(model, lookup)
+                if model_field is None:
+                    raise ValueError(
+                        f"{filter_cls.__name__}.{name} lookup {lookup!r} resolves "
+                        f"to no field on {model.__name__}"
+                    )
             is_aggregate = issubclass(criterion_cls, AggregateCriterion)
             entries.append(
                 FieldMeta(
                     name=name,
                     label=_field_label(filter_cls, name),
-                    # Aggregates set kind directly: ``criterion_kind``'s exact-class
-                    # dict lookup would KeyError on a future AggregateCriterion
-                    # subclass, whereas the value shape is always "number".
+                    # Aggregates set kind directly: ``criterion_kind`` would reject
+                    # a future ``AggregateCriterion`` subclass (its exact-class
+                    # registry has no entry → ValueError), whereas the value shape
+                    # is always "number".
                     kind="number" if is_aggregate else criterion_kind(criterion_cls),
                     nullable=bool(getattr(model_field, "null", False)),
                     choices=_static_choices(model_field),
@@ -1754,6 +1774,13 @@ def field_metadata(filter_cls: type["OperatorFilter"]) -> list[FieldMeta]:
         sub_filter_cls = _filter_class_for(filter_cls, name)
         if sub_filter_cls is not None:
             target_model = sub_filter_cls._comparison_model()
+            if target_model is None:
+                # A descendable sub-filter with no model is a misconfiguration:
+                # fail loudly rather than emit a nameless relation target.
+                raise ValueError(
+                    f"{filter_cls.__name__}.{name} descends into "
+                    f"{sub_filter_cls.__name__}, which has no comparison model"
+                )
             entries.append(
                 FieldMeta(
                     name=name,
@@ -1765,7 +1792,7 @@ def field_metadata(filter_cls: type["OperatorFilter"]) -> list[FieldMeta]:
                         RelationTarget(
                             field=name,
                             filter=sub_filter_cls.__name__,
-                            model=target_model.__name__ if target_model else "",
+                            model=target_model.__name__,
                         )
                     ],
                 )

--- a/games/filters.py
+++ b/games/filters.py
@@ -135,7 +135,8 @@ class GameFilter(OperatorFilter):
     # that shadows the builtin in annotation scope, so ``type[Purchase]`` fails
     # mypy ("Variable ... .type is not valid as a type"). Uniform ``Type`` keeps
     # all six overrides consistent.
-    def _comparison_model(self) -> Type[Game]:
+    @classmethod
+    def _comparison_model(cls) -> Type[Game]:
         from games.models import Game
 
         return Game
@@ -310,7 +311,8 @@ class SessionFilter(OperatorFilter):
         "created_at": FilterField("created_at__date"),
     }
 
-    def _comparison_model(self) -> Type[Session]:
+    @classmethod
+    def _comparison_model(cls) -> Type[Session]:
         from games.models import Session
 
         return Session
@@ -420,7 +422,8 @@ class PurchaseFilter(OperatorFilter):
     # need chained subqueries), so it stays out of ``fields``.
     _IMPERATIVE_CRITERIA = {"search", "games"}
 
-    def _comparison_model(self) -> Type[Purchase]:
+    @classmethod
+    def _comparison_model(cls) -> Type[Purchase]:
         from games.models import Purchase
 
         return Purchase
@@ -556,7 +559,8 @@ class DeviceFilter(OperatorFilter):
         "created_at": FilterField("created_at__date"),
     }
 
-    def _comparison_model(self) -> Type[Device]:
+    @classmethod
+    def _comparison_model(cls) -> Type[Device]:
         from games.models import Device
 
         return Device
@@ -613,7 +617,8 @@ class PlatformFilter(OperatorFilter):
         "created_at": FilterField("created_at__date"),
     }
 
-    def _comparison_model(self) -> Type[Platform]:
+    @classmethod
+    def _comparison_model(cls) -> Type[Platform]:
         from games.models import Platform
 
         return Platform
@@ -680,7 +685,8 @@ class PlayEventFilter(OperatorFilter):
         "created_at": FilterField("created_at__date"),
     }
 
-    def _comparison_model(self) -> Type[PlayEvent]:
+    @classmethod
+    def _comparison_model(cls) -> Type[PlayEvent]:
         from games.models import PlayEvent
 
         return PlayEvent

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -34,11 +34,14 @@ from common.criteria import (
     _comparison_group_for,
     _criterion_class_for,
     _field_comparison_to_q,
+    _filter_class_for,
     _maybe_group_for,
     bool_isnull_handler,
     bool_nonzero_duration_handler,
     comparable_columns,
     duration_hours_handler,
+    FieldMeta,
+    field_metadata,
     filter_from_json,
     search_q,
 )
@@ -2524,7 +2527,8 @@ class _PurchaseStub(OperatorFilter):
     OR: list["_PurchaseStub"] = dc_field(default_factory=list)
     NOT: list["_PurchaseStub"] = dc_field(default_factory=list)
 
-    def _comparison_model(self):
+    @classmethod
+    def _comparison_model(cls):
         from games.models import Purchase
 
         return Purchase
@@ -2545,7 +2549,8 @@ class _SessionStub(OperatorFilter):
     OR: list["_SessionStub"] = dc_field(default_factory=list)
     NOT: list["_SessionStub"] = dc_field(default_factory=list)
 
-    def _comparison_model(self):
+    @classmethod
+    def _comparison_model(cls):
         from games.models import Session
 
         return Session
@@ -3788,3 +3793,139 @@ class TestValueTypeBoundaryIntegration:
         parsed = parse_game_filter(good)
         assert parsed is not None
         assert Game.objects.filter(parsed.to_q()).filter(pk=game.pk).exists()
+
+
+# ── Component 9 — per-model field-metadata registry (issue #187) ──────────────
+
+
+class TestFieldMetadata:
+    """``field_metadata`` returns one entry per filterable field with the
+    {name, label, kind, nullable, choices, relations} shape the nested filter
+    builder's pickers read."""
+
+    @staticmethod
+    def _by_name(filter_cls) -> dict[str, FieldMeta]:
+        return {entry["name"]: entry for entry in field_metadata(filter_cls)}
+
+    @staticmethod
+    def _expected_choices(model, field_name) -> list[dict]:
+        choices = model._meta.get_field(field_name).choices
+        return [{"value": str(value), "label": str(label)} for value, label in choices]
+
+    @pytest.mark.parametrize("filter_cls", _ALL_FILTERS)
+    def test_does_not_raise_and_excludes_search(self, filter_cls):
+        names = {entry["name"] for entry in field_metadata(filter_cls)}
+        # search is a declared StringCriterion on every filter but is deliberately
+        # excluded (served by FindFilter.q; TODO #216 removes it).
+        assert "search" in {f.name for f in dataclasses.fields(filter_cls)}
+        assert "search" not in names
+
+    @pytest.mark.parametrize("filter_cls", _ALL_FILTERS)
+    def test_covers_every_criterion_and_relation_field(self, filter_cls):
+        expected = {
+            f.name
+            for f in dataclasses.fields(filter_cls)
+            if f.name != "search"
+            and (
+                _criterion_class_for(filter_cls, f.name) is not None
+                or _filter_class_for(filter_cls, f.name) is not None
+            )
+        }
+        names = {entry["name"] for entry in field_metadata(filter_cls)}
+        assert names == expected
+
+    @pytest.mark.parametrize("filter_cls", _ALL_FILTERS)
+    def test_non_filter_fields_skipped(self, filter_cls):
+        names = {entry["name"] for entry in field_metadata(filter_cls)}
+        for skipped in ("AND", "OR", "NOT", "field_comparisons", "match"):
+            assert skipped not in names
+
+    @pytest.mark.parametrize("filter_cls", _ALL_FILTERS)
+    def test_leaf_kind_matches_criterion(self, filter_cls):
+        from common.criteria import AggregateCriterion, criterion_kind
+
+        for entry in field_metadata(filter_cls):
+            if entry["kind"] == "relation":
+                continue
+            criterion_cls = _criterion_class_for(filter_cls, entry["name"])
+            assert criterion_cls is not None
+            if issubclass(criterion_cls, AggregateCriterion):
+                # aggregates set kind directly, bypassing the exact-class dict
+                assert entry["kind"] == "number"
+            else:
+                assert entry["kind"] == criterion_kind(criterion_cls)
+
+    def test_aggregate_field_is_number(self):
+        entry = self._by_name(GameFilter)["session_count"]
+        assert entry["kind"] == "number"
+        assert entry["nullable"] is False
+        assert entry["choices"] == []
+        assert entry["relations"] == []
+
+    def test_relation_entry_targets_subfilter(self):
+        entry = self._by_name(GameFilter)["session_filter"]
+        assert entry["kind"] == "relation"
+        assert entry["choices"] == []
+        assert entry["nullable"] is False
+        assert entry["relations"] == [
+            {"field": "session_filter", "filter": "SessionFilter", "model": "Session"}
+        ]
+
+    def test_static_choices_game_status(self):
+        from games.models import Game
+
+        entry = self._by_name(GameFilter)["status"]
+        assert entry["kind"] == "set"
+        assert entry["choices"] == self._expected_choices(Game, "status")
+
+    def test_static_choices_purchase(self):
+        from games.models import Purchase
+
+        by_name = self._by_name(PurchaseFilter)
+        assert by_name["ownership_type"]["choices"] == self._expected_choices(
+            Purchase, "ownership_type"
+        )
+        assert by_name["type"]["choices"] == self._expected_choices(Purchase, "type")
+
+    def test_static_choices_device(self):
+        from games.models import Device
+
+        entry = self._by_name(DeviceFilter)["type"]
+        assert entry["choices"] == self._expected_choices(Device, "type")
+
+    def test_dynamic_fk_and_m2m_have_no_choices(self):
+        game_fields = self._by_name(GameFilter)
+        assert game_fields["platform"]["choices"] == []
+        assert game_fields["platform_group"]["choices"] == []
+        # M2M ``games`` must resolve without AttributeError on ``.null``.
+        purchase_fields = self._by_name(PurchaseFilter)
+        assert purchase_fields["games"]["choices"] == []
+        assert purchase_fields["games"]["nullable"] is False
+
+    def test_nullable_reads_fk_attname(self):
+        from games.models import Game
+
+        # platform → lookup "platform_id" (FK attname) resolves to the FK's .null
+        entry = self._by_name(GameFilter)["platform"]
+        assert entry["nullable"] == bool(Game._meta.get_field("platform").null)
+
+    def test_handler_field_defaults_not_nullable(self):
+        # playtime_hours is handler-mapped (no model column) → nullable False
+        entry = self._by_name(GameFilter)["playtime_hours"]
+        assert entry["kind"] == "number"
+        assert entry["nullable"] is False
+
+    def test_multi_hop_descent_label(self):
+        # platform_group (lookup platform__group) descends to Platform.group; the
+        # label is the field name title-cased (not "Group" from verbose_name).
+        entry = self._by_name(GameFilter)["platform_group"]
+        assert entry["label"] == "Platform Group"
+
+    def test_explicit_filterfield_label_wins(self):
+        from common.criteria import FilterField
+
+        assert GameFilter.fields["platform"].lookup == "platform_id"
+        # default label fallback is the title-cased name
+        assert self._by_name(GameFilter)["name"]["label"] == "Name"
+        # a FilterField.label override would take precedence (plumbing check)
+        assert FilterField(lookup="x", label="Custom").label == "Custom"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,5 +1,13 @@
 """Tests for the filtering system."""
 
+# Stringizes all annotations (PEP 563), matching every filter module
+# (games/filters.py). Without it, the stub filters' ``X | None`` field
+# annotations would be live UnionType objects that the annotation-string-based
+# resolvers (``_criterion_class_for`` / ``_filter_class_for``) can't read.
+# Removable once #218 resolves field types by introspection instead of
+# annotation-string parsing.
+from __future__ import annotations
+
 import dataclasses
 import json
 import logging
@@ -36,6 +44,7 @@ from common.criteria import (
     _field_comparison_to_q,
     _filter_class_for,
     _maybe_group_for,
+    _resolve_model_field,
     bool_isnull_handler,
     bool_nonzero_duration_handler,
     comparable_columns,
@@ -3929,3 +3938,102 @@ class TestFieldMetadata:
         assert self._by_name(GameFilter)["name"]["label"] == "Name"
         # a FilterField.label override would take precedence (plumbing check)
         assert FilterField(lookup="x", label="Custom").label == "Custom"
+
+    def test_resolve_model_field_descent_and_transform(self):
+        from games.models import Game, Platform, Session
+
+        # multi-hop FK descent reaches the terminal related-model field
+        assert _resolve_model_field(
+            Game, "platform__group"
+        ) is Platform._meta.get_field("group")
+        # trailing transform is ignored; stops at the first non-relation field
+        assert _resolve_model_field(
+            Session, "timestamp_start__date"
+        ) is Session._meta.get_field("timestamp_start")
+        # single-segment FK attname resolves to the FK itself
+        assert _resolve_model_field(Game, "platform_id") is Game._meta.get_field(
+            "platform"
+        )
+
+    def test_resolve_model_field_unresolvable_returns_none(self):
+        from games.models import Game
+
+        assert _resolve_model_field(Game, "does_not_exist") is None
+        # reverse relation / aggregate-style name resolves to no concrete field
+        assert _resolve_model_field(Game, "sessions") is None
+
+    def test_nullable_true_for_plain_column(self):
+        # year_released is a nullable plain (non-relation) column — exercises the
+        # nullable=True path for a real model column, not just an FK.
+        entry = self._by_name(GameFilter)["year_released"]
+        assert entry["kind"] == "number"
+        assert entry["nullable"] is True
+
+    def test_relation_payload_for_every_subfilter(self):
+        for filter_cls in _ALL_FILTERS:
+            by_name = self._by_name(filter_cls)
+            for dataclass_field in dataclasses.fields(filter_cls):
+                sub = _filter_class_for(filter_cls, dataclass_field.name)
+                if sub is None:
+                    continue
+                entry = by_name[dataclass_field.name]
+                assert entry["kind"] == "relation"
+                assert entry["relations"] == [
+                    {
+                        "field": dataclass_field.name,
+                        "filter": sub.__name__,
+                        "model": sub._comparison_model().__name__,
+                    }
+                ]
+
+    def test_filterfield_label_and_labels_override_win(self):
+        by_name = self._by_name(_LabelStub)
+        # FilterField.label (highest precedence) surfaces for an in-`fields` field
+        assert by_name["name"]["label"] == "Explicit Name"
+        # OperatorFilter.labels override surfaces for a field outside `fields`
+        assert by_name["mastered"]["label"] == "Override Mastered"
+
+    def test_mistyped_lookup_raises(self):
+        with pytest.raises(ValueError, match="resolves to no field"):
+            field_metadata(_BadLookupStub)
+
+
+@dataclass
+class _LabelStub(OperatorFilter):
+    """Exercises the two label-override branches of ``_field_label``: a
+    ``FilterField.label`` (in ``fields``) and an ``OperatorFilter.labels`` entry
+    (for a field outside ``fields``)."""
+
+    AND: list[_LabelStub] = dc_field(default_factory=list)
+    OR: list[_LabelStub] = dc_field(default_factory=list)
+    NOT: list[_LabelStub] = dc_field(default_factory=list)
+    name: StringCriterion | None = None
+    mastered: BoolCriterion | None = None
+
+    fields = {"name": FilterField(label="Explicit Name")}
+    labels = {"mastered": "Override Mastered"}
+
+    @classmethod
+    def _comparison_model(cls):
+        from games.models import Game
+
+        return Game
+
+
+@dataclass
+class _BadLookupStub(OperatorFilter):
+    """A misconfigured filter whose ``fields`` lookup names no real column — the
+    registry must raise rather than silently emit nullable=False/choices=[]."""
+
+    AND: list[_BadLookupStub] = dc_field(default_factory=list)
+    OR: list[_BadLookupStub] = dc_field(default_factory=list)
+    NOT: list[_BadLookupStub] = dc_field(default_factory=list)
+    year_released: IntCriterion | None = None
+
+    fields = {"year_released": FilterField("yeer_released")}
+
+    @classmethod
+    def _comparison_model(cls):
+        from games.models import Game
+
+        return Game


### PR DESCRIPTION
## Context

Closes #187 — the **foundational** component of the nested filter builder epic (#168). It blocks the field picker, leaf widget, and relation-descent picker that the builder UI needs.

Today the list of filterable fields, their labels, enum choices, and which relations you can descend into is scattered and hardcoded across the filter bars in `common/components/filters.py`. There was no programmatic way to ask "what fields can I filter `Game` on, and what type/choices/relations does each have?"

## What

`field_metadata(filter_cls) -> list[FieldMeta]` in `common/criteria.py`: one entry per filterable field with `{name, label, kind, nullable, choices, relations}`.

- **Unified list** — a relation descent (e.g. Game → its Sessions) is an entry with `kind="relation"` naming its target; value fields carry `relations: []`. Matches the issue's literal spec.
- **Implicit bucketing** — criterion → leaf/aggregate, sub-filter → relation, else skip. Operator fields (`AND`/`OR`/`NOT`), `field_comparisons`, and `match` drop out automatically.
- **`search` excluded** — it is a dead `StringCriterion` field served by `FindFilter.q` / `?search_string=`; removal tracked in #216 (the registry skip carries a `# TODO(#216)`).
- **Labels: plumbing + fallback** — new `FilterField.label` / `OperatorFilter.labels` slots; registry falls back to a title-cased field name. Exact override strings land with the field picker. `verbose_name` is deliberately not consulted (a nested lookup like `platform_group` would surface "Group" instead of "Platform Group").
- **Choices** — static enums only (status / ownership_type / type); FK/M2M fields are left to the dynamic relation picker.
- **Nullable** — resolved through the ORM lookup, read via `getattr(field, "null", False)` so the M2M `games` field can't `AttributeError`.

Builds on existing `_criterion_class_for` / `_filter_class_for` / `criterion_kind` rather than duplicating per-field type tables. `_comparison_model` promoted to a classmethod so the registry maps filter → model without instantiating. Pure Python — JSON/codegen exposure deferred to #152.

## Design notes (adversarial-reviewed)

- Dropped a planned `_id`-strip retry: Django 6 `Model._meta.get_field("platform_id")` accepts attnames, so the resolver just descends `__` segments.
- Aggregates set `kind="number"` directly, dodging the exact-class `_CRITERION_KINDS` lookup (future-subclass-safe).
- `field_metadata` is non-recursive: a relation entry names its target only; callers descend by calling it on the target filter class, which bounds the `GameFilter` ↔ `SessionFilter` cycle.

## Tests

`TestFieldMetadata` (`tests/test_filters.py`) — parametrized over all six filters: field presence/`search` exclusion, kind matching, static choices (Game/Purchase/Device), M2M-safe nullable, FK-attname nullable, multi-hop FK descent, and label fallback.

## Verification

`ruff check` ✓ · `ruff format` ✓ (touched files) · `mypy` ✓ (148 files) · `ts-check` ✓ · full suite **1126 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)