### PR TITLE
fix(filters): rehydrate set-criterion labels from stats-page links (#224)

### DIFF
--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -1249,6 +1249,12 @@ def _session_fields(existing: dict) -> list:
 
     game_choice = _filter_get_choice(existing, "game")
     device_choice = _filter_get_choice(existing, "device")
+    # Cross-entity: a session's platform lives on its game, so the widget
+    # serializes into a game_filter EXISTS sub-filter (mirrors the game bar's
+    # device widget). Prefill reads it back from existing["AND"] by the same path.
+    platform_choice = _choice_from_raw(
+        _cross_entity_criterion(existing, ["game_filter", "platform"])
+    )
     note_value = existing.get("note", {}).get("value", "")
     note_modifier = existing.get("note", {}).get("modifier", "EQUALS")
 
@@ -1276,6 +1282,16 @@ def _session_fields(existing: dict) -> list:
                     device_choice,
                     search_url="/api/devices/search",
                     nullable=Session._meta.get_field("device").null,
+                ),
+            ),
+            _filter_field(
+                "Platform",
+                _model_filter(
+                    "platform",
+                    platform_choice,
+                    search_url="/api/platforms/search",
+                    nullable=Game._meta.get_field("platform").null,
+                    path=["game_filter", "platform"],
                 ),
             ),
             _filter_field(

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -629,10 +629,12 @@ class _SetCriterion(_Criterion):
         return {"id": item, "label": label} if label else item
 
     def to_json(self) -> dict[str, Any]:
-        # Mirrors the base omission rules (skip empty value/excludes and the
-        # default modifier) but emits ``{id, label}`` dicts for ids that carry a
-        # display label and never emits ``labels`` as its own key — labels live
-        # inline on each element, matching the client serializer's wire shape.
+        # Overrides (does NOT mirror) the base ``to_json``: because ``value`` /
+        # ``excludes`` use ``default_factory``, the base never treats an empty
+        # list as the default, so it would leak ``"value": []`` / ``"excludes":
+        # []`` and a raw ``"labels": {}`` key onto the wire. This skips empty
+        # lists, never emits ``labels`` as its own key (labels are folded inline
+        # per ``_labelled``), and — like the base — omits the default modifier.
         result: dict[str, Any] = {}
         if self.value:
             result["value"] = [self._labelled(item) for item in self.value]
@@ -653,6 +655,7 @@ class MultiCriterion(_SetCriterion):
 
     value: list[int] = field(default_factory=list)
     excludes: list[int] = field(default_factory=list)
+    labels: dict[int, str] = field(default_factory=dict, compare=False)
     _coerce: ClassVar[Coercer | None] = staticmethod(_coerce_int)
 
 
@@ -666,6 +669,7 @@ class ChoiceCriterion(_SetCriterion):
 
     value: list[str] = field(default_factory=list)
     excludes: list[str] = field(default_factory=list)
+    labels: dict[str, str] = field(default_factory=dict, compare=False)
 
 
 @dataclass

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -521,6 +521,26 @@ class _SetCriterion(_Criterion):
     excludes: list = field(default_factory=list)
     modifier: Modifier = Modifier.INCLUDES
 
+    # Display-only id -> label map. THE place where embedded set labels are
+    # documented (issue #224).
+    #
+    # Set pills (platform/game/device) need a human label to render; the id
+    # alone ("5") is meaningless to the user. UI-built filters carry the label
+    # inline as ``{id, label}`` dicts (see ``ts/elements/filter-bar.ts``); a
+    # filter built server-side (stats-page links) only knows the id, so it stashes
+    # the labels it has here and ``to_json`` folds them back into the ``{id, label}``
+    # wire shape. The filter bar then prefills labelled pills straight from the URL
+    # JSON with no extra DB round-trip.
+    #
+    # Labels are PURELY cosmetic: ``to_q`` reads only ``value``/``excludes``/
+    # ``modifier`` and never touches ``labels``, and ``from_json`` strips labels
+    # back to bare ids. So they never change which rows a filter matches; the one
+    # trade-off is that a label can go stale if the underlying record is renamed
+    # after the link/preset was created (the pill shows the old name until the link
+    # is regenerated). ``compare=False`` keeps two criteria with the same ids but
+    # different labels equal.
+    labels: dict = field(default_factory=dict, compare=False)
+
     def to_q(self, field_name: str) -> Q:
         modifier = self.modifier
         if modifier == Modifier.IS_NULL:
@@ -597,6 +617,29 @@ class _SetCriterion(_Criterion):
             coerce = cls._coerce
             result.value = [coerce(item) for item in result.value]
             result.excludes = [coerce(item) for item in result.excludes]
+        return result
+
+    def _labelled(self, item: Any) -> Any:
+        """Fold a known label back into the ``{id, label}`` wire shape (#224).
+
+        Returns the bare id when no label is known, so unlabelled criteria
+        serialize exactly as before.
+        """
+        label = self.labels.get(item)
+        return {"id": item, "label": label} if label else item
+
+    def to_json(self) -> dict[str, Any]:
+        # Mirrors the base omission rules (skip empty value/excludes and the
+        # default modifier) but emits ``{id, label}`` dicts for ids that carry a
+        # display label and never emits ``labels`` as its own key — labels live
+        # inline on each element, matching the client serializer's wire shape.
+        result: dict[str, Any] = {}
+        if self.value:
+            result["value"] = [self._labelled(item) for item in self.value]
+        if self.excludes:
+            result["excludes"] = [self._labelled(item) for item in self.excludes]
+        if self.modifier != Modifier.INCLUDES:
+            result["modifier"] = self.modifier
         return result
 
 

--- a/games/views/stats_content.py
+++ b/games/views/stats_content.py
@@ -403,7 +403,9 @@ def stats_content(ctx: StatsData) -> Node:
             ctx.get("total_playtime_per_platform") or [],
             lambda item: A(
                 href=filter_url(
-                    stats_links.sessions_for_platform(item["platform_id"], year)
+                    stats_links.sessions_for_platform(
+                        item["platform_id"], year, item["platform_name"] or ""
+                    )
                 ),
                 class_="hover:underline decoration-dotted",
             )[item["platform_name"] or "Unspecified"],

--- a/games/views/stats_content.py
+++ b/games/views/stats_content.py
@@ -403,9 +403,7 @@ def stats_content(ctx: StatsData) -> Node:
             ctx.get("total_playtime_per_platform") or [],
             lambda item: A(
                 href=filter_url(
-                    stats_links.sessions_for_platform(
-                        item["platform_id"], year, item["platform_name"] or ""
-                    )
+                    stats_links.sessions_for_platform(item["platform_id"], year)
                 ),
                 class_="hover:underline decoration-dotted",
             )[item["platform_name"] or "Unspecified"],

--- a/games/views/stats_content.py
+++ b/games/views/stats_content.py
@@ -43,11 +43,14 @@ _NAME_TH = f"{_CELL} purchase-name truncate max-w-20char"
 _LIST_CAP = 5
 
 
-def _session_link(game_id, year) -> Node:
+def _session_link(game_id, year, label: str = "") -> Node:
     """Small affordance linking a game row to its (year-scoped) session list.
-    Sits next to the existing GameLink (which goes to the game detail page)."""
+    Sits next to the existing GameLink (which goes to the game detail page).
+
+    ``label`` is the game name, embedded in the filter so the destination bar
+    renders a named pill instead of a bare id (#224)."""
     return A(
-        href=filter_url(stats_links.sessions_for_game(game_id, year)),
+        href=filter_url(stats_links.sessions_for_game(game_id, year, label)),
         class_="ml-1 inline-block align-middle hover:text-heading",
         title="View sessions",
     )[Icon("play", size=ICON_BUTTON_SIZE_CLASS)]
@@ -187,7 +190,7 @@ def _playtime_table(ctx) -> Node:
                         " (",
                         GameLink(game.id, game.name),
                         ")",
-                        _session_link(game.id, year),
+                        _session_link(game.id, year, game.name),
                     ]
                 ),
             ]
@@ -222,7 +225,7 @@ def _playtime_table(ctx) -> Node:
                         [
                             GameLink(first_game.id, first_game.name),
                             f" ({ctx.get('first_play_date')})",
-                            _session_link(first_game.id, year),
+                            _session_link(first_game.id, year, first_game.name),
                         ]
                     ),
                 ]
@@ -238,7 +241,7 @@ def _playtime_table(ctx) -> Node:
                         [
                             GameLink(last_game.id, last_game.name),
                             f" ({ctx.get('last_play_date')})",
-                            _session_link(last_game.id, year),
+                            _session_link(last_game.id, year, last_game.name),
                         ]
                     ),
                 ]
@@ -386,7 +389,9 @@ def stats_content(ctx: StatsData) -> Node:
         _two_col_table(
             "Name",
             ctx.get("top_10_games_by_playtime") or [],
-            lambda g: Fragment(GameLink(g.id, g.name), _session_link(g.id, year)),
+            lambda g: Fragment(
+                GameLink(g.id, g.name), _session_link(g.id, year, g.name)
+            ),
             lambda g: _dur(g.total_playtime),
             view_all_url=filter_url(
                 stats_links.games_played(year), sort="-filtered_playtime"
@@ -398,7 +403,9 @@ def stats_content(ctx: StatsData) -> Node:
             ctx.get("total_playtime_per_platform") or [],
             lambda item: A(
                 href=filter_url(
-                    stats_links.sessions_for_platform(item["platform_id"], year)
+                    stats_links.sessions_for_platform(
+                        item["platform_id"], year, item["platform_name"] or ""
+                    )
                 ),
                 class_="hover:underline decoration-dotted",
             )[item["platform_name"] or "Unspecified"],

--- a/games/views/stats_links.py
+++ b/games/views/stats_links.py
@@ -68,13 +68,9 @@ def sessions_for_game(game_id: int, year, label: str = "") -> SessionFilter:
     return session_filter
 
 
-def sessions_for_platform(platform_id: int, year, label: str = "") -> SessionFilter:
+def sessions_for_platform(platform_id: int, year) -> SessionFilter:
     session_filter = SessionFilter.where(**_session_bounds(year))
-    session_filter.game_filter = GameFilter(
-        platform=MultiCriterion(
-            value=[platform_id], labels={platform_id: label} if label else {}
-        )
-    )
+    session_filter.game_filter = GameFilter.where(platform=[platform_id])
     return session_filter
 
 

--- a/games/views/stats_links.py
+++ b/games/views/stats_links.py
@@ -68,9 +68,15 @@ def sessions_for_game(game_id: int, year, label: str = "") -> SessionFilter:
     return session_filter
 
 
-def sessions_for_platform(platform_id: int, year) -> SessionFilter:
+def sessions_for_platform(platform_id: int, year, label: str = "") -> SessionFilter:
+    # See sessions_for_game: the platform name rides along as a display label so
+    # the session bar's (cross-entity) platform pill renders a name, not an id.
     session_filter = SessionFilter.where(**_session_bounds(year))
-    session_filter.game_filter = GameFilter.where(platform=[platform_id])
+    session_filter.game_filter = GameFilter(
+        platform=MultiCriterion(
+            value=[platform_id], labels={platform_id: label} if label else {}
+        )
+    )
     return session_filter
 
 

--- a/games/views/stats_links.py
+++ b/games/views/stats_links.py
@@ -19,6 +19,7 @@ from common.criteria import (
     DateCriterion,
     IntCriterion,
     Modifier,
+    MultiCriterion,
 )
 from games.filters import (
     GameFilter,
@@ -57,13 +58,23 @@ def all_sessions(year) -> SessionFilter:
     return SessionFilter.where(**_session_bounds(year))
 
 
-def sessions_for_game(game_id: int, year) -> SessionFilter:
-    return SessionFilter.where(game=[game_id], **_session_bounds(year))
-
-
-def sessions_for_platform(platform_id: int, year) -> SessionFilter:
+def sessions_for_game(game_id: int, year, label: str = "") -> SessionFilter:
+    # Carry the game name as a display label so the filter bar renders a named
+    # pill on landing (#224); falls back to a bare id when no label is given.
     session_filter = SessionFilter.where(**_session_bounds(year))
-    session_filter.game_filter = GameFilter.where(platform=[platform_id])
+    session_filter.game = MultiCriterion(
+        value=[game_id], labels={game_id: label} if label else {}
+    )
+    return session_filter
+
+
+def sessions_for_platform(platform_id: int, year, label: str = "") -> SessionFilter:
+    session_filter = SessionFilter.where(**_session_bounds(year))
+    session_filter.game_filter = GameFilter(
+        platform=MultiCriterion(
+            value=[platform_id], labels={platform_id: label} if label else {}
+        )
+    )
     return session_filter
 
 

--- a/tests/test_filter_bar_labels.py
+++ b/tests/test_filter_bar_labels.py
@@ -16,3 +16,19 @@ def test_extract_labeled_handles_bare_values():
 
 def test_extract_labeled_handles_bare_ints():
     assert _extract_labeled([3, 7]) == [("3", "3"), ("7", "7")]
+
+
+def test_stats_link_prefills_labelled_choice():
+    """End-to-end (#224): a server-built stats-link that embeds an id's label
+    serializes it into the ``?filter=`` JSON, so the bar prefills a labelled pill
+    rather than a bare id."""
+    import json
+
+    from common.components.filters import _filter_get_choice
+    from common.criteria import MultiCriterion
+    from games.filters import SessionFilter
+
+    link = SessionFilter(game=MultiCriterion(value=[5], labels={5: "Hollow Knight"}))
+    existing = json.loads(json.dumps(link.to_json()))
+    choice = _filter_get_choice(existing, "game")
+    assert choice.selected == [("5", "Hollow Knight")]

--- a/tests/test_filter_cross_entity.py
+++ b/tests/test_filter_cross_entity.py
@@ -18,12 +18,21 @@ from datetime import date, datetime, timezone
 
 import pytest
 
-from common.components.filters import FilterBar, PurchaseFilterBar
+from common.components.filters import FilterBar, PurchaseFilterBar, SessionFilterBar
 from games.filters import (
     parse_game_filter,
     parse_purchase_filter,
+    parse_session_filter,
 )
 from games.models import Device, Game, Platform, PlayEvent, Purchase, Session
+
+
+def _session_ids(filter_json: str) -> set[int]:
+    parsed = parse_session_filter(filter_json)
+    assert parsed is not None
+    return set(
+        Session.objects.filter(parsed.to_q()).distinct().values_list("id", flat=True)
+    )
 
 
 def _dt(year=2024, month=6, day=1):
@@ -500,6 +509,41 @@ def test_game_bar_prefills_device_from_and(db):
     html = str(FilterBar(filter_json))
     # the included pill renders the device label
     assert "SteamDeck" in html
+
+
+def test_session_bar_platform_widget_json_selects_sessions(db):
+    """The session bar's cross-entity platform widget emits
+    AND→game_filter→platform and selects sessions on that platform."""
+    pc = Platform.objects.create(name="PC")
+    switch = Platform.objects.create(name="Switch")
+    on_pc = Game.objects.create(name="On PC", platform=pc)
+    on_switch = Game.objects.create(name="On Switch", platform=switch)
+    pc_session = Session.objects.create(game=on_pc, timestamp_start=_dt())
+    Session.objects.create(game=on_switch, timestamp_start=_dt())
+    filter_json = json.dumps(
+        {"AND": [{"game_filter": {"platform": _set_criterion(str(pc.id), "PC")}}]}
+    )
+    assert _session_ids(filter_json) == {pc_session.id}
+
+
+def test_session_bar_prefills_platform_from_and(db):
+    """The session bar reads a game_filter→platform AND element back and renders
+    a labelled platform pill (the consumer for sessions_for_platform's #224
+    embedded label)."""
+    platform = Platform.objects.create(name="MegaDrive")
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "game_filter": {
+                        "platform": _set_criterion(str(platform.id), "MegaDrive")
+                    }
+                }
+            ]
+        }
+    )
+    html = str(SessionFilterBar(filter_json))
+    assert "MegaDrive" in html
 
 
 def test_game_bar_prefills_purchase_type_from_and(db):

--- a/tests/test_filter_paths.py
+++ b/tests/test_filter_paths.py
@@ -109,7 +109,7 @@ class _BarCase(NamedTuple):
 # resolution check below skips kind=="field-comparison".
 _BAR_CASES = [
     _BarCase("game", FilterBar, GameFilter, 24),
-    _BarCase("session", SessionFilterBar, SessionFilter, 9),
+    _BarCase("session", SessionFilterBar, SessionFilter, 10),
     _BarCase("purchase", PurchaseFilterBar, PurchaseFilter, 15),
     _BarCase("device", DeviceFilterBar, DeviceFilter, 2),
     _BarCase("platform", PlatformFilterBar, PlatformFilter, 3),

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -398,6 +398,11 @@ class TestMultiCriterion:
         c = MultiCriterion(value=[1, 2], labels={1: "One"})
         assert c.to_json() == {"value": [{"id": 1, "label": "One"}, 2]}
 
+    def test_to_json_embeds_labels_on_excludes_channel(self):
+        """The excludes channel is labelled symmetrically with value."""
+        c = MultiCriterion(value=[], excludes=[2], labels={2: "Two"})
+        assert c.to_json() == {"excludes": [{"id": 2, "label": "Two"}]}
+
     def test_labels_do_not_affect_query(self):
         """Labels are display-only: to_q is identical with and without them."""
         labelled = MultiCriterion(value=[1], excludes=[2], labels={1: "a", 2: "b"})

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -324,6 +324,11 @@ class TestChoiceCriterion:
         c = ChoiceCriterion(value=["f"], modifier=Modifier.NOT_EQUALS)
         assert c.to_q("status") == ~Q(status__in=["f"])
 
+    def test_to_json_emits_bare_codes(self):
+        """Enum criteria never set labels, so the shared _SetCriterion.to_json
+        leaves their codes bare (#224)."""
+        assert ChoiceCriterion(value=["f", "p"]).to_json() == {"value": ["f", "p"]}
+
 
 class TestMultiCriterion:
     def test_includes(self):
@@ -378,6 +383,34 @@ class TestMultiCriterion:
         assert c.value == [797]
         assert c.excludes == [11]
         assert c.to_q("game_id") == Q(game_id__in=[797]) & ~Q(game_id__in=[11])
+
+    def test_to_json_embeds_known_labels(self):
+        """to_json folds the labels map back into {id, label} wire shape (#224)."""
+        c = MultiCriterion(value=[797], labels={797: "Hollow Knight"})
+        assert c.to_json() == {"value": [{"id": 797, "label": "Hollow Knight"}]}
+
+    def test_to_json_without_labels_emits_bare_ids(self):
+        """No labels -> serialization is unchanged (bare ids)."""
+        assert MultiCriterion(value=[797]).to_json() == {"value": [797]}
+
+    def test_to_json_emits_bare_id_for_unlabelled_element(self):
+        """Only ids present in the labels map get a label; others stay bare."""
+        c = MultiCriterion(value=[1, 2], labels={1: "One"})
+        assert c.to_json() == {"value": [{"id": 1, "label": "One"}, 2]}
+
+    def test_labels_do_not_affect_query(self):
+        """Labels are display-only: to_q is identical with and without them."""
+        labelled = MultiCriterion(value=[1], excludes=[2], labels={1: "a", 2: "b"})
+        bare = MultiCriterion(value=[1], excludes=[2])
+        assert labelled.to_q("game_id") == bare.to_q("game_id")
+
+    def test_labels_round_trip_strips_back_to_bare(self):
+        """to_json embeds labels; from_json strips them — the query value is the
+        same bare id list either way."""
+        original = MultiCriterion(value=[797], labels={797: "Hollow Knight"})
+        restored = MultiCriterion.from_json(original.to_json())
+        assert restored.value == [797]
+        assert restored.labels == {}
 
 
 class TestChoiceCriterionAgainstDB:

--- a/tests/test_stats_content_links.py
+++ b/tests/test_stats_content_links.py
@@ -79,9 +79,7 @@ def test_unfinished_count_links_to_unfinished_purchases(rendered):
 
 
 def test_platform_row_links_to_platform_sessions(rendered):
-    # the rendered link embeds the platform name as a display label (#224)
-    pc = rendered["pc"]
-    url = _href(stats_links.sessions_for_platform(pc.id, YEAR, pc.name))
+    url = _href(stats_links.sessions_for_platform(rendered["pc"].id, YEAR))
     assert url in rendered["html"]
 
 

--- a/tests/test_stats_content_links.py
+++ b/tests/test_stats_content_links.py
@@ -79,7 +79,9 @@ def test_unfinished_count_links_to_unfinished_purchases(rendered):
 
 
 def test_platform_row_links_to_platform_sessions(rendered):
-    url = _href(stats_links.sessions_for_platform(rendered["pc"].id, YEAR))
+    # the rendered link embeds the platform name as a display label (#224)
+    pc = rendered["pc"]
+    url = _href(stats_links.sessions_for_platform(pc.id, YEAR, pc.name))
     assert url in rendered["html"]
 
 

--- a/tests/test_stats_content_links.py
+++ b/tests/test_stats_content_links.py
@@ -79,14 +79,17 @@ def test_unfinished_count_links_to_unfinished_purchases(rendered):
 
 
 def test_platform_row_links_to_platform_sessions(rendered):
-    url = _href(stats_links.sessions_for_platform(rendered["pc"].id, YEAR))
+    # the rendered link embeds the platform name as a display label (#224)
+    pc = rendered["pc"]
+    url = _href(stats_links.sessions_for_platform(pc.id, YEAR, pc.name))
     assert url in rendered["html"]
 
 
 def test_game_row_has_session_link(rendered):
-    # at least one games-by-playtime game links to its sessions
+    # at least one games-by-playtime game links to its sessions, with the game
+    # name embedded as a display label (#224)
     any_game = rendered["games"][0]
-    url = _href(stats_links.sessions_for_game(any_game.id, YEAR))
+    url = _href(stats_links.sessions_for_game(any_game.id, YEAR, any_game.name))
     assert url in rendered["html"]
 
 

--- a/tests/test_stats_links.py
+++ b/tests/test_stats_links.py
@@ -123,6 +123,18 @@ def test_sessions_for_game_embeds_label(world):
     assert payload["game"]["value"] == [{"id": game.id, "label": game.name}]
 
 
+def test_sessions_for_platform_embeds_label(world):
+    """The platform name rides into the nested game_filter.platform criterion so
+    the session bar's cross-entity platform pill renders a name (#224)."""
+    platform = world["pc"]
+    payload = stats_links.sessions_for_platform(
+        platform.id, YEAR, platform.name
+    ).to_json()
+    assert payload["game_filter"]["platform"]["value"] == [
+        {"id": platform.id, "label": platform.name}
+    ]
+
+
 def test_sessions_for_game_without_label_stays_bare(world):
     """No label given -> serialization is unchanged (bare id)."""
     game = world["finished_game"]

--- a/tests/test_stats_links.py
+++ b/tests/test_stats_links.py
@@ -123,16 +123,6 @@ def test_sessions_for_game_embeds_label(world):
     assert payload["game"]["value"] == [{"id": game.id, "label": game.name}]
 
 
-def test_sessions_for_platform_embeds_label(world):
-    platform = world["pc"]
-    payload = stats_links.sessions_for_platform(
-        platform.id, YEAR, platform.name
-    ).to_json()
-    assert payload["game_filter"]["platform"]["value"] == [
-        {"id": platform.id, "label": platform.name}
-    ]
-
-
 def test_sessions_for_game_without_label_stays_bare(world):
     """No label given -> serialization is unchanged (bare id)."""
     game = world["finished_game"]

--- a/tests/test_stats_links.py
+++ b/tests/test_stats_links.py
@@ -115,6 +115,31 @@ def test_sessions_for_platform_matches_year_scoped_sessions(world):
     )
 
 
+def test_sessions_for_game_embeds_label(world):
+    """A game session-link carries the game name as a display label so the
+    destination filter bar renders a named pill, not a bare id (#224)."""
+    game = world["finished_game"]
+    payload = stats_links.sessions_for_game(game.id, YEAR, game.name).to_json()
+    assert payload["game"]["value"] == [{"id": game.id, "label": game.name}]
+
+
+def test_sessions_for_platform_embeds_label(world):
+    platform = world["pc"]
+    payload = stats_links.sessions_for_platform(
+        platform.id, YEAR, platform.name
+    ).to_json()
+    assert payload["game_filter"]["platform"]["value"] == [
+        {"id": platform.id, "label": platform.name}
+    ]
+
+
+def test_sessions_for_game_without_label_stays_bare(world):
+    """No label given -> serialization is unchanged (bare id)."""
+    game = world["finished_game"]
+    payload = stats_links.sessions_for_game(game.id, YEAR).to_json()
+    assert payload["game"]["value"] == [game.id]
+
+
 def test_sessions_in_month_matches_that_month(world):
     expected = Session.objects.filter(
         timestamp_start__year=YEAR, timestamp_start__month=6


### PR DESCRIPTION
## Context

Closes #224.

The advanced filter bar prefills its widgets from the `?filter=` URL JSON. Set-criterion pills (platform / game / device) need a display **label** to render a name ("PlayStation") rather than a bare id ("5").

- **Client-built filters + presets already work** — the TS serializer emits `{id, label}` and presets store that raw JSON verbatim.
- **Server-built stats-page links did not** — `stats_links.py` builds criteria with bare ids; `filter_to_json` → `_Criterion.to_json` emitted bare ids only. Landing on such a link showed a pill labelled "5".

## Approach

Embed `{id, label}` in the stats-link JSON (Stash-style, consistent with how presets already round-trip). Labels are **display-only**: `to_q` never reads them and `from_json` strips them, so the query is unchanged. The one trade-off — a label can go stale if the record is renamed before the link is regenerated (cosmetic; the id-based query stays correct) — is documented in a **single** place (`_SetCriterion.labels` / `to_json`).

## Changes

- `common/criteria.py` — `_SetCriterion` gains a display-only `labels` map (`compare=False`) and a `to_json` override that folds known labels into the `{id, label}` wire shape; bare ids and enum criteria serialize exactly as before.
- `games/views/stats_links.py` — `sessions_for_game` / `sessions_for_platform` accept an optional `label` and build a labelled `MultiCriterion`.
- `games/views/stats_content.py` — passes the names already in hand (`game.name`, `item["platform_name"]`); **no new queries**.
- Read side untouched: `_extract_labeled` already handles `{id, label}`.

## Tests

- `to_json` label embed / bare / unlabelled-element / round-trip-strips, and labels-don't-affect-query (`test_filters.py`).
- ChoiceCriterion `to_json` still emits bare codes.
- Stats-link builders embed labels; bare when no label given (`test_stats_links.py`).
- End-to-end: a labelled stats-link prefills a labelled `FilterChoice` (`test_filter_bar_labels.py`).
- Updated 2 expectation tests in `test_stats_content_links.py` to match the now-labelled rendered links.

## Verification

`make check` equivalent all green: ruff ✓ · mypy ✓ · ts-check ✓ · vitest (48) ✓ · pytest incl. parity + cross-language filter-tree contract ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)