### PR TITLE
feat(filters): cross-entity platform widget in the session bar

### DIFF
--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -1249,6 +1249,12 @@ def _session_fields(existing: dict) -> list:
 
     game_choice = _filter_get_choice(existing, "game")
     device_choice = _filter_get_choice(existing, "device")
+    # Cross-entity: a session's platform lives on its game, so the widget
+    # serializes into a game_filter EXISTS sub-filter (mirrors the game bar's
+    # device widget). Prefill reads it back from existing["AND"] by the same path.
+    platform_choice = _choice_from_raw(
+        _cross_entity_criterion(existing, ["game_filter", "platform"])
+    )
     note_value = existing.get("note", {}).get("value", "")
     note_modifier = existing.get("note", {}).get("modifier", "EQUALS")
 
@@ -1276,6 +1282,16 @@ def _session_fields(existing: dict) -> list:
                     device_choice,
                     search_url="/api/devices/search",
                     nullable=Session._meta.get_field("device").null,
+                ),
+            ),
+            _filter_field(
+                "Platform",
+                _model_filter(
+                    "platform",
+                    platform_choice,
+                    search_url="/api/platforms/search",
+                    nullable=Game._meta.get_field("platform").null,
+                    path=["game_filter", "platform"],
                 ),
             ),
             _filter_field(

--- a/games/views/stats_content.py
+++ b/games/views/stats_content.py
@@ -403,7 +403,9 @@ def stats_content(ctx: StatsData) -> Node:
             ctx.get("total_playtime_per_platform") or [],
             lambda item: A(
                 href=filter_url(
-                    stats_links.sessions_for_platform(item["platform_id"], year)
+                    stats_links.sessions_for_platform(
+                        item["platform_id"], year, item["platform_name"] or ""
+                    )
                 ),
                 class_="hover:underline decoration-dotted",
             )[item["platform_name"] or "Unspecified"],

--- a/games/views/stats_links.py
+++ b/games/views/stats_links.py
@@ -68,9 +68,15 @@ def sessions_for_game(game_id: int, year, label: str = "") -> SessionFilter:
     return session_filter
 
 
-def sessions_for_platform(platform_id: int, year) -> SessionFilter:
+def sessions_for_platform(platform_id: int, year, label: str = "") -> SessionFilter:
+    # See sessions_for_game: the platform name rides along as a display label so
+    # the session bar's (cross-entity) platform pill renders a name, not an id.
     session_filter = SessionFilter.where(**_session_bounds(year))
-    session_filter.game_filter = GameFilter.where(platform=[platform_id])
+    session_filter.game_filter = GameFilter(
+        platform=MultiCriterion(
+            value=[platform_id], labels={platform_id: label} if label else {}
+        )
+    )
     return session_filter
 
 

--- a/tests/test_filter_cross_entity.py
+++ b/tests/test_filter_cross_entity.py
@@ -18,12 +18,21 @@ from datetime import date, datetime, timezone
 
 import pytest
 
-from common.components.filters import FilterBar, PurchaseFilterBar
+from common.components.filters import FilterBar, PurchaseFilterBar, SessionFilterBar
 from games.filters import (
     parse_game_filter,
     parse_purchase_filter,
+    parse_session_filter,
 )
 from games.models import Device, Game, Platform, PlayEvent, Purchase, Session
+
+
+def _session_ids(filter_json: str) -> set[int]:
+    parsed = parse_session_filter(filter_json)
+    assert parsed is not None
+    return set(
+        Session.objects.filter(parsed.to_q()).distinct().values_list("id", flat=True)
+    )
 
 
 def _dt(year=2024, month=6, day=1):
@@ -500,6 +509,41 @@ def test_game_bar_prefills_device_from_and(db):
     html = str(FilterBar(filter_json))
     # the included pill renders the device label
     assert "SteamDeck" in html
+
+
+def test_session_bar_platform_widget_json_selects_sessions(db):
+    """The session bar's cross-entity platform widget emits
+    AND→game_filter→platform and selects sessions on that platform."""
+    pc = Platform.objects.create(name="PC")
+    switch = Platform.objects.create(name="Switch")
+    on_pc = Game.objects.create(name="On PC", platform=pc)
+    on_switch = Game.objects.create(name="On Switch", platform=switch)
+    pc_session = Session.objects.create(game=on_pc, timestamp_start=_dt())
+    Session.objects.create(game=on_switch, timestamp_start=_dt())
+    filter_json = json.dumps(
+        {"AND": [{"game_filter": {"platform": _set_criterion(str(pc.id), "PC")}}]}
+    )
+    assert _session_ids(filter_json) == {pc_session.id}
+
+
+def test_session_bar_prefills_platform_from_and(db):
+    """The session bar reads a game_filter→platform AND element back and renders
+    a labelled platform pill (the consumer for sessions_for_platform's #224
+    embedded label)."""
+    platform = Platform.objects.create(name="MegaDrive")
+    filter_json = json.dumps(
+        {
+            "AND": [
+                {
+                    "game_filter": {
+                        "platform": _set_criterion(str(platform.id), "MegaDrive")
+                    }
+                }
+            ]
+        }
+    )
+    html = str(SessionFilterBar(filter_json))
+    assert "MegaDrive" in html
 
 
 def test_game_bar_prefills_purchase_type_from_and(db):

--- a/tests/test_filter_paths.py
+++ b/tests/test_filter_paths.py
@@ -109,7 +109,7 @@ class _BarCase(NamedTuple):
 # resolution check below skips kind=="field-comparison".
 _BAR_CASES = [
     _BarCase("game", FilterBar, GameFilter, 24),
-    _BarCase("session", SessionFilterBar, SessionFilter, 9),
+    _BarCase("session", SessionFilterBar, SessionFilter, 10),
     _BarCase("purchase", PurchaseFilterBar, PurchaseFilter, 15),
     _BarCase("device", DeviceFilterBar, DeviceFilter, 2),
     _BarCase("platform", PlatformFilterBar, PlatformFilter, 3),

--- a/tests/test_stats_content_links.py
+++ b/tests/test_stats_content_links.py
@@ -79,7 +79,9 @@ def test_unfinished_count_links_to_unfinished_purchases(rendered):
 
 
 def test_platform_row_links_to_platform_sessions(rendered):
-    url = _href(stats_links.sessions_for_platform(rendered["pc"].id, YEAR))
+    # the rendered link embeds the platform name as a display label (#224)
+    pc = rendered["pc"]
+    url = _href(stats_links.sessions_for_platform(pc.id, YEAR, pc.name))
     assert url in rendered["html"]
 
 

--- a/tests/test_stats_links.py
+++ b/tests/test_stats_links.py
@@ -123,6 +123,18 @@ def test_sessions_for_game_embeds_label(world):
     assert payload["game"]["value"] == [{"id": game.id, "label": game.name}]
 
 
+def test_sessions_for_platform_embeds_label(world):
+    """The platform name rides into the nested game_filter.platform criterion so
+    the session bar's cross-entity platform pill renders a name (#224)."""
+    platform = world["pc"]
+    payload = stats_links.sessions_for_platform(
+        platform.id, YEAR, platform.name
+    ).to_json()
+    assert payload["game_filter"]["platform"]["value"] == [
+        {"id": platform.id, "label": platform.name}
+    ]
+
+
 def test_sessions_for_game_without_label_stays_bare(world):
     """No label given -> serialization is unchanged (bare id)."""
     game = world["finished_game"]


### PR DESCRIPTION
## Context

Follow-up to #229 (issue #224). The stats **"Platforms by playtime"** rows link to the session list filtered by platform, but the session filter bar had no platform widget — so the constraint applied invisibly and could not be edited or shown as a pill. This was the missing consumer for the platform display-label that #224 wanted to embed.

> ⚠️ **Stacked on #229** — base branch is `fix/224-set-criterion-label-rehydration` (it depends on that PR's `_SetCriterion.labels` infra). Retarget to `main` once #229 merges.

## Changes

- **`common/components/filters.py`** — add a **Platform** widget to `_session_fields`. A session's platform lives on its game, so it's cross-entity: serializes into a `game_filter` EXISTS sub-filter at path `["game_filter", "platform"]` (mirrors the game bar's Device widget over `session_filter`); prefill reads it back from the canonicalized `AND` list via `_cross_entity_criterion`.
- **`games/views/stats_links.py`** — `sessions_for_platform` regains its optional `label`, building a labelled `MultiCriterion` on the nested platform criterion.
- **`games/views/stats_content.py`** — passes the platform name it already has on hand.
- **No client/TS change** — `filter-bar.ts` already serializes arbitrary cross-entity paths generically.

## Tests

- `test_filter_cross_entity.py` — the platform widget's JSON selects the right sessions (round-trip via `to_q`); the session bar prefills a labelled platform pill from the `AND` element.
- `test_filter_paths.py` — session bar widget-count inventory bumped 9 → 10.
- `test_stats_links.py` / `test_stats_content_links.py` — `sessions_for_platform` embeds the platform label; rendered href carries it.

## Verification

ruff ✓ · mypy ✓ · ts-check ✓ · vitest (48) ✓ · pytest **1172 passed** (incl. cross-entity round-trip + parity + cross-language contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)