### PR TITLE
fix(filters): data-drive field-comparison operators + contract-guard behavioral tokens (#152)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ dist/
 /games/static/js/dist/
 /ts/generated/
 /ts/elements/filter-tree/fixtures.canonical.json
+/ts/elements/filter-tokens.canonical.json
 .claude/

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -1660,6 +1660,7 @@ class ComparableColumn(TypedDict):
     value: str  # column name, e.g. "timestamp_end"
     label: str  # field verbose_name, title-cased, e.g. "Timestamp End"
     group: ComparisonGroup
+    operators: list[str]  # Modifier values valid for this column's group (#152)
 
 
 def comparable_columns(model: type[models.Model]) -> list[ComparableColumn]:
@@ -1680,7 +1681,16 @@ def comparable_columns(model: type[models.Model]) -> list[ComparableColumn]:
             continue
         verbose_name = getattr(model_field, "verbose_name", column)
         columns.append(
-            ComparableColumn(value=column, label=verbose_name.title(), group=group)
+            ComparableColumn(
+                value=column,
+                label=verbose_name.title(),
+                group=group,
+                # Send the allowed operators as data so the TS widget renders them
+                # directly instead of re-deriving the group->operators mapping (#152).
+                operators=[
+                    modifier.value for modifier in _allowed_comparison_modifiers(group)
+                ],
+            )
         )
     columns.sort(key=lambda entry: entry["label"].lower())
     return columns

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -1653,6 +1653,9 @@ def _comparison_group_for(model: type[models.Model], column: str) -> ComparisonG
     return group
 
 
+type ModifierValue = str  # a Modifier.value, e.g. "INCLUDES"
+
+
 class ComparableColumn(TypedDict):
     """A model column that can take part in a field-to-field comparison, ready for
     a picker: its field name, a human label, and its comparison group."""
@@ -1660,7 +1663,7 @@ class ComparableColumn(TypedDict):
     value: str  # column name, e.g. "timestamp_end"
     label: str  # field verbose_name, title-cased, e.g. "Timestamp End"
     group: ComparisonGroup
-    operators: list[str]  # Modifier values valid for this column's group (#152)
+    operators: list[ModifierValue]  # valid for this column's group (#152)
 
 
 def comparable_columns(model: type[models.Model]) -> list[ComparableColumn]:

--- a/e2e/test_field_comparison_e2e.py
+++ b/e2e/test_field_comparison_e2e.py
@@ -126,6 +126,32 @@ def test_dependent_options_and_and_mode(live_server, page):
 
 @pytest.mark.django_db
 @override_settings(ROOT_URLCONF="e2e.test_field_comparison_e2e")
+def test_operator_options_track_column_group(live_server, page):
+    """The operator <select> is filled from the chosen column's server-supplied
+    `operators` (#152), so each comparison group offers the right set: bool is
+    equality-only, string adds containment, ordered groups have neither extreme."""
+    page.goto(live_server.url + "/test-fc-empty/")
+    page.locator("[data-fc-add]").click()
+    row = page.locator("[data-fc-row]").first
+    left = row.locator("[data-fc-left]")
+    operator = row.locator("[data-fc-op]")
+
+    # bool column (emulated) -> EQUALS / NOT_EQUALS only.
+    left.select_option("emulated")
+    assert operator.locator('option[value="EQUALS"]').count() == 1
+    assert operator.locator('option[value="NOT_EQUALS"]').count() == 1
+    assert operator.locator('option[value="GREATER_THAN"]').count() == 0
+    assert operator.locator('option[value="INCLUDES"]').count() == 0
+
+    # string column (note) -> ordered + containment.
+    left.select_option("note")
+    assert operator.locator('option[value="INCLUDES"]').count() == 1
+    assert operator.locator('option[value="EXCLUDES"]').count() == 1
+    assert operator.locator('option[value="GREATER_THAN"]').count() == 1
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF="e2e.test_field_comparison_e2e")
 def test_or_mode_serializes_isolated_wrapper(live_server, page):
     page.goto(live_server.url + "/test-fc-empty/")
     page.locator("[data-fc-add]").click()

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -710,6 +710,14 @@ class FieldComparisonWidgetTest(TestCase):
         self.assertIn("timestamp_start", html)
         self.assertIn('mode="AND"', html)
 
+    def test_columns_prop_carries_operators(self):
+        # Each column ships its allowed operators as data (#152) so the TS widget
+        # renders them directly; the key + a representative ordered op reach the
+        # serialized attribute (JSON key/value text survives attribute escaping).
+        html = str(SessionFilterBar(filter_json=""))
+        self.assertIn("operators", html)
+        self.assertIn("LESS_THAN", html)
+
     def test_no_double_escaped_markup(self):
         # The columns JSON attribute must not introduce escaped element markup.
         html = str(SessionFilterBar(filter_json=""))

--- a/tests/test_filter_tokens_contract.py
+++ b/tests/test_filter_tokens_contract.py
@@ -1,0 +1,56 @@
+"""Cross-language contract for the behavioral filter tokens (#152).
+
+The TS vitest suite emits filter-tokens.canonical.json = the actual token arrays
+ts/elements/filter-tokens.ts exports. This test asserts every token is a real
+``common.criteria.Modifier`` value, so a renamed/removed Python modifier fails CI
+instead of silently orphaning a TS literal (the #141 failure mode). Membership —
+not set-identity — is the contract: *which* tokens are presence/range is a TS UI
+decision; that each names a live Modifier is the cross-language invariant.
+
+Skipped if the artifact is missing (run ``make test-ts`` first); ``make check``
+orders test-ts before this so the gate always sees fresh output. Mirrors
+tests/test_filter_tree_contract.py.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from common.criteria import Modifier
+
+CANONICAL_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "ts"
+    / "elements"
+    / "filter-tokens.canonical.json"
+)
+
+MODIFIER_VALUES = {modifier.value for modifier in Modifier}
+
+
+def test_canonical_artifact_present_under_ci():
+    """In CI the artifact MUST exist (``make test-ts`` runs before pytest), so a
+    pipeline that forgets to generate it fails loudly here instead of letting the
+    contract test below silently skip."""
+    if os.environ.get("CI"):
+        assert CANONICAL_PATH.exists(), (
+            "filter-tokens.canonical.json missing under CI — `make test-ts` must "
+            "run before pytest"
+        )
+
+
+@pytest.mark.skipif(
+    not CANONICAL_PATH.exists(),
+    reason="filter-tokens.canonical.json missing — run `make test-ts` first",
+)
+def test_behavioral_tokens_are_real_modifiers():
+    tokens = json.loads(CANONICAL_PATH.read_text())
+    flattened = [(group, value) for group, values in tokens.items() for value in values]
+    assert flattened, "no tokens emitted — the TS artifact is empty"
+    for group, value in flattened:
+        assert value in MODIFIER_VALUES, (
+            f"{group} token {value!r} is not a common.criteria.Modifier value — "
+            "the TS token drifted from the Python enum (#152)"
+        )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -2604,6 +2604,19 @@ class TestComparableColumns:
         ]
         assert columns["mastered"]["operators"] == ["EQUALS", "NOT_EQUALS"]
 
+    def test_operators_for_datetime_and_date_groups(self):
+        """Close the group matrix: datetime (Session) and date (Purchase) carry
+        the ordered-only operator set, like number."""
+        from games.models import Purchase, Session
+
+        from common.criteria import _allowed_comparison_modifiers
+
+        ordered = [
+            modifier.value for modifier in _allowed_comparison_modifiers("number")
+        ]
+        assert self._by_value(Session)["timestamp_end"]["operators"] == ordered
+        assert self._by_value(Purchase)["date_purchased"]["operators"] == ordered
+
     def test_known_game_columns(self):
         from games.models import Game
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -2580,11 +2580,29 @@ class TestComparableColumns:
     def _by_value(self, model):
         return {entry["value"]: entry for entry in comparable_columns(model)}
 
-    def test_entries_have_value_label_group_keys(self):
+    def test_entries_have_value_label_group_operators_keys(self):
         from games.models import Game
 
         for entry in comparable_columns(Game):
-            assert set(entry.keys()) == {"value", "label", "group"}
+            assert set(entry.keys()) == {"value", "label", "group", "operators"}
+
+    def test_operators_match_allowed_comparison_modifiers(self):
+        """Each column carries the server-derived operator list (#152) so the TS
+        widget renders it directly instead of re-deriving group->operators."""
+        from games.models import Game
+
+        from common.criteria import _allowed_comparison_modifiers
+
+        columns = self._by_value(Game)
+        # string adds containment; number is ordered-only; bool is equality-only.
+        assert columns["name"]["operators"] == [
+            modifier.value for modifier in _allowed_comparison_modifiers("string")
+        ]
+        assert "INCLUDES" in columns["name"]["operators"]
+        assert columns["year_released"]["operators"] == [
+            modifier.value for modifier in _allowed_comparison_modifiers("number")
+        ]
+        assert columns["mastered"]["operators"] == ["EQUALS", "NOT_EQUALS"]
 
     def test_known_game_columns(self):
         from games.models import Game

--- a/ts/elements/field-comparison-set.ts
+++ b/ts/elements/field-comparison-set.ts
@@ -3,10 +3,10 @@
  *
  * Drives common/components/filters.py FieldComparisonSet. Each row's left column
  * is server-rendered with the full column option set; this module fills the
- * operator and right-column selects from the chosen left column's comparison
- * group (mirroring the server's _allowed_comparison_modifiers / same-group rule),
- * restoring any saved value stashed in data-selected. The set's rows + AND/OR
- * mode are read back by filter-bar.ts on Apply (see readFieldComparisonSet).
+ * operator select from the chosen column's server-supplied `operators` list and
+ * the right-column select from the same-group columns, restoring any saved value
+ * stashed in data-selected. The set's rows + AND/OR mode are read back by
+ * filter-bar.ts on Apply (see readFieldComparisonSet).
  *
  * The single-row logic (refreshRow) is intentionally separable from the set
  * container so the nested boolean builder (#168) can reuse it inside a group.
@@ -17,6 +17,7 @@ interface Column {
   value: string;
   label: string;
   group: string;
+  operators: string[]; // server-supplied allowed operators (#152)
 }
 
 export interface ComparisonRow {
@@ -26,8 +27,11 @@ export interface ComparisonRow {
   granularity?: "date"; // omitted when "raw" to keep filter JSON compact
 }
 
-// Operator labels by Modifier value — must match the modifiers the server
-// accepts per group (common/criteria.py _allowed_comparison_modifiers).
+// Presentation-only glyphs for the operator tokens the server sends. Not a
+// source of truth for *which* operators are valid — that's the per-column
+// `operators` list (server-derived from _allowed_comparison_modifiers). A token
+// with no glyph here falls back to its raw value, so an added operator still
+// renders.
 const OPERATOR_LABELS: Record<string, string> = {
   EQUALS: "=",
   NOT_EQUALS: "≠",
@@ -38,26 +42,6 @@ const OPERATOR_LABELS: Record<string, string> = {
   INCLUDES: "contains",
   EXCLUDES: "doesn't contain",
 };
-
-const ORDERED = [
-  "EQUALS",
-  "NOT_EQUALS",
-  "GREATER_THAN",
-  "LESS_THAN",
-  "GREATER_THAN_OR_EQUAL",
-  "LESS_THAN_OR_EQUAL",
-];
-
-function operatorsForGroup(group: string): string[] {
-  if (group === "bool") return ["EQUALS", "NOT_EQUALS"];
-  if (group === "string") return [...ORDERED, "INCLUDES", "EXCLUDES"];
-  return ORDERED;
-}
-
-function groupOf(columns: Column[], value: string): string | null {
-  const column = columns.find((candidate) => candidate.value === value);
-  return column ? column.group : null;
-}
 
 function fillSelect(
   select: HTMLSelectElement,
@@ -93,7 +77,8 @@ function refreshRow(row: HTMLElement, columns: Column[]): void {
   operator.removeAttribute("data-selected");
   right.removeAttribute("data-selected");
 
-  const group = groupOf(columns, left.value);
+  const leftColumn = columns.find((column) => column.value === left.value) ?? null;
+  const group = leftColumn?.group ?? null;
 
   // Day-granular toggle is only meaningful for datetime operands.
   const granularityWrap = row.querySelector<HTMLElement>("[data-fc-granularity-wrap]");
@@ -102,7 +87,7 @@ function refreshRow(row: HTMLElement, columns: Column[]): void {
   if (granularityWrap) granularityWrap.hidden = !isDatetime;
   if (granularityInput && !isDatetime) granularityInput.checked = false;
 
-  if (!group) {
+  if (!leftColumn || !group) {
     fillSelect(operator, [], "", "—");
     fillSelect(right, [], "", "column…");
     operator.disabled = true;
@@ -113,7 +98,7 @@ function refreshRow(row: HTMLElement, columns: Column[]): void {
   right.disabled = false;
   fillSelect(
     operator,
-    operatorsForGroup(group).map((modifier) => [modifier, OPERATOR_LABELS[modifier]]),
+    leftColumn.operators.map((modifier) => [modifier, OPERATOR_LABELS[modifier] ?? modifier]),
     operatorSaved,
     "—",
   );

--- a/ts/elements/field-comparison-set.ts
+++ b/ts/elements/field-comparison-set.ts
@@ -31,7 +31,10 @@ export interface ComparisonRow {
 // source of truth for *which* operators are valid — that's the per-column
 // `operators` list (server-derived from _allowed_comparison_modifiers). A token
 // with no glyph here falls back to its raw value, so an added operator still
-// renders.
+// renders. Intentionally NOT contract-guarded against the Python enum: these are
+// labels, not vocabulary, so a renamed modifier degrades to its raw token (e.g.
+// "GREATER_THAN" instead of ">") rather than breaking — acceptable for a
+// cosmetic map.
 const OPERATOR_LABELS: Record<string, string> = {
   EQUALS: "=",
   NOT_EQUALS: "≠",
@@ -96,9 +99,13 @@ function refreshRow(row: HTMLElement, columns: Column[]): void {
   }
   operator.disabled = false;
   right.disabled = false;
+  // `?? []` defends against a columns prop missing `operators` (server/client
+  // skew, a stale cached page): degrade to an empty operator list rather than
+  // throwing mid-loop and leaving the rest of the rows unwired.
+  const operators = leftColumn.operators ?? [];
   fillSelect(
     operator,
-    leftColumn.operators.map((modifier) => [modifier, OPERATOR_LABELS[modifier] ?? modifier]),
+    operators.map((modifier) => [modifier, OPERATOR_LABELS[modifier] ?? modifier]),
     operatorSaved,
     "—",
   );

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -7,6 +7,7 @@
  */
 import { readFilterBarProps } from "../generated/props.js";
 import { readFieldComparisonSet } from "./field-comparison-set.js";
+import { isPresenceModifier, isRangeModifier } from "./filter-tokens.js";
 import { readSearchSelect } from "./search-select.js";
 
 interface Criterion {
@@ -140,7 +141,7 @@ function readStringWidget(element: HTMLElement): Record<string, unknown> | null 
   const modifier =
     element.querySelector<HTMLInputElement>('input[data-string-modifier-radio]:checked')
       ?.value ?? "EQUALS";
-  if (modifier === "IS_NULL" || modifier === "NOT_NULL") {
+  if (isPresenceModifier(modifier)) {
     return { modifier };
   }
   const textInput = element.querySelector<HTMLInputElement>('input[type="text"]');
@@ -154,13 +155,13 @@ function readNumberWidget(element: HTMLElement): Criterion | Record<string, unkn
   const modifier =
     element.querySelector<HTMLInputElement>('input[data-number-modifier-radio]:checked')
       ?.value ?? "EQUALS";
-  if (modifier === "IS_NULL" || modifier === "NOT_NULL") {
+  if (isPresenceModifier(modifier)) {
     return { modifier };
   }
   const value = parseNumberInputValue(
     element.querySelector<HTMLInputElement>('input[type="number"]:not([data-number-value2])'),
   );
-  if (modifier === "BETWEEN" || modifier === "NOT_BETWEEN") {
+  if (isRangeModifier(modifier)) {
     const value2Marker = element.querySelector('[data-number-value2]');
     const value2Input =
       value2Marker instanceof HTMLInputElement
@@ -192,8 +193,7 @@ function readSetWidget(element: HTMLElement): Record<string, unknown> | null {
   const included = parseJSONAttr<PillEntry>(element, "data-included");
   const excluded = parseJSONAttr<PillEntry>(element, "data-excluded");
   const modifier = element.getAttribute("data-modifier");
-  const isPresence = modifier === "NOT_NULL" || modifier === "IS_NULL";
-  if (isPresence) {
+  if (modifier && isPresenceModifier(modifier)) {
     return { modifier };
   }
   if (included.length > 0 || excluded.length > 0) {

--- a/ts/elements/filter-tokens.test.ts
+++ b/ts/elements/filter-tokens.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Cross-language contract artifact for the behavioral filter tokens (#152).
+ *
+ * Writes filter-tokens.canonical.json = the actual token arrays this module
+ * exports. `tests/test_filter_tokens_contract.py` reads it and asserts every
+ * token is a real `common.criteria.Modifier`, so a renamed/removed Python
+ * modifier fails CI instead of orphaning a TS literal (the #141 failure mode).
+ * Mirrors how serializer.test.ts emits fixtures.canonical.json.
+ */
+import { describe, it, expect } from "vitest";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  PRESENCE_MODIFIERS,
+  RANGE_MODIFIERS,
+  isPresenceModifier,
+  isRangeModifier,
+} from "./filter-tokens.js";
+
+describe("filter behavioral tokens", () => {
+  it("presence/range membership helpers reflect their token sets", () => {
+    expect(isPresenceModifier("IS_NULL")).toBe(true);
+    expect(isPresenceModifier("EQUALS")).toBe(false);
+    expect(isRangeModifier("BETWEEN")).toBe(true);
+    expect(isRangeModifier("EQUALS")).toBe(false);
+  });
+
+  it("writes the canonical artifact for the Python contract", () => {
+    const tokens = {
+      PRESENCE_MODIFIERS: [...PRESENCE_MODIFIERS],
+      RANGE_MODIFIERS: [...RANGE_MODIFIERS],
+    };
+    const canonicalPath = fileURLToPath(
+      new URL("./filter-tokens.canonical.json", import.meta.url),
+    );
+    writeFileSync(canonicalPath, JSON.stringify(tokens, null, 2));
+    expect(tokens.PRESENCE_MODIFIERS.length).toBeGreaterThan(0);
+    expect(tokens.RANGE_MODIFIERS.length).toBeGreaterThan(0);
+  });
+});

--- a/ts/elements/filter-tokens.test.ts
+++ b/ts/elements/filter-tokens.test.ts
@@ -20,9 +20,14 @@ import {
 
 describe("filter behavioral tokens", () => {
   it("presence/range membership helpers reflect their token sets", () => {
+    // Pin every token individually so accidentally dropping one (e.g. NOT_BETWEEN,
+    // which no e2e exercises) fails here rather than silently regressing the
+    // value2 read / value-less-criterion behavior keyed on it.
     expect(isPresenceModifier("IS_NULL")).toBe(true);
+    expect(isPresenceModifier("NOT_NULL")).toBe(true);
     expect(isPresenceModifier("EQUALS")).toBe(false);
     expect(isRangeModifier("BETWEEN")).toBe(true);
+    expect(isRangeModifier("NOT_BETWEEN")).toBe(true);
     expect(isRangeModifier("EQUALS")).toBe(false);
   });
 

--- a/ts/elements/filter-tokens.ts
+++ b/ts/elements/filter-tokens.ts
@@ -1,0 +1,28 @@
+/**
+ * Behavioral filter-modifier tokens the TS widgets branch on (#152).
+ *
+ * These are NOT the filter vocabulary — that flows from the server as data
+ * (data-kind, server-rendered modifier rows, the field-comparison `operators`
+ * list). These are the handful of modifier tokens whose IDENTITY drives client
+ * UI behavior, so they legitimately live in TS:
+ *
+ *   - PRESENCE_MODIFIERS: mutually exclusive with value pills (selecting one
+ *     clears the pills, and adding a pill clears a presence modifier).
+ *   - RANGE_MODIFIERS: reveal the second value input.
+ *
+ * The single TS home for these tokens. `tests/test_filter_tokens_contract.py`
+ * asserts every value here is a real `common.criteria.Modifier`, so a renamed or
+ * removed Python modifier fails CI instead of silently orphaning a literal (the
+ * #141 failure mode).
+ */
+
+export const PRESENCE_MODIFIERS = ["IS_NULL", "NOT_NULL"] as const;
+export const RANGE_MODIFIERS = ["BETWEEN", "NOT_BETWEEN"] as const;
+
+export function isPresenceModifier(modifier: string): boolean {
+  return (PRESENCE_MODIFIERS as readonly string[]).includes(modifier);
+}
+
+export function isRangeModifier(modifier: string): boolean {
+  return (RANGE_MODIFIERS as readonly string[]).includes(modifier);
+}

--- a/ts/elements/filter-tokens.ts
+++ b/ts/elements/filter-tokens.ts
@@ -6,9 +6,12 @@
  * list). These are the handful of modifier tokens whose IDENTITY drives client
  * UI behavior, so they legitimately live in TS:
  *
- *   - PRESENCE_MODIFIERS: mutually exclusive with value pills (selecting one
- *     clears the pills, and adding a pill clears a presence modifier).
- *   - RANGE_MODIFIERS: reveal the second value input.
+ *   - PRESENCE_MODIFIERS: in the set widget, mutually exclusive with value pills
+ *     (selecting one clears the pills, and adding a pill clears a presence
+ *     modifier); in the string/number widgets, serialize to a value-less
+ *     `{ modifier }` criterion (no value/value2).
+ *   - RANGE_MODIFIERS: signal that a second bound (value2) is present and must be
+ *     read and serialized from the number widget's second input.
  *
  * The single TS home for these tokens. `tests/test_filter_tokens_contract.py`
  * asserts every value here is a real `common.criteria.Modifier`, so a renamed or

--- a/ts/elements/search-select.ts
+++ b/ts/elements/search-select.ts
@@ -21,6 +21,8 @@
  * in one place (the Python components), never duplicated here.
  */
 
+import { isPresenceModifier } from "./filter-tokens.js";
+
 // The contract for the "search-select:change" CustomEvent this widget emits.
 // Consumers (e.g. add_purchase.ts) import these types — never redefine them.
 export interface SearchSelectOption {
@@ -52,12 +54,10 @@ interface FilterPillEntry {
 
 const DEBOUNCE_MS = 100;
 
-// Presence modifiers — the sole definition of this set (the former Python
-// _PRESENCE_MODIFIERS constant was removed with its only consumer in #141).
-// They are mutually exclusive with value pills — selecting one clears all
-// value pills.  Non-presence modifiers (INCLUDES_ALL, INCLUDES_ONLY) coexist
-// with value pills.
-const PRESENCE_MODIFIERS = ["NOT_NULL", "IS_NULL"];
+// Presence modifiers (IS_NULL / NOT_NULL) are mutually exclusive with value
+// pills — selecting one clears all value pills. Non-presence modifiers
+// (INCLUDES_ALL, INCLUDES_ONLY) coexist with value pills. The token set lives in
+// ./filter-tokens (contract-guarded against common.criteria.Modifier, #152).
 
 const initWidget = (containerElement: Element) => {
   const container = containerElement as SearchSelectContainer;
@@ -482,7 +482,7 @@ const initWidget = (containerElement: Element) => {
     const modifierPill = pills.querySelector("[data-search-select-modifier]");
     if (modifierPill) {
       const modifierValue = modifierPill.getAttribute("data-search-select-modifier") ?? "";
-      if (PRESENCE_MODIFIERS.includes(modifierValue)) {
+      if (isPresenceModifier(modifierValue)) {
         clearModifier();
       }
     }
@@ -510,7 +510,7 @@ const initWidget = (containerElement: Element) => {
   const setModifier = (modifierValue: string, label: string) => {
     // Remove any existing modifier pill to avoid duplicates.
     clearModifierPill();
-    if (PRESENCE_MODIFIERS.includes(modifierValue)) {
+    if (isPresenceModifier(modifierValue)) {
       pills.innerHTML = "";
     }
     const pill = cloneTemplate("pill-modifier")!;


### PR DESCRIPTION
Closes #152.

## Problem
Filter-vocabulary constants were duplicated across Python (`common/criteria.py`) and the TS filter widgets, kept in sync only by hand-written "must match" comments with no build-time enforcement. #141 surfaced the failure mode (a comment orphaned by a removed Python constant).

## Approach — eliminate at the root, don't synchronize copies
An audit + data-flow trace showed **most "duplication" already flows server→client as data** (widget `kind`, paths, current modifier, server-rendered modifier option lists). The genuine duplication reduced to **two things**:

### Part A — field-comparison operators become data
The one real "must match" mirror: TS `operatorsForGroup` duplicated Python `_allowed_comparison_modifiers`. The per-column `group` was already sent as data; only the mapping was missing.
- `ComparableColumn` gains `operators: list[str]`, filled from `_allowed_comparison_modifiers(group)`, carried in the `columns` JSON the server already serializes.
- `field-comparison-set.ts` reads `column.operators` directly; **deletes** `operatorsForGroup`/`ORDERED`/`groupOf` and the mirror comment. `OPERATOR_LABELS` stays as presentation glyphs with a raw-token fallback (`?? token`).

→ The mapping is now correct-by-construction (one Python source, sent per-request).

### Part B — behavioral tokens guarded by a tiny contract
Tokens TS branches on for UI behavior (not vocabulary): presence `IS_NULL`/`NOT_NULL` (clears value pills), range `BETWEEN`/`NOT_BETWEEN` (second input).
- New `ts/elements/filter-tokens.ts` — one home for these, consumed by `search-select.ts` + `filter-bar.ts`.
- New `filter-tokens.test.ts` emits `filter-tokens.canonical.json`; new `tests/test_filter_tokens_contract.py` asserts every token is a real `common.criteria.Modifier` value. Reuses the existing TS→JSON→pytest harness — **no TS parsing, no dead Python constant**. A renamed/removed Python modifier now fails CI instead of orphaning a TS literal.

## Intentionally NOT done
No `gen_ts_constants` command, committed generated artifact, or Makefile umbrella. The trace showed codegen would over-solve a problem already mostly data-driven, and (per adversarial review) codegen alone wouldn't enforce without the same consumer refactor anyway. `RelationMatch`/widget-`kind`/`MAX_*`/`RESERVED_KEYS`/`ComparisonGranularity` left as-is — already data-driven, already contract-tested, or low-drift with divergent sets.

## Verification
- `make check` passes: lint, mypy, ts-check, vitest, pytest **incl. e2e `test_field_comparison_e2e` (real-browser operator-dropdown flow)** + the new contract. 1298 passed.
- Drift guard proven: a temporary `Modifier.IS_NULL` value rename made the contract test fail with a clear message; reverted → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)