### PR TITLE
feat(filters): recursive group shell custom element (#189)

### DIFF
--- a/common/components/__init__.py
+++ b/common/components/__init__.py
@@ -31,6 +31,7 @@ from common.components.custom_elements import (
     DropdownLinkItem,
     DropdownMenuPanel,
     DropdownSubmenu,
+    FilterGroup,
     ListboxPanel,
     MenuDropdown,
     SelectDropdown,
@@ -254,6 +255,7 @@ __all__ = [
     "StringFilter",
     "NumberFilter",
     "FieldComparisonSet",
+    "FilterGroup",
     "Option",
     "Select",
 ]

--- a/common/components/custom_elements.py
+++ b/common/components/custom_elements.py
@@ -170,6 +170,26 @@ register_element("field-comparison-set", "FieldComparisonSet", FieldComparisonSe
 _FieldComparisonSet = custom_element_builder("field-comparison-set")
 
 
+class FilterGroupProps(TypedDict):
+    model: str  # root model key (e.g. "game"); drives 2d metadata + serialization
+
+
+register_element("filter-group", "FilterGroup", FilterGroupProps)
+_FilterGroup = custom_element_builder("filter-group")
+
+
+def FilterGroup(*, model: str) -> Node:
+    """The recursive nested-filter group shell (issue #189, phase 2c of #168).
+
+    A self-seeding client-built tree: the element starts from an empty root AND
+    group and owns the whole `FilterNode` tree in JS, re-rendering on each
+    restructuring op. Behavior + DOM live in ``ts/elements/filter-group.ts``;
+    the connective/negate UI, leaf widgets, and relation block (sibling 2c
+    components) hydrate the inert slots during 2d assembly. Media (the compiled
+    JS) is attached automatically by ``custom_element_builder``."""
+    return _FilterGroup(model=model)
+
+
 # The <sort-header> builder lives in primitives.py (next to StyledTable, which
 # renders it). Its whole contract is two plain attributes already on the anchor
 # (href + data-shift-href), so the props are empty; registration here is

--- a/common/components/custom_elements.py
+++ b/common/components/custom_elements.py
@@ -171,7 +171,10 @@ _FieldComparisonSet = custom_element_builder("field-comparison-set")
 
 
 class FilterGroupProps(TypedDict):
-    model: str  # root model key (e.g. "game"); drives 2d metadata + serialization
+    # Root model key (e.g. "game"). Reserved for 2d: it will select the field-
+    # metadata registry + serialization model. The element reads it but does not
+    # consume it yet in this phase (#189).
+    model: str
 
 
 register_element("filter-group", "FilterGroup", FilterGroupProps)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@tailwindcss/typography": "^0.5.13",
     "@types/node": "^26.0.1",
     "concurrently": "^8.2.2",
+    "jsdom": "^29.1.1",
     "npm-check-updates": "^16.14.20",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       npm-check-updates:
         specifier: ^16.14.20
         version: 16.14.20
@@ -41,7 +44,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@26.0.1)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0))
+        version: 4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0))
 
 packages:
 
@@ -49,13 +52,68 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -65,6 +123,15 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -625,6 +692,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   boxen@7.1.1:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
@@ -746,10 +816,18 @@ packages:
     resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
     engines: {node: '>=12'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
@@ -763,6 +841,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -810,6 +891,10 @@ packages:
   enhanced-resolve@5.23.0:
     resolution: {integrity: sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==}
     engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -986,6 +1071,10 @@ packages:
     resolution: {integrity: sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -1099,6 +1188,9 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
 
@@ -1122,6 +1214,15 @@ packages:
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1244,6 +1345,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
@@ -1258,6 +1363,9 @@ packages:
   make-fetch-happen@11.1.1:
     resolution: {integrity: sha512-rLWS7GCSTcEujjVBs2YqG7Y4643u8ucvCJeSRqiLYhesrDuzeuFIk37xREzAsfQaqzl8b9rNCE4m6J8tvX4Q8w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1460,6 +1568,9 @@ packages:
     engines: {node: '>= 0.10'}
     hasBin: true
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1531,6 +1642,10 @@ packages:
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   pupa@3.3.0:
     resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
@@ -1628,6 +1743,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   semver-diff@4.0.0:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
@@ -1773,6 +1892,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
@@ -1799,9 +1921,24 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.5:
+    resolution: {integrity: sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==}
+
+  tldts@7.4.5:
+    resolution: {integrity: sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -1832,6 +1969,10 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unique-filename@2.0.1:
     resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
@@ -1955,6 +2096,22 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1995,6 +2152,13 @@ packages:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -2022,10 +2186,58 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
   '@babel/runtime@7.29.7': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@colors/colors@1.5.0':
     optional: true
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -2042,6 +2254,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@exodus/bytes@1.15.1': {}
 
   '@gar/promisify@1.1.3': {}
 
@@ -2527,6 +2741,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   boxen@7.1.1:
     dependencies:
       ansi-align: 3.0.1
@@ -2687,7 +2905,19 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   date-fns@2.30.0:
     dependencies:
@@ -2696,6 +2926,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -2734,6 +2966,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -2921,6 +3155,12 @@ snapshots:
     dependencies:
       lru-cache: 7.18.3
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   http-cache-semantics@4.2.0: {}
 
   http-proxy-agent@5.0.0:
@@ -3014,6 +3254,8 @@ snapshots:
 
   is-path-inside@3.0.3: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-typedarray@1.0.0: {}
 
   is-yarn-global@0.4.1: {}
@@ -3033,6 +3275,32 @@ snapshots:
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-buffer@3.0.1: {}
 
@@ -3117,6 +3385,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.1: {}
+
   lru-cache@7.18.3: {}
 
   magic-string@0.30.21:
@@ -3164,6 +3434,8 @@ snapshots:
       ssri: 10.0.6
     transitivePeerDependencies:
       - supports-color
+
+  mdn-data@2.27.1: {}
 
   merge2@1.4.1: {}
 
@@ -3429,6 +3701,10 @@ snapshots:
 
   parse-github-url@1.0.4: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -3480,6 +3756,8 @@ snapshots:
       sisteransi: 1.0.5
 
   proto-list@1.2.4: {}
+
+  punycode@2.3.1: {}
 
   pupa@3.3.0:
     dependencies:
@@ -3595,6 +3873,10 @@ snapshots:
 
   safer-buffer@2.1.2:
     optional: true
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   semver-diff@4.0.0:
     dependencies:
@@ -3728,6 +4010,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
@@ -3751,9 +4035,23 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.4.5: {}
+
+  tldts@7.4.5:
+    dependencies:
+      tldts-core: 7.4.5
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.5
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -3778,6 +4076,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@8.3.0: {}
+
+  undici@7.28.0: {}
 
   unique-filename@2.0.1:
     dependencies:
@@ -3839,7 +4139,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitest@4.1.9(@types/node@26.0.1)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)):
+  vitest@4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0))
@@ -3863,8 +4163,25 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.0.1
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -3909,6 +4226,10 @@ snapshots:
       typedarray-to-buffer: 3.1.5
 
   xdg-basedir@5.1.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/timetracker/urls.py
+++ b/timetracker/urls.py
@@ -34,3 +34,33 @@ urlpatterns = [
 if settings.DEBUG:
     urlpatterns.append(path("admin/", admin.site.urls))
     urlpatterns.append(path("__debug__/", include("debug_toolbar.urls")))
+
+    # DEBUG-only eyeball page for the #189 <filter-group> shell — bare element,
+    # no auth/navbar, not linked from nav. Visit /filter-group-demo/ under
+    # `make dev`. The route registers only when DEBUG is on, so it cannot leak
+    # into production. Assets are resolved through static() so they load under
+    # the dev server's /static/ prefix (the element's own module imports resolve
+    # relative to its URL). The "Toggle dark" button flips the dark-mode class.
+    from django.http import HttpResponse
+    from django.templatetags.static import static
+
+    from common.components import FilterGroup
+
+    def filter_group_demo(_request: object) -> HttpResponse:
+        stylesheet = static("base.css")
+        module = static("js/dist/elements/filter-group.js")
+        html = (
+            "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+            "<title>filter-group demo</title>"
+            f'<link rel="stylesheet" href="{stylesheet}">'
+            f'<script type="module" src="{module}"></script>'
+            "</head><body class='bg-white p-6 dark:bg-gray-900'>"
+            '<button type="button" onclick="document.documentElement.classList.toggle(\'dark\')" '
+            'class="mb-4 rounded border border-gray-300 px-3 py-1 text-sm '
+            'dark:border-gray-600 dark:text-white">Toggle dark</button>'
+            f'<div style="max-width:760px">{FilterGroup(model="game")}</div>'
+            "</body></html>"
+        )
+        return HttpResponse(html)
+
+    urlpatterns.append(path("filter-group-demo/", filter_group_demo))

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import "./filter-group.js"; // side-effect: customElements.define("filter-group", …)
+import type { FilterGroupElement } from "./filter-group.js";
+
+function mount(): FilterGroupElement {
+  document.body.replaceChildren();
+  const host = document.createElement("filter-group") as FilterGroupElement;
+  host.setAttribute("model", "game");
+  document.body.appendChild(host); // connectedCallback → initial render
+  return host;
+}
+
+function button(host: HTMLElement, action: string, path: number[]): HTMLButtonElement | null {
+  return host.querySelector<HTMLButtonElement>(
+    `button[data-action="${action}"][data-path="${JSON.stringify(path)}"]`,
+  );
+}
+
+function clickAction(host: HTMLElement, action: string, path: number[]): void {
+  const target = button(host, action, path);
+  if (!target) throw new Error(`no ${action} button at ${JSON.stringify(path)}`);
+  target.click();
+}
+
+function slots(host: HTMLElement): HTMLElement[] {
+  return [...host.querySelectorAll<HTMLElement>("[data-node-slot]")];
+}
+
+describe("<filter-group> initial render", () => {
+  it("renders a root AND group with one criterion slot and a footer", () => {
+    const host = mount();
+    const root = host.querySelector('[data-kind="group"][data-path="[]"]');
+    expect(root).not.toBeNull();
+    expect(host.querySelector('[data-slot="connective"]')?.textContent).toBe("AND");
+    expect(slots(host)).toHaveLength(1);
+    expect(slots(host)[0].dataset.nodeKind).toBe("criterion");
+    expect(button(host, "add-condition", [])).not.toBeNull();
+    expect(button(host, "add-group", [])).not.toBeNull();
+    expect(button(host, "add-relation", [])).not.toBeNull();
+  });
+
+  it("gives the root no remove/wrap controls", () => {
+    const host = mount();
+    expect(button(host, "remove", [])).toBeNull();
+    expect(button(host, "wrap", [])).toBeNull();
+  });
+});
+
+describe("<filter-group> footer add buttons", () => {
+  it("+ condition appends a criterion slot", () => {
+    const host = mount();
+    clickAction(host, "add-condition", []);
+    expect(slots(host)).toHaveLength(2);
+  });
+
+  it("+ group nests a group card", () => {
+    const host = mount();
+    clickAction(host, "add-group", []);
+    expect(host.querySelector('[data-kind="group"][data-path="[1]"]')).not.toBeNull();
+  });
+
+  it("+ relation adds a relation slot", () => {
+    const host = mount();
+    clickAction(host, "add-relation", []);
+    const relationSlot = slots(host).find((slot) => slot.dataset.nodeKind === "relation");
+    expect(relationSlot).toBeDefined();
+  });
+});
+
+describe("<filter-group> restructuring", () => {
+  it("remove deletes the addressed node", () => {
+    const host = mount();
+    clickAction(host, "add-condition", []); // two criteria now
+    clickAction(host, "remove", [0]);
+    expect(slots(host)).toHaveLength(1);
+  });
+
+  it("↑/↓ reorder siblings and disable at the ends", () => {
+    const host = mount();
+    clickAction(host, "add-group", []); // [0]=criterion, [1]=group
+    // first child's up is disabled; last child's down is disabled
+    expect(button(host, "up", [0])?.disabled).toBe(true);
+    expect(button(host, "down", [1])?.disabled).toBe(true);
+    clickAction(host, "down", [0]); // criterion moves after the group
+    const kinds = [...host.querySelector('[data-path="[]"]')!.children]
+      .find((child) => child.className.includes("pl-3"))!;
+    expect(kinds.children[0].matches('[data-kind="group"]')).toBe(true);
+  });
+
+  it("wrap nests a node in a new group; unwrap dissolves it", () => {
+    const host = mount();
+    clickAction(host, "wrap", [0]); // the seed criterion → wrapped in a group
+    const wrapper = host.querySelector('[data-kind="group"][data-path="[0]"]');
+    expect(wrapper).not.toBeNull();
+    expect(slots(host)).toHaveLength(1); // still one criterion, now nested
+    clickAction(host, "unwrap", [0]); // dissolve back
+    expect(host.querySelector('[data-kind="group"][data-path="[0]"]')).toBeNull();
+    expect(slots(host)).toHaveLength(1);
+  });
+});
+
+describe("<filter-group> depth cap", () => {
+  it("disables + group / + relation at the soft cap (depth 5)", () => {
+    const host = mount();
+    // Nest groups down the [1,1,1,1,1] spine; each new group seeds a criterion at *,0.
+    const paths = [[], [1], [1, 1], [1, 1, 1], [1, 1, 1, 1]];
+    for (const path of paths) clickAction(host, "add-group", path);
+    const deepest = [1, 1, 1, 1, 1];
+    expect(host.querySelector(`[data-kind="group"][data-path="${JSON.stringify(deepest)}"]`)).not.toBeNull();
+    expect(button(host, "add-group", deepest)?.disabled).toBe(true);
+    expect(button(host, "add-relation", deepest)?.disabled).toBe(true);
+    expect(button(host, "add-condition", deepest)?.disabled).toBeFalsy();
+  });
+});
+
+describe("<filter-group> change event", () => {
+  it("dispatches filter-tree-change carrying the new tree on each edit", () => {
+    const host = mount();
+    const events: GroupNodeLike[] = [];
+    host.addEventListener("filter-tree-change", (event) => {
+      events.push((event as CustomEvent).detail.tree);
+    });
+    clickAction(host, "add-condition", []);
+    expect(events).toHaveLength(1);
+    expect(events[0].children).toHaveLength(2);
+    expect(host.serialize()).toBeTypeOf("object");
+  });
+});
+
+type GroupNodeLike = { children: unknown[] };

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -111,6 +111,8 @@ describe("<filter-group> depth cap", () => {
     expect(button(host, "add-group", deepest)?.disabled).toBe(true);
     expect(button(host, "add-relation", deepest)?.disabled).toBe(true);
     expect(button(host, "add-condition", deepest)?.disabled).toBeFalsy();
+    // the deepest group's own Wrap is disabled too — wrapping it would breach the cap
+    expect(button(host, "wrap", deepest)?.disabled).toBe(true);
   });
 });
 

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -128,4 +128,44 @@ describe("<filter-group> change event", () => {
   });
 });
 
+describe("<filter-group> inert-slot contract (2d hydration)", () => {
+  it("leaf/relation slots carry data-path and a round-trippable data-payload", () => {
+    const host = mount();
+    clickAction(host, "add-relation", []); // [0]=criterion, [1]=relation
+    const relationSlot = slots(host).find((slot) => slot.dataset.nodeKind === "relation")!;
+    expect(relationSlot.dataset.path).toBe(JSON.stringify([1]));
+    expect(JSON.parse(relationSlot.dataset.payload!)).toMatchObject({
+      kind: "relation",
+      field: "",
+      match: "ANY",
+      negate: false,
+    });
+    const criterionSlot = slots(host).find((slot) => slot.dataset.nodeKind === "criterion")!;
+    expect(JSON.parse(criterionSlot.dataset.payload!)).toMatchObject({ kind: "criterion", negate: false });
+  });
+
+  it("the connective slot carries its group path for component 2", () => {
+    const host = mount();
+    expect(host.querySelector<HTMLElement>('[data-slot="connective"]')!.dataset.path).toBe("[]");
+  });
+});
+
+describe("<filter-group> duplicate + event fidelity", () => {
+  it("duplicate adds a sibling copy", () => {
+    const host = mount();
+    clickAction(host, "duplicate", [0]);
+    expect(slots(host)).toHaveLength(2);
+  });
+
+  it("dispatches exactly one change event per effective edit (no spurious)", () => {
+    const host = mount();
+    let count = 0;
+    host.addEventListener("filter-tree-change", () => (count += 1));
+    clickAction(host, "add-condition", []);
+    clickAction(host, "add-group", []);
+    clickAction(host, "remove", [0]);
+    expect(count).toBe(3);
+  });
+});
+
 type GroupNodeLike = { children: unknown[] };

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -1,0 +1,263 @@
+/**
+ * <filter-group> — the recursive group shell of the nested filter builder
+ * (issue #189, phase 2c of #168).
+ *
+ * Holds the whole `FilterNode` tree in JS (the single source of truth the
+ * serializer consumes) and re-renders the DOM from it on every edit. This shell
+ * owns only *structure*: group cards, alternating depth coloring, the soft depth
+ * cap, the footer add-buttons, and the buttons-only restructuring affordances
+ * (remove / duplicate / wrap / unwrap / ↑ / ↓). The connective+negate UI (comp 2),
+ * leaf widgets (comp 3/4), and relation block (comp 5) are sibling 2c components;
+ * here their places are **inert slots** carrying each node's identity + payload,
+ * hydrated during 2d assembly.
+ *
+ * Correctness (every mutation) lives in the pure `filter-tree/operations.ts`
+ * module and is vitest-tested; this file is the thin DOM projection over it.
+ */
+import { readFilterGroupProps } from "../generated/props.js";
+import { serialize } from "./filter-tree/serializer.js";
+import type { Connective, FilterNode, GroupNode } from "./filter-tree/types.js";
+import {
+  type NodePath,
+  canAddGroup,
+  canAddRelation,
+  canUnwrap,
+  canWrap,
+  duplicateAt,
+  emptyCriterion,
+  emptyGroup,
+  emptyRelation,
+  emptyRoot,
+  insertChild,
+  move,
+  removeAt,
+  unwrapGroup,
+  wrapInGroup,
+} from "./filter-tree/operations.js";
+
+// Full, static class strings only — Tailwind detects complete strings, so the
+// depth palette is a fixed lookup (never `bg-depth-${n}`). ~4-shade cycle (Qui).
+const DEPTH_BACKGROUNDS = [
+  "bg-gray-50 dark:bg-gray-900/40",
+  "bg-white dark:bg-gray-800/40",
+  "bg-gray-100 dark:bg-gray-800/20",
+  "bg-white dark:bg-gray-700/20",
+];
+const CARD_CLASS = "flex flex-col gap-2 rounded-lg border border-gray-200 p-2 dark:border-gray-700";
+const HEADER_CLASS = "flex items-center justify-between gap-2";
+const CHILDREN_CLASS = "flex flex-col gap-2 pl-3";
+const FOOTER_CLASS = "flex flex-wrap gap-2";
+const SLOT_ROW_CLASS = "flex items-center justify-between gap-2";
+const SLOT_CLASS =
+  "flex-1 rounded border border-dashed border-gray-300 px-2 py-1 text-sm text-gray-600 " +
+  "dark:border-gray-600 dark:text-gray-300";
+const CONNECTIVE_SLOT_CLASS =
+  "rounded border border-gray-300 px-2 py-1 text-xs font-medium text-gray-700 " +
+  "dark:border-gray-600 dark:text-gray-200";
+const BUTTON_CLASS =
+  "rounded border border-gray-200 px-2 py-1 text-xs hover:bg-gray-100 disabled:cursor-not-allowed " +
+  "disabled:opacity-50 dark:border-gray-700 dark:hover:bg-gray-700";
+
+function depthBackground(depth: number): string {
+  return DEPTH_BACKGROUNDS[depth % DEPTH_BACKGROUNDS.length];
+}
+
+function element<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  return node;
+}
+
+// A restructuring action button: carries the action name + the target path so a
+// single delegated listener can route it. `disabled` greys it out (the op is also
+// re-guarded in the handler, so a stale click is harmless).
+function actionButton(
+  action: string,
+  label: string,
+  path: NodePath,
+  { disabled = false, title = "" } = {},
+): HTMLButtonElement {
+  const button = element("button", BUTTON_CLASS);
+  button.type = "button";
+  button.textContent = label;
+  button.dataset.action = action;
+  button.dataset.path = JSON.stringify(path);
+  if (disabled) button.disabled = true;
+  if (title) button.title = title;
+  return button;
+}
+
+function slotLabel(node: FilterNode): string {
+  if (node.kind === "criterion") return node.field ? `condition · ${node.field}` : "condition · (unset)";
+  if (node.kind === "relation") return node.field ? `relation · ${node.field}` : "relation · (unset)";
+  return "comparison";
+}
+
+export class FilterGroupElement extends HTMLElement {
+  private tree: GroupNode = emptyRoot();
+  private model = "";
+  private wired = false;
+
+  connectedCallback(): void {
+    this.model = readFilterGroupProps(this).model;
+    if (!this.wired) {
+      this.addEventListener("click", this.onClick);
+      this.wired = true;
+    }
+    this.render();
+  }
+
+  /** The current node tree (read-only source of truth) — for 2d serialize/count. */
+  getTree(): GroupNode {
+    return this.tree;
+  }
+
+  /** Convenience: the canonical OperatorFilter JSON for the current tree. */
+  serialize(): Record<string, unknown> {
+    return serialize(this.tree);
+  }
+
+  private onClick = (event: Event): void => {
+    const button = (event.target as HTMLElement).closest<HTMLElement>("[data-action]");
+    if (!button || button.dataset.path === undefined) return;
+    const path = JSON.parse(button.dataset.path) as number[];
+    this.applyAction(button.dataset.action ?? "", path);
+  };
+
+  private applyAction(action: string, path: NodePath): void {
+    const before = this.tree;
+    switch (action) {
+      case "add-condition":
+        this.tree = insertChild(this.tree, path, emptyCriterion());
+        break;
+      case "add-group":
+        if (canAddGroup(this.tree, path)) this.tree = insertChild(this.tree, path, emptyGroup());
+        break;
+      case "add-relation":
+        if (canAddRelation(this.tree, path)) this.tree = insertChild(this.tree, path, emptyRelation());
+        break;
+      case "remove":
+        this.tree = removeAt(this.tree, path);
+        break;
+      case "duplicate":
+        this.tree = duplicateAt(this.tree, path);
+        break;
+      case "wrap":
+        if (canWrap(this.tree, path)) this.tree = wrapInGroup(this.tree, path);
+        break;
+      case "unwrap":
+        if (canUnwrap(this.tree, path)) this.tree = unwrapGroup(this.tree, path);
+        break;
+      case "up":
+        this.tree = move(this.tree, path, -1);
+        break;
+      case "down":
+        this.tree = move(this.tree, path, 1);
+        break;
+      default:
+        return;
+    }
+    if (this.tree === before) return; // a guarded no-op changed nothing
+    this.render();
+    this.dispatchEvent(
+      new CustomEvent("filter-tree-change", { bubbles: true, detail: { tree: this.tree } }),
+    );
+  }
+
+  private render(): void {
+    this.replaceChildren(this.renderGroup(this.tree, [], 0, 1));
+  }
+
+  private renderGroup(node: GroupNode, path: NodePath, index: number, siblingCount: number): HTMLElement {
+    const card = element("div", `${CARD_CLASS} ${depthBackground(path.length)}`);
+    card.dataset.kind = "group";
+    card.dataset.path = JSON.stringify(path);
+
+    const header = element("div", HEADER_CLASS);
+    header.appendChild(this.connectiveSlot(node.connective, path));
+    if (path.length > 0) header.appendChild(this.controls(path, true, index, siblingCount));
+    card.appendChild(header);
+
+    const childrenBox = element("div", CHILDREN_CLASS);
+    node.children.forEach((child, childIndex) => {
+      childrenBox.appendChild(this.renderChild(child, [...path, childIndex], childIndex, node.children.length));
+    });
+    card.appendChild(childrenBox);
+
+    card.appendChild(this.footer(path));
+    return card;
+  }
+
+  private renderChild(child: FilterNode, path: NodePath, index: number, siblingCount: number): HTMLElement {
+    if (child.kind === "group") return this.renderGroup(child, path, index, siblingCount);
+    const row = element("div", SLOT_ROW_CLASS);
+    const slot = element("div", SLOT_CLASS);
+    slot.dataset.nodeSlot = "";
+    slot.dataset.nodeKind = child.kind;
+    slot.dataset.path = JSON.stringify(path);
+    slot.dataset.payload = JSON.stringify(child); // identity + payload for 2d hydration
+    slot.textContent = slotLabel(child);
+    row.appendChild(slot);
+    row.appendChild(this.controls(path, false, index, siblingCount));
+    return row;
+  }
+
+  // The connective is an inert placeholder here — component 2 replaces it with a
+  // real AND/OR selector + ¬ toggle, reading the same data-path.
+  private connectiveSlot(connective: Connective, path: NodePath): HTMLElement {
+    const slot = element("div", CONNECTIVE_SLOT_CLASS);
+    slot.dataset.slot = "connective";
+    slot.dataset.path = JSON.stringify(path);
+    slot.textContent = connective;
+    return slot;
+  }
+
+  private controls(path: NodePath, isGroup: boolean, index: number, siblingCount: number): HTMLElement {
+    const bar = element("div", "flex items-center gap-1");
+    bar.appendChild(actionButton("up", "↑", path, { disabled: index === 0, title: "Move up" }));
+    bar.appendChild(
+      actionButton("down", "↓", path, { disabled: index >= siblingCount - 1, title: "Move down" }),
+    );
+    bar.appendChild(
+      actionButton("wrap", "Wrap", path, {
+        disabled: !canWrap(this.tree, path),
+        title: canWrap(this.tree, path) ? "Wrap in a group" : "Max nesting reached",
+      }),
+    );
+    if (isGroup) {
+      bar.appendChild(
+        actionButton("unwrap", "Unwrap", path, {
+          disabled: !canUnwrap(this.tree, path),
+          title: "Dissolve this group into its parent",
+        }),
+      );
+    }
+    bar.appendChild(actionButton("duplicate", "Duplicate", path, { title: "Duplicate" }));
+    bar.appendChild(actionButton("remove", "Remove", path, { title: "Remove" }));
+    return bar;
+  }
+
+  private footer(path: NodePath): HTMLElement {
+    const footer = element("div", FOOTER_CLASS);
+    const capReached = !canAddGroup(this.tree, path);
+    footer.appendChild(actionButton("add-condition", "+ condition", path));
+    footer.appendChild(
+      actionButton("add-group", "+ group", path, {
+        disabled: capReached,
+        title: capReached ? "Max nesting reached" : "Add a nested group",
+      }),
+    );
+    footer.appendChild(
+      actionButton("add-relation", "+ relation", path, {
+        disabled: !canAddRelation(this.tree, path),
+        title: capReached ? "Max nesting reached" : "Add a relation descent",
+      }),
+    );
+    return footer;
+  }
+}
+
+customElements.define("filter-group", FilterGroupElement);

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -129,9 +129,10 @@ export class FilterGroupElement extends HTMLElement {
     this.render();
   }
 
-  /** The current node tree — for 2d serialize/count. Do not mutate it: the shell's
-   *  immutability invariant (and the change-event dispatch) relies on edits going
-   *  through the pure ops, so the type is `Readonly` to flag in-place writes. */
+  /** The current node tree — for 2d serialize/count. Do not mutate it: every edit
+   *  must go through the pure ops (the change-event dispatch depends on it). The
+   *  `Readonly` is shallow — it flags top-level rebinds only; deep mutation of
+   *  `children` or a nested node stays on the honor system. */
   getTree(): Readonly<GroupNode> {
     return this.tree;
   }
@@ -178,8 +179,13 @@ export class FilterGroupElement extends HTMLElement {
       case "down":
         this.tree = move(this.tree, path, 1);
         break;
-      default:
-        return;
+      default: {
+        // Exhaustiveness guard: every TreeAction is handled above, so `action`
+        // narrows to `never` here. Adding a member without a case fails tsc. The
+        // runtime `return` still guards the `as TreeAction` cast of dataset.action.
+        const unhandled: never = action;
+        return unhandled;
+      }
     }
     if (this.tree === before) return; // a guarded/boundary no-op changed nothing
     this.render();
@@ -241,10 +247,11 @@ export class FilterGroupElement extends HTMLElement {
     bar.appendChild(
       actionButton("down", "↓", path, { disabled: index >= siblingCount - 1, title: "Move down" }),
     );
+    const wrappable = canWrap(this.tree, path);
     bar.appendChild(
       actionButton("wrap", "Wrap", path, {
-        disabled: !canWrap(this.tree, path),
-        title: canWrap(this.tree, path) ? "Wrap in a group" : "Max nesting reached",
+        disabled: !wrappable,
+        title: wrappable ? "Wrap in a group" : "Max nesting reached",
       }),
     );
     if (isGroup) {

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -16,7 +16,7 @@
  */
 import { readFilterGroupProps } from "../generated/props.js";
 import { serialize } from "./filter-tree/serializer.js";
-import type { Connective, FilterNode, GroupNode } from "./filter-tree/types.js";
+import type { Connective, FilterNode, FilterTreeChangeDetail, GroupNode } from "./filter-tree/types.js";
 import {
   type NodePath,
   canAddGroup,
@@ -36,7 +36,8 @@ import {
 } from "./filter-tree/operations.js";
 
 // Full, static class strings only — Tailwind detects complete strings, so the
-// depth palette is a fixed lookup (never `bg-depth-${n}`). ~4-shade cycle (Qui).
+// depth palette is a fixed lookup (never `bg-depth-${n}`). ~4-shade cycle that
+// repeats past depth 3, giving nested cards alternating backgrounds.
 const DEPTH_BACKGROUNDS = [
   "bg-gray-50 dark:bg-gray-900/40",
   "bg-white dark:bg-gray-800/40",
@@ -58,6 +59,23 @@ const BUTTON_CLASS =
   "rounded border border-gray-200 px-2 py-1 text-xs hover:bg-gray-100 disabled:cursor-not-allowed " +
   "disabled:opacity-50 dark:border-gray-700 dark:hover:bg-gray-700";
 
+// The closed set of restructuring actions a button can carry; producer
+// (actionButton) and consumer (applyAction's switch) share it so a typo on either
+// side fails tsc instead of silently no-op'ing.
+type TreeAction =
+  | "add-condition"
+  | "add-group"
+  | "add-relation"
+  | "remove"
+  | "duplicate"
+  | "wrap"
+  | "unwrap"
+  | "up"
+  | "down";
+
+// The event the shell dispatches after every edit (see FilterTreeChangeDetail).
+export const FILTER_TREE_CHANGE_EVENT = "filter-tree-change";
+
 function depthBackground(depth: number): string {
   return DEPTH_BACKGROUNDS[depth % DEPTH_BACKGROUNDS.length];
 }
@@ -72,10 +90,11 @@ function element<K extends keyof HTMLElementTagNameMap>(
 }
 
 // A restructuring action button: carries the action name + the target path so a
-// single delegated listener can route it. `disabled` greys it out (the op is also
-// re-guarded in the handler, so a stale click is harmless).
+// single delegated listener can route it. `disabled` greys it out; the cap-gated
+// actions (add-group/add-relation/wrap/unwrap) are additionally re-guarded in the
+// handler, so a stale click on a since-invalidated one is harmless.
 function actionButton(
-  action: string,
+  action: TreeAction,
   label: string,
   path: NodePath,
   { disabled = false, title = "" } = {},
@@ -110,8 +129,10 @@ export class FilterGroupElement extends HTMLElement {
     this.render();
   }
 
-  /** The current node tree (read-only source of truth) — for 2d serialize/count. */
-  getTree(): GroupNode {
+  /** The current node tree — for 2d serialize/count. Do not mutate it: the shell's
+   *  immutability invariant (and the change-event dispatch) relies on edits going
+   *  through the pure ops, so the type is `Readonly` to flag in-place writes. */
+  getTree(): Readonly<GroupNode> {
     return this.tree;
   }
 
@@ -122,12 +143,12 @@ export class FilterGroupElement extends HTMLElement {
 
   private onClick = (event: Event): void => {
     const button = (event.target as HTMLElement).closest<HTMLElement>("[data-action]");
-    if (!button || button.dataset.path === undefined) return;
-    const path = JSON.parse(button.dataset.path) as number[];
-    this.applyAction(button.dataset.action ?? "", path);
+    if (!button || button.dataset.action === undefined || button.dataset.path === undefined) return;
+    const path: NodePath = JSON.parse(button.dataset.path) as number[];
+    this.applyAction(button.dataset.action as TreeAction, path);
   };
 
-  private applyAction(action: string, path: NodePath): void {
+  private applyAction(action: TreeAction, path: NodePath): void {
     const before = this.tree;
     switch (action) {
       case "add-condition":
@@ -160,11 +181,10 @@ export class FilterGroupElement extends HTMLElement {
       default:
         return;
     }
-    if (this.tree === before) return; // a guarded no-op changed nothing
+    if (this.tree === before) return; // a guarded/boundary no-op changed nothing
     this.render();
-    this.dispatchEvent(
-      new CustomEvent("filter-tree-change", { bubbles: true, detail: { tree: this.tree } }),
-    );
+    const detail: FilterTreeChangeDetail = { tree: this.tree };
+    this.dispatchEvent(new CustomEvent(FILTER_TREE_CHANGE_EVENT, { bubbles: true, detail }));
   }
 
   private render(): void {

--- a/ts/elements/filter-tree/operations.test.ts
+++ b/ts/elements/filter-tree/operations.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { group } from "./serializer.js";
-import type { FilterNode, GroupNode } from "./types.js";
+import type { CriterionLeaf, FilterNode, GroupNode } from "./types.js";
 import {
   SOFT_DEPTH_CAP,
   canAddGroup,
@@ -99,11 +99,15 @@ describe("insertChild / removeAt", () => {
   });
 
   it("does not mutate the input tree", () => {
-    const tree = group("AND", [criterion("a")]);
+    const tree = group("AND", [criterion("a"), criterion("b")]);
     const snapshot = structuredClone(tree);
-    insertChild(tree, [], criterion("b"));
-    removeAt(group("AND", [criterion("a"), criterion("b")]), [0]);
+    insertChild(tree, [], criterion("c"));
+    removeAt(tree, [0]);
     expect(tree).toEqual(snapshot);
+  });
+
+  it("removing the last child of root yields an empty group", () => {
+    expect(removeAt(group("AND", [criterion("a")]), [0])).toEqual(group("AND", []));
   });
 });
 
@@ -117,9 +121,13 @@ describe("duplicateAt", () => {
     const tree = group("AND", [group("OR", [criterion("a")])]);
     const result = duplicateAt(tree, [0]);
     const clone = result.children[1];
-    if (clone.kind !== "group") throw new Error("expected a group clone");
-    expect(clone).toEqual(tree.children[0]);
-    expect(clone).not.toBe(tree.children[0]);
+    if (clone.kind !== "group" || clone.children[0].kind !== "criterion") {
+      throw new Error("expected a nested group clone");
+    }
+    (clone.children[0] as CriterionLeaf).field = "MUTATED";
+    const original = tree.children[0];
+    if (original.kind !== "group") throw new Error("expected a group");
+    expect((original.children[0] as CriterionLeaf).field).toBe("a"); // untouched
   });
 });
 
@@ -134,12 +142,37 @@ describe("move", () => {
     expect(move(tree, [1], 1)).toEqual(group("AND", [criterion("a"), criterion("c"), criterion("b")]));
   });
 
-  it("is a no-op past the first slot", () => {
-    expect(move(tree, [0], -1)).toEqual(tree);
+  it("returns the same root reference past the first slot", () => {
+    expect(move(tree, [0], -1)).toBe(tree);
   });
 
-  it("is a no-op past the last slot", () => {
-    expect(move(tree, [2], 1)).toEqual(tree);
+  it("returns the same root reference past the last slot", () => {
+    expect(move(tree, [2], 1)).toBe(tree);
+  });
+
+  it("reorders within a nested group", () => {
+    const nested = group("AND", [group("OR", [criterion("a"), criterion("b")])]);
+    expect(move(nested, [0, 0], 1)).toEqual(group("AND", [group("OR", [criterion("b"), criterion("a")])]));
+  });
+});
+
+describe("error branches", () => {
+  it("setConnective throws on a non-group node", () => {
+    expect(() => setConnective(group("AND", [criterion("a")]), [0], "OR")).toThrow();
+  });
+
+  it("setMatch throws on a non-relation node", () => {
+    expect(() => setMatch(group("AND", [criterion("a")]), [0], "NONE")).toThrow();
+  });
+
+  it("wrapInGroup and unwrapGroup throw at the root path", () => {
+    expect(() => wrapInGroup(emptyRoot(), [])).toThrow();
+    expect(() => unwrapGroup(emptyRoot(), [])).toThrow();
+  });
+
+  it("toggleNegate works on a relation node", () => {
+    const tree = group("AND", [relation("sessions", group("AND", []))]);
+    expect(nodeAt(toggleNegate(tree, [0]), [0])).toMatchObject({ kind: "relation", negate: true });
   });
 });
 
@@ -219,6 +252,16 @@ describe("depth", () => {
     const tree = group("AND", [relation("sessions", group("AND", [criterion("a")]))]);
     // root(0) → relation child group(1). The relation itself is not a group level.
     expect(deepestGroupDepth(tree, 0)).toBe(1);
+  });
+
+  it("recurses through a relation's nested child groups", () => {
+    // root(0) → relation child group(1) → nested OR group(2).
+    const tree = group("AND", [relation("sessions", group("AND", [group("OR", [criterion("a")])]))]);
+    expect(deepestGroupDepth(tree, 0)).toBe(2);
+  });
+
+  it("canWrap accounts for a relation's child group depth", () => {
+    expect(canWrap(group("AND", [relation("sessions", group("AND", []))]), [0])).toBe(true);
   });
 
   it("counts nested groups", () => {

--- a/ts/elements/filter-tree/operations.test.ts
+++ b/ts/elements/filter-tree/operations.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from "vitest";
+import { group } from "./serializer.js";
+import type { FilterNode, GroupNode } from "./types.js";
+import {
+  SOFT_DEPTH_CAP,
+  canAddGroup,
+  canAddRelation,
+  canUnwrap,
+  canWrap,
+  deepestGroupDepth,
+  duplicateAt,
+  emptyCriterion,
+  emptyGroup,
+  emptyRelation,
+  emptyRoot,
+  groupDepthAt,
+  insertChild,
+  move,
+  nodeAt,
+  removeAt,
+  setConnective,
+  setMatch,
+  toggleNegate,
+  unwrapGroup,
+  wrapInGroup,
+} from "./operations.js";
+
+function criterion(field: string): FilterNode {
+  return { kind: "criterion", field, criterion: { value: field, modifier: "INCLUDES" }, negate: false };
+}
+
+function relation(field: string, child: GroupNode): FilterNode {
+  return { kind: "relation", field, match: "ANY", child, negate: false };
+}
+
+describe("factories", () => {
+  it("emptyRoot is an AND group with one empty criterion", () => {
+    expect(emptyRoot()).toEqual(group("AND", [emptyCriterion()]));
+  });
+
+  it("emptyCriterion has empty field and payload", () => {
+    expect(emptyCriterion()).toEqual({ kind: "criterion", field: "", criterion: {}, negate: false });
+  });
+
+  it("emptyRelation is ANY over an empty child group", () => {
+    expect(emptyRelation()).toEqual({
+      kind: "relation",
+      field: "",
+      match: "ANY",
+      child: group("AND", []),
+      negate: false,
+    });
+  });
+});
+
+describe("nodeAt", () => {
+  const tree = group("AND", [criterion("a"), group("OR", [criterion("b"), criterion("c")])]);
+
+  it("returns the root at the empty path", () => {
+    expect(nodeAt(tree, [])).toBe(tree);
+  });
+
+  it("descends through group children", () => {
+    expect(nodeAt(tree, [1, 0])).toEqual(criterion("b"));
+  });
+
+  it("throws on an out-of-range index", () => {
+    expect(() => nodeAt(tree, [5])).toThrow();
+  });
+
+  it("throws when descending into a leaf", () => {
+    expect(() => nodeAt(tree, [0, 0])).toThrow();
+  });
+});
+
+describe("insertChild / removeAt", () => {
+  it("appends a child by default", () => {
+    const tree = group("AND", [criterion("a")]);
+    expect(insertChild(tree, [], criterion("b"))).toEqual(group("AND", [criterion("a"), criterion("b")]));
+  });
+
+  it("inserts at an explicit index", () => {
+    const tree = group("AND", [criterion("a"), criterion("c")]);
+    expect(insertChild(tree, [], criterion("b"), 1)).toEqual(
+      group("AND", [criterion("a"), criterion("b"), criterion("c")]),
+    );
+  });
+
+  it("inserts into a nested group", () => {
+    const tree = group("AND", [group("OR", [criterion("a")])]);
+    expect(insertChild(tree, [0], criterion("b"))).toEqual(
+      group("AND", [group("OR", [criterion("a"), criterion("b")])]),
+    );
+  });
+
+  it("removes the addressed child", () => {
+    const tree = group("AND", [criterion("a"), criterion("b"), criterion("c")]);
+    expect(removeAt(tree, [1])).toEqual(group("AND", [criterion("a"), criterion("c")]));
+  });
+
+  it("does not mutate the input tree", () => {
+    const tree = group("AND", [criterion("a")]);
+    const snapshot = structuredClone(tree);
+    insertChild(tree, [], criterion("b"));
+    removeAt(group("AND", [criterion("a"), criterion("b")]), [0]);
+    expect(tree).toEqual(snapshot);
+  });
+});
+
+describe("duplicateAt", () => {
+  it("inserts a deep clone immediately after the original", () => {
+    const tree = group("AND", [criterion("a"), criterion("b")]);
+    expect(duplicateAt(tree, [0])).toEqual(group("AND", [criterion("a"), criterion("a"), criterion("b")]));
+  });
+
+  it("clones deeply (mutating the copy does not touch the original)", () => {
+    const tree = group("AND", [group("OR", [criterion("a")])]);
+    const result = duplicateAt(tree, [0]);
+    const clone = result.children[1];
+    if (clone.kind !== "group") throw new Error("expected a group clone");
+    expect(clone).toEqual(tree.children[0]);
+    expect(clone).not.toBe(tree.children[0]);
+  });
+});
+
+describe("move", () => {
+  const tree = group("AND", [criterion("a"), criterion("b"), criterion("c")]);
+
+  it("moves a node earlier", () => {
+    expect(move(tree, [1], -1)).toEqual(group("AND", [criterion("b"), criterion("a"), criterion("c")]));
+  });
+
+  it("moves a node later", () => {
+    expect(move(tree, [1], 1)).toEqual(group("AND", [criterion("a"), criterion("c"), criterion("b")]));
+  });
+
+  it("is a no-op past the first slot", () => {
+    expect(move(tree, [0], -1)).toEqual(tree);
+  });
+
+  it("is a no-op past the last slot", () => {
+    expect(move(tree, [2], 1)).toEqual(tree);
+  });
+});
+
+describe("setConnective / setMatch / toggleNegate", () => {
+  it("changes a group's connective in place", () => {
+    const tree = group("AND", [criterion("a")]);
+    expect(setConnective(tree, [], "OR")).toEqual(group("OR", [criterion("a")]));
+  });
+
+  it("sets a relation's quantifier", () => {
+    const tree = group("AND", [relation("sessions", group("AND", []))]);
+    const result = setMatch(tree, [0], "NONE");
+    expect(nodeAt(result, [0])).toMatchObject({ kind: "relation", match: "NONE" });
+  });
+
+  it("toggles a node's negate flag", () => {
+    const tree = group("AND", [criterion("a")]);
+    expect(toggleNegate(tree, [0])).toEqual(group("AND", [{ ...criterion("a"), negate: true }]));
+  });
+
+  it("cancels under double negation", () => {
+    const tree = group("AND", [criterion("a")]);
+    expect(toggleNegate(toggleNegate(tree, [0]), [0])).toEqual(tree);
+  });
+
+  it("negates a group", () => {
+    const tree = group("AND", [group("OR", [criterion("a")])]);
+    expect(nodeAt(toggleNegate(tree, [0]), [0])).toMatchObject({ kind: "group", negate: true });
+  });
+});
+
+describe("wrapInGroup", () => {
+  it("wraps a node in a group defaulting to the parent's connective", () => {
+    const tree = group("OR", [criterion("a"), criterion("b")]);
+    expect(wrapInGroup(tree, [0])).toEqual(group("OR", [group("OR", [criterion("a")]), criterion("b")]));
+  });
+
+  it("inherits an AND parent's connective", () => {
+    const tree = group("AND", [criterion("a")]);
+    expect(wrapInGroup(tree, [0])).toEqual(group("AND", [group("AND", [criterion("a")])]));
+  });
+
+  it("can wrap a nested group", () => {
+    const tree = group("AND", [group("OR", [criterion("a")])]);
+    expect(wrapInGroup(tree, [0])).toEqual(group("AND", [group("AND", [group("OR", [criterion("a")])])]));
+  });
+});
+
+describe("unwrapGroup", () => {
+  it("splices a group's children into the parent at its slot", () => {
+    const tree = group("AND", [criterion("a"), group("OR", [criterion("b"), criterion("c")]), criterion("d")]);
+    expect(unwrapGroup(tree, [1])).toEqual(
+      group("AND", [criterion("a"), criterion("b"), criterion("c"), criterion("d")]),
+    );
+  });
+
+  it("drops the dissolved group (connective and negate are lost)", () => {
+    const tree = group("AND", [{ ...emptyGroup("OR"), negate: true, children: [criterion("b")] }]);
+    expect(unwrapGroup(tree, [0])).toEqual(group("AND", [criterion("b")]));
+  });
+
+  it("throws on a non-group node", () => {
+    const tree = group("AND", [criterion("a")]);
+    expect(() => unwrapGroup(tree, [0])).toThrow();
+  });
+});
+
+describe("depth", () => {
+  it("reports a group's depth as its path length", () => {
+    const tree = group("AND", [group("OR", [group("AND", [])])]);
+    expect(groupDepthAt(tree, [])).toBe(0);
+    expect(groupDepthAt(tree, [0])).toBe(1);
+    expect(groupDepthAt(tree, [0, 0])).toBe(2);
+  });
+
+  it("counts a relation's child group as one level deeper", () => {
+    const tree = group("AND", [relation("sessions", group("AND", [criterion("a")]))]);
+    // root(0) → relation child group(1). The relation itself is not a group level.
+    expect(deepestGroupDepth(tree, 0)).toBe(1);
+  });
+
+  it("counts nested groups", () => {
+    const tree = group("AND", [criterion("a"), group("OR", [group("AND", [criterion("b")])])]);
+    expect(deepestGroupDepth(tree, 0)).toBe(2);
+  });
+
+  it("a leaf-only group adds no depth", () => {
+    expect(deepestGroupDepth(group("AND", [criterion("a"), criterion("b")]), 0)).toBe(0);
+  });
+});
+
+describe("soft cap", () => {
+  // Build a left-spine of nested groups to a given depth.
+  function spine(depth: number): GroupNode {
+    let node = emptyGroup("AND");
+    for (let i = 0; i < depth; i++) node = group("AND", [node]);
+    return node;
+  }
+
+  it("allows adding a group below the cap", () => {
+    expect(canAddGroup(spine(4), [0, 0, 0, 0])).toBe(true); // depth-4 group → child depth 5
+  });
+
+  it("disallows adding a group at the cap", () => {
+    const tree = spine(5);
+    expect(groupDepthAt(tree, [0, 0, 0, 0, 0])).toBe(SOFT_DEPTH_CAP);
+    expect(canAddGroup(tree, [0, 0, 0, 0, 0])).toBe(false); // depth-5 group → child depth 6
+  });
+
+  it("gates relations the same way as groups", () => {
+    expect(canAddRelation(spine(5), [0, 0, 0, 0, 0])).toBe(false);
+    expect(canAddRelation(spine(4), [0, 0, 0, 0])).toBe(true);
+  });
+
+  it("allows wrapping a leaf while the wrapper stays within the cap", () => {
+    const tree = group("AND", [criterion("a")]);
+    expect(canWrap(tree, [0])).toBe(true);
+  });
+
+  it("disallows wrapping when it would push the subtree past the cap", () => {
+    // The deepest group of spine(5) is at depth 5; wrapping it lands the wrapper
+    // at depth 5 and the group itself at depth 6 — past the cap.
+    const tree = spine(5);
+    expect(groupDepthAt(tree, [0, 0, 0, 0, 0])).toBe(SOFT_DEPTH_CAP);
+    expect(canWrap(tree, [0, 0, 0, 0, 0])).toBe(false);
+  });
+
+  it("never allows wrapping the root", () => {
+    expect(canWrap(emptyRoot(), [])).toBe(false);
+  });
+
+  it("allows unwrapping a non-root group only", () => {
+    const tree = group("AND", [group("OR", [criterion("a")]), criterion("b")]);
+    expect(canUnwrap(tree, [0])).toBe(true);
+    expect(canUnwrap(tree, [1])).toBe(false); // a leaf
+    expect(canUnwrap(tree, [])).toBe(false); // the root
+  });
+});

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -196,10 +196,9 @@ export function unwrapGroup(root: GroupNode, path: NodePath): GroupNode {
   const { parentPath, index } = splitPath(path);
   const node = nodeAt(root, path);
   if (node.kind !== "group") throw new Error(`Cannot unwrap a non-group node`);
-  const dissolved = node;
   return updateChildren(root, parentPath, (children) => [
     ...children.slice(0, index),
-    ...dissolved.children,
+    ...node.children,
     ...children.slice(index + 1),
   ]);
 }

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -12,7 +12,14 @@
  * shell renders a relation's child group as an inert slot, not a navigable subtree),
  * so a group reached at path `P` always sits at group-nesting depth `P.length`.
  */
-import { type Connective, type FilterNode, type GroupNode, type RelationMatch } from "./types.js";
+import {
+  type Connective,
+  type CriterionLeaf,
+  type FilterNode,
+  type GroupNode,
+  type RelationMatch,
+  type RelationNode,
+} from "./types.js";
 import { group } from "./serializer.js";
 
 export type NodePath = readonly number[];
@@ -26,13 +33,13 @@ export const SOFT_DEPTH_CAP = 5;
 
 // An empty criterion leaf: field unchosen, payload empty. A leaf widget (comp 4)
 // fills `field`/`criterion` in 2d; until then it is an inert slot in the shell.
-export function emptyCriterion(): FilterNode {
+export function emptyCriterion(): CriterionLeaf {
   return { kind: "criterion", field: "", criterion: {}, negate: false };
 }
 
 // An empty relation descent: ANY over an empty child group is the "has ≥1 related
 // row" presence test (design spec). Relation field + quantifier are set by comp 5.
-export function emptyRelation(): FilterNode {
+export function emptyRelation(): RelationNode {
   return { kind: "relation", field: "", match: "ANY", child: group("AND", []), negate: false };
 }
 
@@ -68,14 +75,14 @@ function groupAt(root: GroupNode, path: NodePath): GroupNode {
 
 // ── Immutable spine rewrite ──────────────────────────────────────────────────
 
-// Replace the node at `path` with `fn(node)`, cloning only the groups along the
-// spine. The input tree is never mutated.
+// Replace the node at `path` with `transform(node)`, cloning only the groups along
+// the spine. The input tree is never mutated.
 function replaceNodeAt(
   root: GroupNode,
   path: NodePath,
-  fn: (node: FilterNode) => FilterNode,
+  transform: (node: FilterNode) => FilterNode,
 ): GroupNode {
-  const result = replaceNode(root, path, fn);
+  const result = replaceNode(root, path, transform);
   if (result.kind !== "group") throw new Error(`Root replacement must stay a group`);
   return result;
 }
@@ -83,14 +90,14 @@ function replaceNodeAt(
 function replaceNode(
   node: FilterNode,
   path: NodePath,
-  fn: (node: FilterNode) => FilterNode,
+  transform: (node: FilterNode) => FilterNode,
 ): FilterNode {
-  if (path.length === 0) return fn(node);
+  if (path.length === 0) return transform(node);
   if (node.kind !== "group") throw new Error(`Path descends into a non-group node`);
   const [index, ...rest] = path;
   const child = node.children[index];
   if (child === undefined) throw new Error(`Path index ${index} out of range`);
-  const newChild = replaceNode(child, rest, fn);
+  const newChild = replaceNode(child, rest, transform);
   return { ...node, children: node.children.map((existing, i) => (i === index ? newChild : existing)) };
 }
 
@@ -98,11 +105,11 @@ function replaceNode(
 function updateChildren(
   root: GroupNode,
   groupPath: NodePath,
-  fn: (children: FilterNode[]) => FilterNode[],
+  transform: (children: FilterNode[]) => FilterNode[],
 ): GroupNode {
   return replaceNodeAt(root, groupPath, (node) => {
     if (node.kind !== "group") throw new Error(`Node at path is not a group`);
-    return { ...node, children: fn([...node.children]) };
+    return { ...node, children: transform([...node.children]) };
   });
 }
 
@@ -139,12 +146,15 @@ export function duplicateAt(root: GroupNode, path: NodePath): GroupNode {
 }
 
 // Move the node at `path` one slot earlier (-1) or later (+1) among its siblings.
-// A move past either boundary is a no-op (the element disables ↑/↓ at the ends).
+// A move past either boundary returns the *same* root reference unchanged, so a
+// caller can identity-compare to detect the no-op (the element also disables ↑/↓
+// at the ends).
 export function move(root: GroupNode, path: NodePath, direction: -1 | 1): GroupNode {
   const { parentPath, index } = splitPath(path);
+  const siblings = groupAt(root, parentPath).children;
+  const target = index + direction;
+  if (target < 0 || target >= siblings.length) return root;
   return updateChildren(root, parentPath, (children) => {
-    const target = index + direction;
-    if (target < 0 || target >= children.length) return children;
     const reordered = [...children];
     [reordered[index], reordered[target]] = [reordered[target], reordered[index]];
     return reordered;

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -1,0 +1,245 @@
+/**
+ * Pure, immutable tree operations for the nested filter builder (issue #189).
+ *
+ * The builder's single source of truth is a `GroupNode`-rooted `FilterNode` tree
+ * (the same model the serializer consumes — `types.ts`). Every restructuring
+ * affordance is a pure function here: it returns a new tree and never mutates its
+ * input, so the custom element can hold `tree`, call an op, reassign, and re-render.
+ * DOM lives in `filter-group.ts`; correctness lives here (and is vitest-tested).
+ *
+ * Addressing: a `NodePath` is the list of `group.children` indices from the root.
+ * Paths only ever descend through groups — leaves and relations are terminal (the
+ * shell renders a relation's child group as an inert slot, not a navigable subtree),
+ * so a group reached at path `P` always sits at group-nesting depth `P.length`.
+ */
+import { type Connective, type FilterNode, type GroupNode, type RelationMatch } from "./types.js";
+import { group } from "./serializer.js";
+
+export type NodePath = readonly number[];
+
+// Soft UI cap on group nesting (design spec): the root group is depth 0; a new
+// group/relation child may be created up to depth 5, deeper is disabled. The
+// backend hard bound is MAX_FILTER_DEPTH = 10 (types.ts) — this is only the hint.
+export const SOFT_DEPTH_CAP = 5;
+
+// ── Node factories ───────────────────────────────────────────────────────────
+
+// An empty criterion leaf: field unchosen, payload empty. A leaf widget (comp 4)
+// fills `field`/`criterion` in 2d; until then it is an inert slot in the shell.
+export function emptyCriterion(): FilterNode {
+  return { kind: "criterion", field: "", criterion: {}, negate: false };
+}
+
+// An empty relation descent: ANY over an empty child group is the "has ≥1 related
+// row" presence test (design spec). Relation field + quantifier are set by comp 5.
+export function emptyRelation(): FilterNode {
+  return { kind: "relation", field: "", match: "ANY", child: group("AND", []), negate: false };
+}
+
+// A new sub-group seeded with one empty criterion so it is never vacuously empty
+// in the UI. Connective defaults to AND; comp 2 lets the user switch it.
+export function emptyGroup(connective: Connective = "AND"): GroupNode {
+  return group(connective, [emptyCriterion()]);
+}
+
+// The initial tree: root is always an AND group pre-seeded with one empty leaf row.
+export function emptyRoot(): GroupNode {
+  return group("AND", [emptyCriterion()]);
+}
+
+// ── Navigation ───────────────────────────────────────────────────────────────
+
+export function nodeAt(root: GroupNode, path: NodePath): FilterNode {
+  let node: FilterNode = root;
+  for (const index of path) {
+    if (node.kind !== "group") throw new Error(`Path descends into a non-group node`);
+    const child: FilterNode | undefined = node.children[index];
+    if (child === undefined) throw new Error(`Path index ${index} out of range`);
+    node = child;
+  }
+  return node;
+}
+
+function groupAt(root: GroupNode, path: NodePath): GroupNode {
+  const node = nodeAt(root, path);
+  if (node.kind !== "group") throw new Error(`Node at path is not a group`);
+  return node;
+}
+
+// ── Immutable spine rewrite ──────────────────────────────────────────────────
+
+// Replace the node at `path` with `fn(node)`, cloning only the groups along the
+// spine. The input tree is never mutated.
+function replaceNodeAt(
+  root: GroupNode,
+  path: NodePath,
+  fn: (node: FilterNode) => FilterNode,
+): GroupNode {
+  const result = replaceNode(root, path, fn);
+  if (result.kind !== "group") throw new Error(`Root replacement must stay a group`);
+  return result;
+}
+
+function replaceNode(
+  node: FilterNode,
+  path: NodePath,
+  fn: (node: FilterNode) => FilterNode,
+): FilterNode {
+  if (path.length === 0) return fn(node);
+  if (node.kind !== "group") throw new Error(`Path descends into a non-group node`);
+  const [index, ...rest] = path;
+  const child = node.children[index];
+  if (child === undefined) throw new Error(`Path index ${index} out of range`);
+  const newChild = replaceNode(child, rest, fn);
+  return { ...node, children: node.children.map((existing, i) => (i === index ? newChild : existing)) };
+}
+
+// Transform the `children` array of the group at `groupPath`.
+function updateChildren(
+  root: GroupNode,
+  groupPath: NodePath,
+  fn: (children: FilterNode[]) => FilterNode[],
+): GroupNode {
+  return replaceNodeAt(root, groupPath, (node) => {
+    if (node.kind !== "group") throw new Error(`Node at path is not a group`);
+    return { ...node, children: fn([...node.children]) };
+  });
+}
+
+function splitPath(path: NodePath): { parentPath: NodePath; index: number } {
+  if (path.length === 0) throw new Error(`Path addresses the root, which has no parent`);
+  return { parentPath: path.slice(0, -1), index: path[path.length - 1] };
+}
+
+// ── Structural operations ────────────────────────────────────────────────────
+
+export function insertChild(
+  root: GroupNode,
+  groupPath: NodePath,
+  node: FilterNode,
+  index?: number,
+): GroupNode {
+  return updateChildren(root, groupPath, (children) => {
+    const at = index ?? children.length;
+    return [...children.slice(0, at), node, ...children.slice(at)];
+  });
+}
+
+export function removeAt(root: GroupNode, path: NodePath): GroupNode {
+  const { parentPath, index } = splitPath(path);
+  return updateChildren(root, parentPath, (children) => children.filter((_, i) => i !== index));
+}
+
+export function duplicateAt(root: GroupNode, path: NodePath): GroupNode {
+  const { parentPath, index } = splitPath(path);
+  return updateChildren(root, parentPath, (children) => {
+    const clone = structuredClone(children[index]);
+    return [...children.slice(0, index + 1), clone, ...children.slice(index + 1)];
+  });
+}
+
+// Move the node at `path` one slot earlier (-1) or later (+1) among its siblings.
+// A move past either boundary is a no-op (the element disables ↑/↓ at the ends).
+export function move(root: GroupNode, path: NodePath, direction: -1 | 1): GroupNode {
+  const { parentPath, index } = splitPath(path);
+  return updateChildren(root, parentPath, (children) => {
+    const target = index + direction;
+    if (target < 0 || target >= children.length) return children;
+    const reordered = [...children];
+    [reordered[index], reordered[target]] = [reordered[target], reordered[index]];
+    return reordered;
+  });
+}
+
+export function setConnective(root: GroupNode, groupPath: NodePath, connective: Connective): GroupNode {
+  return replaceNodeAt(root, groupPath, (node) => {
+    if (node.kind !== "group") throw new Error(`Node at path is not a group`);
+    return { ...node, connective };
+  });
+}
+
+export function setMatch(root: GroupNode, path: NodePath, match: RelationMatch): GroupNode {
+  return replaceNodeAt(root, path, (node) => {
+    if (node.kind !== "relation") throw new Error(`Node at path is not a relation`);
+    return { ...node, match };
+  });
+}
+
+// Negation is a per-node flag, never a connective (design spec). Toggling it twice
+// cancels. The ¬ button UI lives in component 2; this is the operation it calls.
+export function toggleNegate(root: GroupNode, path: NodePath): GroupNode {
+  return replaceNodeAt(root, path, (node) => ({ ...node, negate: !node.negate }));
+}
+
+// Wrap the node at `path` in a new group whose connective defaults to the parent
+// group's connective (design spec). The node becomes the wrapper's only child.
+export function wrapInGroup(root: GroupNode, path: NodePath): GroupNode {
+  const { parentPath } = splitPath(path);
+  const parentConnective = groupAt(root, parentPath).connective;
+  return replaceNodeAt(root, path, (node) => group(parentConnective, [node]));
+}
+
+// Dissolve the group at `path`, splicing its children into the parent at its slot.
+// The dissolved group's connective and negate flag are dropped — only valid when
+// `canUnwrap` holds (a non-root group); the element gates the button on it.
+export function unwrapGroup(root: GroupNode, path: NodePath): GroupNode {
+  const { parentPath, index } = splitPath(path);
+  const node = nodeAt(root, path);
+  if (node.kind !== "group") throw new Error(`Cannot unwrap a non-group node`);
+  const dissolved = node;
+  return updateChildren(root, parentPath, (children) => [
+    ...children.slice(0, index),
+    ...dissolved.children,
+    ...children.slice(index + 1),
+  ]);
+}
+
+// ── Depth ────────────────────────────────────────────────────────────────────
+
+// The deepest group-nesting depth anywhere in `group`'s subtree, given the group
+// itself sits at `groupDepth`. A child group is +1; a relation's child group is +1
+// (the relation node is not itself a group); leaves contribute nothing. This is the
+// single primitive every cap check is derived from.
+export function deepestGroupDepth(node: GroupNode, groupDepth: number): number {
+  let deepest = groupDepth;
+  for (const child of node.children) {
+    if (child.kind === "group") {
+      deepest = Math.max(deepest, deepestGroupDepth(child, groupDepth + 1));
+    } else if (child.kind === "relation") {
+      deepest = Math.max(deepest, deepestGroupDepth(child.child, groupDepth + 1));
+    }
+  }
+  return deepest;
+}
+
+// A group reached at `groupPath` sits at depth `groupPath.length` (paths descend
+// through group children only).
+export function groupDepthAt(_root: GroupNode, groupPath: NodePath): number {
+  return groupPath.length;
+}
+
+// `+ group`/`+ relation` add a child group one level below the current group; allow
+// only while that child stays within the soft cap.
+export function canAddGroup(root: GroupNode, groupPath: NodePath): boolean {
+  return groupDepthAt(root, groupPath) < SOFT_DEPTH_CAP;
+}
+
+export function canAddRelation(root: GroupNode, groupPath: NodePath): boolean {
+  return canAddGroup(root, groupPath);
+}
+
+// Wrapping pushes the node's whole subtree one level deeper (under a fresh wrapper
+// group at the node's current slot depth). Allowed only when the deepest resulting
+// group stays within the soft cap. Works for every node kind because the wrapper is
+// a group holding the node, and `deepestGroupDepth` accounts for groups/relations.
+export function canWrap(root: GroupNode, path: NodePath): boolean {
+  if (path.length === 0) return false; // the root cannot be wrapped
+  const slotDepth = path.length;
+  const node = nodeAt(root, path);
+  return deepestGroupDepth(group("AND", [node]), slotDepth) <= SOFT_DEPTH_CAP;
+}
+
+// Unwrap is meaningful only for a non-root group.
+export function canUnwrap(root: GroupNode, path: NodePath): boolean {
+  return path.length > 0 && nodeAt(root, path).kind === "group";
+}

--- a/ts/elements/filter-tree/types.ts
+++ b/ts/elements/filter-tree/types.ts
@@ -47,6 +47,14 @@ export interface RelationNode {
 
 export type FilterNode = GroupNode | CriterionLeaf | ComparisonLeaf | RelationNode;
 
+// Payload of the `filter-tree-change` CustomEvent the <filter-group> shell
+// dispatches after every edit — the new root tree. Named so producer (the
+// element) and consumers (2d serialize/count, tests) share one typed contract,
+// mirroring the OpenMenuDetail precedent in menu-behavior.ts.
+export interface FilterTreeChangeDetail {
+  tree: GroupNode;
+}
+
 // Per-model metadata the importer consumes to classify a JSON key as a relation
 // descent (and find its target model) or a criterion leaf. Unknown keys are
 // dropped, mirroring the backend's `from_json` (it iterates declared fields only).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from "vitest/config";
 
 // Vitest/Vite resolves `./foo.js` import specifiers to the sibling `foo.ts`,
 // so the module's NodeNext-style `.js` imports work without a compile step.
+//
+// The global environment stays `node` so the pure-function suites run fast; the
+// few DOM/custom-element tests opt into jsdom per-file via `// @vitest-environment
+// jsdom` (e.g. ts/elements/filter-group.test.ts).
 export default defineConfig({
   test: {
     include: ["ts/**/*.test.ts"],


### PR DESCRIPTION
Closes #189. Phase **2c** of the nested filter builder (#168).

The **recursive group shell**: the structural skeleton of the nested AND/OR/NOT filter builder. It owns the in-memory `FilterNode` tree (the same model the #188 serializer consumes) and renders it as nested group cards with buttons-only restructuring. Built in isolation, in parallel with sibling components 2–5; those wire into its seams during 2d assembly.

## What's here
- **`ts/elements/filter-tree/operations.ts`** — pure, immutable tree operations addressed by `NodePath`: `insertChild` / `removeAt` / `duplicateAt` / `move` / `wrapInGroup` / `unwrapGroup` / `setConnective` / `setMatch` / `toggleNegate`, node factories, and the depth rules. A single `deepestGroupDepth` primitive (a relation's child group = **+1 level**, a `¬` flag = **0 levels**) drives the soft depth cap of 5 (`canAddGroup` / `canAddRelation` / `canWrap`). Backend hard cap (10) stays the real bound.
- **`ts/elements/filter-group.ts`** — the `<filter-group>` custom element. Holds the `GroupNode` tree, full re-renders recursive plain-`<div>` cards (alternating depth coloring, footer `+ condition / + group / + relation`, per-node `remove / duplicate / wrap / unwrap / ↑ / ↓`), routes clicks through a single delegated listener, and dispatches `filter-tree-change`. Exposes `getTree()` / `serialize()`.
- **`custom_elements.py`** — `FilterGroupProps` + `register_element` + `FilterGroup(*, model)` builder (JS Media auto-attached); exported from `common.components`.

## Scope decisions (design interview)
- **Inert mount slots** for sibling-owned parts — the connective chip and leaf/relation children render as identity-carrying mount points (`data-slot` / `data-node-slot` + `data-path` + serialized payload). Components 2 (connective + negate UI), 3/4 (leaf widgets), 5 (relation block) hydrate them in 2d.
- **Negate:** the pure `toggleNegate` op ships here; the ¬ *button UI* belongs to component 2.

## Tests
vitest runs node-only, so correctness lives in the pure ops module (40 vitest cases). The element gets a **jsdom-env** vitest DOM test (10 cases) — adds the `jsdom` devDep + a per-file `// @vitest-environment jsdom` pragma so the existing node suites stay node-fast.

Local `make check` slice — all green:
- vitest: **100 passed** (40 ops + 10 jsdom DOM + existing)
- pytest `tests/`: **1177 passed**
- `make ts-check`, `ruff check`, `ruff format --check`, `mypy`, icon-drift: clean
- render + auto-Media smoke for `FilterGroup`

## Follow-up
- #233 — re-render reconciliation + stable node keys (2d prerequisite before stateful leaf widgets mount; #189's slots are inert so it's moot here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)