### PR TITLE
feat(filters): connective + NOT toggle chips on filter-group (#190)

### DIFF
--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -32,7 +32,7 @@ describe("<filter-group> initial render", () => {
     const host = mount();
     const root = host.querySelector('[data-kind="group"][data-path="[]"]');
     expect(root).not.toBeNull();
-    expect(host.querySelector('[data-slot="connective"]')?.textContent).toBe("AND");
+    expect(button(host, "toggle-connective", [])?.textContent).toBe("AND");
     expect(slots(host)).toHaveLength(1);
     expect(slots(host)[0].dataset.nodeKind).toBe("criterion");
     expect(button(host, "add-condition", [])).not.toBeNull();
@@ -145,10 +145,59 @@ describe("<filter-group> inert-slot contract (2d hydration)", () => {
     const criterionSlot = slots(host).find((slot) => slot.dataset.nodeKind === "criterion")!;
     expect(JSON.parse(criterionSlot.dataset.payload!)).toMatchObject({ kind: "criterion", negate: false });
   });
+});
 
-  it("the connective slot carries its group path for component 2", () => {
+describe("<filter-group> connective + negate (component 2, #190)", () => {
+  it("connective chip flips the group connective AND<->OR", () => {
     const host = mount();
-    expect(host.querySelector<HTMLElement>('[data-slot="connective"]')!.dataset.path).toBe("[]");
+    expect(button(host, "toggle-connective", [])?.textContent).toBe("AND");
+    clickAction(host, "toggle-connective", []);
+    expect(button(host, "toggle-connective", [])?.textContent).toBe("OR");
+    expect(Object.keys(host.serialize())[0]).toBe("OR");
+    clickAction(host, "toggle-connective", []);
+    expect(button(host, "toggle-connective", [])?.textContent).toBe("AND");
+  });
+
+  it("color-codes the connective chip by value (teal AND / orange OR)", () => {
+    const host = mount();
+    expect(button(host, "toggle-connective", [])?.className).toContain("teal");
+    clickAction(host, "toggle-connective", []);
+    const orChip = button(host, "toggle-connective", []);
+    expect(orChip?.className).toContain("orange");
+    expect(orChip?.className).not.toContain("teal");
+  });
+
+  it("negate chip on a group wraps it in {NOT:[…]} and flips aria-pressed", () => {
+    const host = mount();
+    const before = button(host, "toggle-negate", []);
+    expect(before?.getAttribute("aria-pressed")).toBe("false");
+    clickAction(host, "toggle-negate", []);
+    expect(button(host, "toggle-negate", [])?.getAttribute("aria-pressed")).toBe("true");
+    expect(Object.keys(host.serialize())[0]).toBe("NOT");
+    // toggling off restores the un-negated shape (UI re-render round-trips)
+    clickAction(host, "toggle-negate", []);
+    expect(button(host, "toggle-negate", [])?.getAttribute("aria-pressed")).toBe("false");
+    expect(Object.keys(host.serialize())[0]).toBe("AND");
+  });
+
+  it("negate chip on a leaf negates only that leaf", () => {
+    const host = mount(); // root AND with one seed criterion at [0]
+    expect(button(host, "toggle-negate", [0])?.getAttribute("aria-pressed")).toBe("false");
+    clickAction(host, "toggle-negate", [0]);
+    expect(button(host, "toggle-negate", [0])?.getAttribute("aria-pressed")).toBe("true");
+    // root stays a plain AND group; the negation is on the leaf inside it
+    const serialized = host.serialize() as { AND: Record<string, unknown>[] };
+    expect(Object.keys(serialized)[0]).toBe("AND");
+    expect(Object.keys(serialized.AND[0])[0]).toBe("NOT");
+  });
+
+  it("dispatches filter-tree-change on connective and negate edits", () => {
+    const host = mount();
+    let count = 0;
+    host.addEventListener("filter-tree-change", () => (count += 1));
+    clickAction(host, "toggle-connective", []);
+    clickAction(host, "toggle-negate", []);
+    expect(count).toBe(2);
   });
 });
 

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -4,11 +4,13 @@
  *
  * Holds the whole `FilterNode` tree in JS (the single source of truth the
  * serializer consumes) and re-renders the DOM from it on every edit. This shell
- * owns only *structure*: group cards, alternating depth coloring, the soft depth
+ * owns the *structure* — group cards, alternating depth coloring, the soft depth
  * cap, the footer add-buttons, and the buttons-only restructuring affordances
- * (remove / duplicate / wrap / unwrap / ↑ / ↓). The connective+negate UI (comp 2),
- * leaf widgets (comp 3/4), and relation block (comp 5) are sibling 2c components;
- * here their places are **inert slots** carrying each node's identity + payload,
+ * (remove / duplicate / wrap / unwrap / ↑ / ↓) — plus the connective + NOT chips
+ * (comp 2, #190), which are stateless projections of each node's
+ * connective/negate flag wired through the same data-action delegation. The leaf
+ * widgets (comp 3/4) and relation block (comp 5) are sibling 2c components; here
+ * their places are **inert slots** carrying each node's identity + payload,
  * hydrated during 2d assembly.
  *
  * Correctness (every mutation) lives in the pure `filter-tree/operations.ts`
@@ -31,6 +33,8 @@ import {
   insertChild,
   move,
   removeAt,
+  toggleConnective,
+  toggleNegate,
   unwrapGroup,
   wrapInGroup,
 } from "./filter-tree/operations.js";
@@ -52,9 +56,27 @@ const SLOT_ROW_CLASS = "flex items-center justify-between gap-2";
 const SLOT_CLASS =
   "flex-1 rounded border border-dashed border-gray-300 px-2 py-1 text-sm text-gray-600 " +
   "dark:border-gray-600 dark:text-gray-300";
-const CONNECTIVE_SLOT_CLASS =
-  "rounded border border-gray-300 px-2 py-1 text-xs font-medium text-gray-700 " +
-  "dark:border-gray-600 dark:text-gray-200";
+// Connective + NOT chips (component 2, issue #190). Pill shape (rounded-full) +
+// saturated fill sets this cluster apart from the square, gray restructuring
+// buttons so it never reads as "just another button". The connective is
+// color-coded by value with a NON-semantic cool/warm pair — AND = teal, OR =
+// orange — kept out of the action palette (blue/red/green/gray) so it reads as
+// "logic type", not status. The NOT-on look uses an amber FILL + RING so a lit
+// NOT chip stays distinct from an adjacent OR chip (fill-only) — they never read
+// as one blob.
+const CHIP_BASE = "rounded-full border px-2.5 py-0.5 text-xs font-semibold hover:cursor-pointer";
+const CONNECTIVE_AND_CLASS =
+  "border-teal-300 bg-teal-100 text-teal-800 " +
+  "dark:border-teal-500/60 dark:bg-teal-500/20 dark:text-teal-200";
+const CONNECTIVE_OR_CLASS =
+  "border-orange-300 bg-orange-100 text-orange-800 " +
+  "dark:border-orange-500/60 dark:bg-orange-500/20 dark:text-orange-200";
+const NEGATE_OFF_CLASS =
+  "border-gray-200 text-gray-500 hover:bg-gray-100 " +
+  "dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700";
+const NEGATE_ON_CLASS =
+  "border-amber-400 bg-amber-100 text-amber-900 ring-1 ring-amber-400 " +
+  "dark:border-amber-500/70 dark:bg-amber-500/25 dark:text-amber-100 dark:ring-amber-500/70";
 const BUTTON_CLASS =
   "rounded border border-gray-200 px-2 py-1 text-xs hover:bg-gray-100 disabled:cursor-not-allowed " +
   "disabled:opacity-50 dark:border-gray-700 dark:hover:bg-gray-700";
@@ -71,7 +93,9 @@ type TreeAction =
   | "wrap"
   | "unwrap"
   | "up"
-  | "down";
+  | "down"
+  | "toggle-connective"
+  | "toggle-negate";
 
 // The event the shell dispatches after every edit (see FilterTreeChangeDetail).
 export const FILTER_TREE_CHANGE_EVENT = "filter-tree-change";
@@ -179,6 +203,12 @@ export class FilterGroupElement extends HTMLElement {
       case "down":
         this.tree = move(this.tree, path, 1);
         break;
+      case "toggle-connective":
+        this.tree = toggleConnective(this.tree, path);
+        break;
+      case "toggle-negate":
+        this.tree = toggleNegate(this.tree, path);
+        break;
       default: {
         // Exhaustiveness guard: every TreeAction is handled above, so `action`
         // narrows to `never` here. Adding a member without a case fails tsc. The
@@ -203,7 +233,12 @@ export class FilterGroupElement extends HTMLElement {
     card.dataset.path = JSON.stringify(path);
 
     const header = element("div", HEADER_CLASS);
-    header.appendChild(this.connectiveSlot(node.connective, path));
+    // NOT is the leftmost control on every node (groups and leaves) so negation
+    // always reads in the same place; the connective follows it on groups.
+    const connectiveCluster = element("div", "flex items-center gap-1");
+    connectiveCluster.appendChild(this.negateChip(node, path));
+    connectiveCluster.appendChild(this.connectiveChip(node.connective, path));
+    header.appendChild(connectiveCluster);
     if (path.length > 0) header.appendChild(this.controls(path, true, index, siblingCount));
     card.appendChild(header);
 
@@ -226,19 +261,50 @@ export class FilterGroupElement extends HTMLElement {
     slot.dataset.path = JSON.stringify(path);
     slot.dataset.payload = JSON.stringify(child); // identity + payload for 2d hydration
     slot.textContent = slotLabel(child);
+    // NOT leads the row (leftmost), matching the group header; the slot and the
+    // restructuring controls follow.
+    row.appendChild(this.negateChip(child, path));
     row.appendChild(slot);
     row.appendChild(this.controls(path, false, index, siblingCount));
     return row;
   }
 
-  // The connective is an inert placeholder here — component 2 replaces it with a
-  // real AND/OR selector + ¬ toggle, reading the same data-path.
-  private connectiveSlot(connective: Connective, path: NodePath): HTMLElement {
-    const slot = element("div", CONNECTIVE_SLOT_CLASS);
-    slot.dataset.slot = "connective";
-    slot.dataset.path = JSON.stringify(path);
-    slot.textContent = connective;
-    return slot;
+  // A chip-style toggle button: a restructuring action (so it rides the existing
+  // data-action delegation + applyAction) wearing its own chip classes instead of
+  // BUTTON_CLASS. `pressed` reflects an on/off state via aria-pressed.
+  private chip(
+    action: TreeAction,
+    label: string,
+    path: NodePath,
+    className: string,
+    { title = "", pressed }: { title?: string; pressed?: boolean } = {},
+  ): HTMLButtonElement {
+    const button = element("button", `${CHIP_BASE} ${className}`);
+    button.type = "button";
+    button.textContent = label;
+    button.dataset.action = action;
+    button.dataset.path = JSON.stringify(path);
+    if (title) button.title = title;
+    if (pressed !== undefined) button.setAttribute("aria-pressed", String(pressed));
+    return button;
+  }
+
+  // The connective chip: label is the value itself; clicking flips AND<->OR. Color
+  // carries the value (no lit/pressed state — the label already shows it).
+  private connectiveChip(connective: Connective, path: NodePath): HTMLButtonElement {
+    const colorClass = connective === "AND" ? CONNECTIVE_AND_CLASS : CONNECTIVE_OR_CLASS;
+    return this.chip("toggle-connective", connective, path, colorClass, {
+      title: "Toggle AND/OR for this group",
+    });
+  }
+
+  // The NOT negate chip (groups and leaves): constant label, lit when the node's
+  // negate flag is set. Clicking toggles it.
+  private negateChip(node: FilterNode, path: NodePath): HTMLButtonElement {
+    return this.chip("toggle-negate", "NOT", path, node.negate ? NEGATE_ON_CLASS : NEGATE_OFF_CLASS, {
+      title: node.negate ? "Remove negation" : "Negate",
+      pressed: node.negate,
+    });
   }
 
   private controls(path: NodePath, isGroup: boolean, index: number, siblingCount: number): HTMLElement {

--- a/ts/elements/filter-tree/operations.test.ts
+++ b/ts/elements/filter-tree/operations.test.ts
@@ -20,6 +20,7 @@ import {
   removeAt,
   setConnective,
   setMatch,
+  toggleConnective,
   toggleNegate,
   unwrapGroup,
   wrapInGroup,
@@ -161,6 +162,10 @@ describe("error branches", () => {
     expect(() => setConnective(group("AND", [criterion("a")]), [0], "OR")).toThrow();
   });
 
+  it("toggleConnective throws on a non-group node", () => {
+    expect(() => toggleConnective(group("AND", [criterion("a")]), [0])).toThrow();
+  });
+
   it("setMatch throws on a non-relation node", () => {
     expect(() => setMatch(group("AND", [criterion("a")]), [0], "NONE")).toThrow();
   });
@@ -180,6 +185,17 @@ describe("setConnective / setMatch / toggleNegate", () => {
   it("changes a group's connective in place", () => {
     const tree = group("AND", [criterion("a")]);
     expect(setConnective(tree, [], "OR")).toEqual(group("OR", [criterion("a")]));
+  });
+
+  it("flips a group's connective AND->OR and back", () => {
+    const tree = group("AND", [criterion("a")]);
+    expect(toggleConnective(tree, [])).toEqual(group("OR", [criterion("a")]));
+    expect(toggleConnective(toggleConnective(tree, []), [])).toEqual(tree);
+  });
+
+  it("flips a nested group's connective by path", () => {
+    const tree = group("AND", [group("OR", [criterion("a")])]);
+    expect(nodeAt(toggleConnective(tree, [0]), [0])).toMatchObject({ kind: "group", connective: "AND" });
   });
 
   it("sets a relation's quantifier", () => {

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -168,6 +168,17 @@ export function setConnective(root: GroupNode, groupPath: NodePath, connective: 
   });
 }
 
+// Flip a group's connective between the two values (AND<->OR). The connective is
+// a fixed binary (design spec), so the chip UI in component 2 is a flip, not a
+// pick; this is the payload-free operation it dispatches. `setConnective` keeps
+// the explicit-value setter for programmatic/import use.
+export function toggleConnective(root: GroupNode, groupPath: NodePath): GroupNode {
+  return replaceNodeAt(root, groupPath, (node) => {
+    if (node.kind !== "group") throw new Error(`Node at path is not a group`);
+    return { ...node, connective: node.connective === "AND" ? "OR" : "AND" };
+  });
+}
+
 export function setMatch(root: GroupNode, path: NodePath, match: RelationMatch): GroupNode {
   return replaceNodeAt(root, path, (node) => {
     if (node.kind !== "relation") throw new Error(`Node at path is not a relation`);


### PR DESCRIPTION
Phase 2c **component 2** of the nested filter builder (#168), depends on #189 (group shell) and #188 (serializer), both merged. Closes #190.

Makes the group shell's inert connective placeholder a real **AND/OR toggle** and adds a **NOT (negate) toggle** to every node — groups and leaves.

## Approach

Decided with the user **not** to introduce a new custom element. A controlled toggle has no behavior the `<filter-group>` shell doesn't already own (re-render-from-tree, event dispatch), and the only consumer builds its chips client-side. So this extends the shell's existing event-delegated `applyAction`/`data-action` path:

- Two new `TreeAction` members (`toggle-connective`, `toggle-negate`) + a new pure `toggleConnective` op mirroring `toggleNegate`. The existing `never` exhaustiveness guard types both — a missing case fails `tsc`. No new infrastructure, no magic role string.
- **Client-only — no Python change.** The serializer already round-trips `negate` via `wrapNegate`/`withNegateToggled`.

## UX

- Connective + NOT render as **pills** (rounded-full + saturated fill) so they're distinct from the square gray restructuring buttons.
- Connective **color-coded by value** with a non-semantic cool/warm pair — **teal AND / orange OR** — kept out of the action palette (blue/red/green/gray) so it reads as logic-type, not status.
- **NOT** lit with an amber fill+ring when set, kept visually distinct from an adjacent OR pill (fill-only). NOT is the **leftmost** control on every node so negation reads in one consistent place (groups *and* leaves).
- Visually verified on `/filter-group-demo/` in light + dark.

## Tests

- `toggleConnective`: flip / double-identity / throws on non-group.
- `<filter-group>` DOM: connective flip + color class per value; group & leaf NOT (`aria-pressed` + `{NOT:[…]}` serialization); change-event dispatch. Updated the inert-slot contract test (connective no longer inert; leaf slots stay inert for #192).
- `make check` green (lint, mypy, ts-check, vitest, pytest incl. the cross-language filter-tree contract).

## Adversarial review

Two parallel reviewers (correctness + conventions/tests) — no correctness bugs; folded the test-coverage gaps (color class, leaf `aria-pressed`) and comment fixes.

## Follow-up

#236 — NOT chip on an empty group serializes away (documented design, edge-case, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)