### PR TITLE
fix(filters): empty group can't carry a lit-but-dropped NOT (#236)

### DIFF
--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -201,6 +201,39 @@ describe("<filter-group> connective + negate (component 2, #190)", () => {
   });
 });
 
+describe("<filter-group> empty groups (#236)", () => {
+  it("auto-collapses a nested group when its last child is removed", () => {
+    const host = mount();
+    clickAction(host, "add-group", []); // [0]=seed criterion, [1]=group with [1,0]=criterion
+    expect(host.querySelector('[data-kind="group"][data-path="[1]"]')).not.toBeNull();
+    clickAction(host, "remove", [1, 0]); // empties the nested group → it is removed
+    expect(host.querySelector('[data-kind="group"][data-path="[1]"]')).toBeNull();
+    expect(slots(host)).toHaveLength(1); // only the root's seed criterion remains
+  });
+
+  it("renders a 'matches all' empty state with no NOT/connective chip when root is cleared", () => {
+    const host = mount();
+    clickAction(host, "remove", [0]); // remove the root's only seed criterion
+    expect(button(host, "toggle-negate", [])).toBeNull();
+    expect(button(host, "toggle-connective", [])).toBeNull();
+    expect(host.textContent).toContain("No conditions. This will match all items.");
+    // the add affordances stay so the user can rebuild
+    expect(button(host, "add-condition", [])).not.toBeNull();
+    expect(button(host, "add-group", [])).not.toBeNull();
+    // an empty filter serializes to {} (matches everything)
+    expect(host.serialize()).toEqual({});
+  });
+
+  it("rebuilds from the empty state and restores the header chips", () => {
+    const host = mount();
+    clickAction(host, "remove", [0]);
+    clickAction(host, "add-condition", []);
+    expect(button(host, "toggle-negate", [])).not.toBeNull();
+    expect(button(host, "toggle-connective", [])?.textContent).toBe("AND");
+    expect(slots(host)).toHaveLength(1);
+  });
+});
+
 describe("<filter-group> duplicate + event fidelity", () => {
   it("duplicate adds a sibling copy", () => {
     const host = mount();

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -224,6 +224,16 @@ describe("<filter-group> empty groups (#236)", () => {
     expect(host.serialize()).toEqual({});
   });
 
+  it("a cascade removal collapses the group in the DOM and fires one change event", () => {
+    const host = mount();
+    clickAction(host, "add-group", []); // [1]=group seeded with [1,0]=criterion
+    let count = 0;
+    host.addEventListener("filter-tree-change", () => (count += 1));
+    clickAction(host, "remove", [1, 0]); // empties the nested group → collapses it
+    expect(count).toBe(1);
+    expect(host.querySelector('[data-kind="group"][data-path="[1]"]')).toBeNull();
+  });
+
   it("rebuilds from the empty state and restores the header chips", () => {
     const host = mount();
     clickAction(host, "remove", [0]);

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -52,6 +52,11 @@ const CARD_CLASS = "flex flex-col gap-2 rounded-lg border border-gray-200 p-2 da
 const HEADER_CLASS = "flex items-center justify-between gap-2";
 const CHILDREN_CLASS = "flex flex-col gap-2 pl-3";
 const FOOTER_CLASS = "flex flex-wrap gap-2";
+// Shown in place of the header when the root group is empty: an empty filter
+// serializes to {} (matches everything), so say so rather than render a NOT/AND
+// chip on a group with nothing to negate or join (issue #236).
+const EMPTY_STATE_CLASS = "px-2 py-1 text-sm text-gray-500 dark:text-gray-400";
+const EMPTY_STATE_TEXT = "No conditions. This will match all items.";
 const SLOT_ROW_CLASS = "flex items-center justify-between gap-2";
 const SLOT_CLASS =
   "flex-1 rounded border border-dashed border-gray-300 px-2 py-1 text-sm text-gray-600 " +
@@ -231,6 +236,17 @@ export class FilterGroupElement extends HTMLElement {
     const card = element("div", `${CARD_CLASS} ${depthBackground(path.length)}`);
     card.dataset.kind = "group";
     card.dataset.path = JSON.stringify(path);
+
+    // Only the root may be empty (non-root groups auto-collapse on their last
+    // child's removal). A header-less "matches all" state keeps an empty group
+    // off the NOT/connective chips it has nothing to apply to (issue #236).
+    if (path.length === 0 && node.children.length === 0) {
+      const emptyState = element("div", EMPTY_STATE_CLASS);
+      emptyState.textContent = EMPTY_STATE_TEXT;
+      card.appendChild(emptyState);
+      card.appendChild(this.footer(path));
+      return card;
+    }
 
     const header = element("div", HEADER_CLASS);
     // NOT is the leftmost control on every node (groups and leaves) so negation

--- a/ts/elements/filter-tree/operations.test.ts
+++ b/ts/elements/filter-tree/operations.test.ts
@@ -126,6 +126,27 @@ describe("insertChild / removeAt", () => {
     const tree = group("AND", [group("OR", [criterion("a")])]);
     expect(removeAt(tree, [0, 0])).toEqual(group("AND", []));
   });
+
+  it("prunes only emptied groups, stopping at a non-empty ancestor", () => {
+    const tree = group("AND", [group("OR", [group("AND", [criterion("a")]), criterion("keep")])]);
+    // Removing 'a' empties its AND, which is pruned; the OR survives (has 'keep'),
+    // so the cascade stops there — no spurious sibling removal.
+    expect(removeAt(tree, [0, 0, 0])).toEqual(group("AND", [group("OR", [criterion("keep")])]));
+  });
+
+  it("does not descend or prune a relation's (possibly empty) child group", () => {
+    // A relation is a terminal slot; removeAt never walks into its child group, so
+    // an empty relation child (the ANY presence test) is never treated as prunable.
+    const tree = group("OR", [criterion("a"), relation("sessions", group("AND", []))]);
+    expect(removeAt(tree, [0])).toEqual(group("OR", [relation("sessions", group("AND", []))]));
+  });
+
+  it("does not mutate the input tree during a cascade", () => {
+    const tree = group("AND", [criterion("a"), group("OR", [group("AND", [criterion("b")])])]);
+    const snapshot = structuredClone(tree);
+    removeAt(tree, [1, 0, 0]); // full multi-level cascade
+    expect(tree).toEqual(snapshot);
+  });
 });
 
 describe("duplicateAt", () => {

--- a/ts/elements/filter-tree/operations.test.ts
+++ b/ts/elements/filter-tree/operations.test.ts
@@ -110,6 +110,22 @@ describe("insertChild / removeAt", () => {
   it("removing the last child of root yields an empty group", () => {
     expect(removeAt(group("AND", [criterion("a")]), [0])).toEqual(group("AND", []));
   });
+
+  it("removing the last child of a nested group removes that group", () => {
+    const tree = group("AND", [criterion("a"), group("OR", [criterion("b")])]);
+    expect(removeAt(tree, [1, 0])).toEqual(group("AND", [criterion("a")]));
+  });
+
+  it("cascades through multiple ancestors that empty as a result", () => {
+    const tree = group("AND", [criterion("a"), group("OR", [group("AND", [criterion("b")])])]);
+    // Removing the only leaf empties its group, which empties its parent group.
+    expect(removeAt(tree, [1, 0, 0])).toEqual(group("AND", [criterion("a")]));
+  });
+
+  it("stops the cascade at the root, leaving it empty", () => {
+    const tree = group("AND", [group("OR", [criterion("a")])]);
+    expect(removeAt(tree, [0, 0])).toEqual(group("AND", []));
+  });
 });
 
 describe("duplicateAt", () => {

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -132,9 +132,24 @@ export function insertChild(
   });
 }
 
+// Remove the node at `path`, then collapse any group the removal leaves empty:
+// an emptied non-root group is removed from its own parent, cascading upward as
+// long as each removal empties the next ancestor. The root is the one group
+// allowed to sit empty (it cannot be removed — the shell renders it as a "matches
+// all" empty state), so the walk stops there. Keeps the invariant that no
+// rendered, NOT-able group is ever empty (issue #236).
 export function removeAt(root: GroupNode, path: NodePath): GroupNode {
   const { parentPath, index } = splitPath(path);
-  return updateChildren(root, parentPath, (children) => children.filter((_, i) => i !== index));
+  let next = updateChildren(root, parentPath, (children) => children.filter((_, i) => i !== index));
+  let groupPath: NodePath = parentPath;
+  while (groupPath.length > 0 && groupAt(next, groupPath).children.length === 0) {
+    const { parentPath: grandparentPath, index: groupIndex } = splitPath(groupPath);
+    next = updateChildren(next, grandparentPath, (children) =>
+      children.filter((_, i) => i !== groupIndex),
+    );
+    groupPath = grandparentPath;
+  }
+  return next;
 }
 
 export function duplicateAt(root: GroupNode, path: NodePath): GroupNode {

--- a/ts/elements/filter-tree/types.ts
+++ b/ts/elements/filter-tree/types.ts
@@ -18,8 +18,11 @@ export type ComparisonPayload = Record<string, unknown>;
 export interface GroupNode {
   kind: "group";
   connective: Connective; // negation is a separate flag, never a connective
-  // negate on a group with no children is meaningless; silently dropped on
-  // export — wrapNegate returns identity when the inner dict is empty.
+  // negate on a group with no children is meaningless and serializes away
+  // (wrapNegate returns identity for an empty dict). The builder never lets that
+  // state arise: non-root groups auto-collapse when emptied, and the empty root
+  // renders a header-less "matches all" state with no NOT chip (issue #236). The
+  // wrapNegate guard remains only as defense for imported/legacy JSON.
   negate: boolean;
   children: FilterNode[];
 }


### PR DESCRIPTION
Closes #236.

## Problem

A `<filter-group>` with **0 children** rendered a *lit* NOT chip (`aria-pressed="true"`), but serialization silently dropped the negation — `wrapNegate` returns identity on an empty `{}` (negating the identity element is still identity). So the UI claimed a negation the exported `?filter=` did not carry. Reachable since #190 made group-negate a UI control: seed a group → remove its only child → click NOT.

## Approach

Rejected preserving the negation via a backend "match-nothing" sentinel — a zero-result filter has no real use case, and Django's `~Q()` on an empty `Q` is a footgun, so it would mean fragile backend + cross-language-contract work for a filter nobody wants.

Instead, make the lit-NOT-on-empty state **unreachable by construction**:

- **Non-root groups can't sit empty** — `removeAt` cascades: emptying a group removes it from its parent, climbing until a non-empty ancestor or the root.
- **The root** (the one group that can't be removed) renders a header-less empty state — *"No conditions. This will match all items."* + the add affordances — so it shows **no NOT/connective chip**. An empty filter serializes to `{}` (matches everything), which the message states truthfully.

No group rendered with a NOT chip is ever empty → the mismatch can't be produced from the UI. `wrapNegate`'s empty-guard stays as defense for imported/legacy JSON. **TS-only; no backend, no contract change.**

## Changes

| File | Change |
|------|--------|
| `ts/elements/filter-tree/operations.ts` | `removeAt` cascade-prunes emptied non-root groups |
| `ts/elements/filter-group.ts` | `renderGroup` empty-root branch → "matches all" empty state, no header chips |
| `ts/elements/filter-tree/types.ts` | `GroupNode.negate` comment reworded (state now unreachable) |
| `operations.test.ts`, `filter-group.test.ts` | cascade-prune + empty-root + rebuild tests |

## Verification

- `vitest run` — 125 pass (incl. new cases)
- `tsc --noEmit -p tsconfig.check.json` — clean
- `pytest tests/test_filter_tree_contract.py` — 13 pass (serializer logic untouched)

Part of #168 (nested filter builder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)