### PR TITLE
chore: drop stray .playwright-mcp log, gitignore the dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dist/
 /ts/elements/filter-tree/fixtures.canonical.json
 /ts/elements/filter-tokens.canonical.json
 .claude/
+
+# Playwright MCP browser session artifacts
+.playwright-mcp/

--- a/.playwright-mcp/console-2026-06-30T19-29-06-881Z.log
+++ b/.playwright-mcp/console-2026-06-30T19-29-06-881Z.log
@@ -1,1 +1,0 @@
-[   36231ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:8000/favicon.ico:0


### PR DESCRIPTION
A Playwright MCP browser-session log (`.playwright-mcp/console-*.log`) got swept into #239 by `git add -A`. Remove it and gitignore `.playwright-mcp/` so these artifacts never get committed again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)