### PR TITLE
feat(filters): 2c leaf row + criterion widgets (#192)

### DIFF
--- a/common/components/custom_elements.py
+++ b/common/components/custom_elements.py
@@ -171,10 +171,13 @@ _FieldComparisonSet = custom_element_builder("field-comparison-set")
 
 
 class FilterGroupProps(TypedDict):
-    # Root model key (e.g. "game"). Reserved for 2d: it will select the field-
-    # metadata registry + serialization model. The element reads it but does not
-    # consume it yet in this phase (#189).
+    # Root model key (e.g. "game"); the deserializer selects its serialization
+    # model from it.
     model: str
+    # JSON of the model's field_metadata() — the leaf row (#192) reads it to build
+    # each criterion's modifier dropdown + value widget client-side. Mirrors the
+    # FieldComparisonSetProps.columns precedent (JSON in a str-typed prop).
+    fields: str
 
 
 register_element("filter-group", "FilterGroup", FilterGroupProps)
@@ -186,11 +189,29 @@ def FilterGroup(*, model: str) -> Node:
 
     A self-seeding client-built tree: the element starts from an empty root AND
     group and owns the whole `FilterNode` tree in JS, re-rendering on each
-    restructuring op. Behavior + DOM live in ``ts/elements/filter-group.ts``;
-    the connective/negate UI, leaf widgets, and relation block (sibling 2c
-    components) hydrate the inert slots during 2d assembly. Media (the compiled
-    JS) is attached automatically by ``custom_element_builder``."""
-    return _FilterGroup(model=model)
+    restructuring op. Behavior + DOM live in ``ts/elements/filter-group.ts``.
+
+    Carries two things the leaf row (#192) needs client-side: the model's
+    ``field_metadata`` (as the ``fields`` JSON prop) and an **id-less**
+    ``FilterFieldPicker`` in a ``<template>`` the shell clones into each leaf's
+    field cell (id-less so per-leaf clones don't collide; the TS assigns a unique
+    id per clone). The filter class is resolved from ``model`` by convention
+    (``filter_for_model``) — no registry. Media is auto-attached by
+    ``custom_element_builder``."""
+    import json
+
+    from common.components.filters import FilterFieldPicker
+    from common.components.primitives import Template
+    from common.criteria import field_metadata
+    from games.filters import filter_for_model
+
+    filter_cls = filter_for_model(model)
+    return _FilterGroup(
+        model=model,
+        fields=json.dumps(field_metadata(filter_cls)),
+    )[
+        Template(data_field_picker_template="")[FilterFieldPicker(filter_cls)],
+    ]
 
 
 # The <sort-header> builder lives in primitives.py (next to StyledTable, which

--- a/common/components/custom_elements.py
+++ b/common/components/custom_elements.py
@@ -200,17 +200,23 @@ def FilterGroup(*, model: str) -> Node:
     ``custom_element_builder``."""
     import json
 
-    from common.components.filters import FilterFieldPicker
+    from common.components.filters import FilterFieldPicker, field_widget_templates
     from common.components.primitives import Template
     from common.criteria import field_metadata
     from games.filters import filter_for_model
 
     filter_cls = filter_for_model(model)
+    # One blank value-widget <template data-field="name"> per leaf field, cloned
+    # into a leaf's value cell on field-pick, plus the field-picker combobox
+    # template cloned into every leaf's field cell (id-less → the TS assigns a
+    # unique id per clone).
+    widget_templates = list(field_widget_templates(filter_cls).values())
     return _FilterGroup(
         model=model,
         fields=json.dumps(field_metadata(filter_cls)),
     )[
         Template(data_field_picker_template="")[FilterFieldPicker(filter_cls)],
+        *widget_templates,
     ]
 
 

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -1751,8 +1751,9 @@ def StringFilter(
     *,
     path: FilterWidgetPath,
 ) -> Node:
-    """Renders a string filter with 8 modifier radio options and a text input."""
+    """Renders a string filter: a modifier ``<select>`` and a text input."""
     from common.criteria import Modifier
+    from games.forms import SELECT_CLASS
 
     if modifier not in [m.value for m in Modifier.for_strings()]:
         modifier = "EQUALS"
@@ -1768,16 +1769,19 @@ def StringFilter(
         ("NOT_NULL", "is not null"),
     ]
 
-    # Grid of Radios using standard Radio primitives
-    radio_buttons = [
-        Radio(
-            name=f"{input_name_prefix}-modifier",
-            label=lbl,
-            checked=(modifier == mod_val),
-            value=mod_val,
-            data_string_modifier_radio="",
-        )
-        for mod_val, lbl in options
+    # A compact modifier dropdown (was an 8-radio grid): one control reads well both
+    # in the flat bar and nested in the filter builder's tree.
+    modifier_select = Select(
+        [
+            ("name", f"{input_name_prefix}-modifier"),
+            ("data-string-modifier-select", ""),
+            ("class", SELECT_CLASS),
+        ]
+    )[
+        *[
+            Option(value=mod_val, selected=(modifier == mod_val))[lbl]
+            for mod_val, lbl in options
+        ]
     ]
 
     input_disabled = modifier in ("IS_NULL", "NOT_NULL")
@@ -1806,7 +1810,7 @@ def StringFilter(
         filter_widget_attributes(path, "string"),
         class_="flex flex-col gap-2 @container",
     )[
-        Div(class_="grid grid-cols-2 @md:grid-cols-4 gap-2 py-1")[*radio_buttons],
+        modifier_select,
         Input(input_attrs),
     ]
 
@@ -1837,6 +1841,7 @@ def NumberFilter(
     so the widget never flashes before its JS runs.
     """
     from common.criteria import Modifier
+    from games.forms import SELECT_CLASS
 
     if modifier not in [m.value for m in Modifier.for_numbers()]:
         modifier = "EQUALS"
@@ -1852,15 +1857,17 @@ def NumberFilter(
         ("NOT_NULL", "is not null"),
     ]
 
-    radio_buttons = [
-        Radio(
-            name=f"{input_name_prefix}-modifier",
-            label=lbl,
-            checked=(modifier == mod_val),
-            value=mod_val,
-            data_number_modifier_radio="",
-        )
-        for mod_val, lbl in options
+    modifier_select = Select(
+        [
+            ("name", f"{input_name_prefix}-modifier"),
+            ("data-number-modifier-select", ""),
+            ("class", SELECT_CLASS),
+        ]
+    )[
+        *[
+            Option(value=mod_val, selected=(modifier == mod_val))[lbl]
+            for mod_val, lbl in options
+        ]
     ]
 
     inputs_disabled = modifier in ("IS_NULL", "NOT_NULL")
@@ -1897,7 +1904,7 @@ def NumberFilter(
         filter_widget_attributes(path, "number"),
         class_="flex flex-col gap-2 @container",
     )[
-        Div(class_="grid grid-cols-2 @md:grid-cols-4 gap-2 py-1")[*radio_buttons],
+        modifier_select,
         Div(class_="flex items-center gap-2")[
             Input(value_attrs, type="number"),
             Input(value2_attrs, type="number"),

--- a/e2e/test_number_filter_e2e.py
+++ b/e2e/test_number_filter_e2e.py
@@ -83,13 +83,11 @@ def test_number_filter_defaults_and_greater_than(live_server, page):
     value2_input = page.locator('input[name="filter-year-value2"]')
     assert value_input.is_enabled()
     # EQUALS is the default; the second input is hidden.
-    assert page.locator(
-        'input[name="filter-year-modifier"][value="EQUALS"]'
-    ).is_checked()
+    assert page.locator('select[name="filter-year-modifier"]').input_value() == "EQUALS"
     assert value2_input.is_hidden()
 
     value_input.fill("2015")
-    page.locator('input[name="filter-year-modifier"][value="GREATER_THAN"]').click()
+    page.locator('select[name="filter-year-modifier"]').select_option("GREATER_THAN")
     _submit(page)
 
     parsed = _filter_from_url(page.url)
@@ -104,7 +102,7 @@ def test_number_filter_between_reveals_and_serializes(live_server, page):
     value2_input = page.locator('input[name="filter-year-value2"]')
     assert value2_input.is_hidden()
 
-    page.locator('input[name="filter-year-modifier"][value="BETWEEN"]').click()
+    page.locator('select[name="filter-year-modifier"]').select_option("BETWEEN")
     assert value2_input.is_visible()
 
     page.locator('input[name="filter-year"]').fill("2000")
@@ -127,7 +125,7 @@ def test_number_filter_null_states(live_server, page):
     value_input = page.locator('input[name="filter-year"]')
     value_input.fill("1999")
 
-    page.locator('input[name="filter-year-modifier"][value="IS_NULL"]').click()
+    page.locator('select[name="filter-year-modifier"]').select_option("IS_NULL")
 
     # Both inputs disable and clear under a presence modifier.
     assert not value_input.is_enabled()
@@ -147,13 +145,14 @@ def test_number_filter_prefilled_states(live_server, page):
     assert page.locator('input[name="filter-year"]').input_value() == "2000"
     assert page.locator('input[name="filter-year-value2"]').input_value() == "2010"
     assert page.locator('input[name="filter-year-value2"]').is_visible()
-    assert page.locator(
-        'input[name="filter-year-modifier"][value="BETWEEN"]'
-    ).is_checked()
+    assert (
+        page.locator('select[name="filter-year-modifier"]').input_value() == "BETWEEN"
+    )
 
-    # session_count: IS_NULL — value input disabled, modifier checked.
+    # session_count: IS_NULL — value input disabled, modifier selected.
     session_input = page.locator('input[name="filter-session-count"]')
     assert not session_input.is_enabled()
-    assert page.locator(
-        'input[name="filter-session-count-modifier"][value="IS_NULL"]'
-    ).is_checked()
+    assert (
+        page.locator('select[name="filter-session-count-modifier"]').input_value()
+        == "IS_NULL"
+    )

--- a/e2e/test_string_filter_e2e.py
+++ b/e2e/test_string_filter_e2e.py
@@ -65,15 +65,12 @@ def test_string_filter_defaults_and_toggles(live_server, page):
     name_input = page.locator('input[name="filter-name"]')
     assert name_input.is_enabled()
 
-    is_radio = page.locator('input[name="filter-name-modifier"][value="EQUALS"]')
-    assert is_radio.is_checked()
+    modifier_select = page.locator('select[name="filter-name-modifier"]')
+    assert modifier_select.input_value() == "EQUALS"
 
-    # 2. Enter values, click "includes" (INCLUDES), and submit
+    # 2. Enter values, choose "includes" (INCLUDES), and submit
     name_input.fill("PlayStation")
-    includes_radio = page.locator(
-        'input[name="filter-name-modifier"][value="INCLUDES"]'
-    )
-    includes_radio.click()
+    modifier_select.select_option("INCLUDES")
 
     with page.expect_navigation():
         page.evaluate(
@@ -92,9 +89,8 @@ def test_string_filter_null_states(live_server, page):
     name_input = page.locator('input[name="filter-name"]')
     name_input.fill("Xbox")
 
-    # Click "is null"
-    is_null_radio = page.locator('input[name="filter-name-modifier"][value="IS_NULL"]')
-    is_null_radio.click()
+    # Choose "is null"
+    page.locator('select[name="filter-name-modifier"]').select_option("IS_NULL")
 
     # Verification of interactive disabling
     assert not name_input.is_enabled()
@@ -117,33 +113,33 @@ def test_string_filter_prefilled_states(live_server, page):
     name_input = page.locator('input[name="filter-name"]')
     group_input = page.locator('input[name="filter-group"]')
 
-    # Verifies name matches "Switch" and "includes" is checked
+    # Verifies name matches "Switch" and "includes" is selected
     assert name_input.input_value() == "Switch"
     assert name_input.is_enabled()
-    assert page.locator(
-        'input[name="filter-name-modifier"][value="INCLUDES"]'
-    ).is_checked()
+    assert (
+        page.locator('select[name="filter-name-modifier"]').input_value() == "INCLUDES"
+    )
 
-    # Verifies group is empty, disabled, and "is null" is checked
+    # Verifies group is empty, disabled, and "is null" is selected
     assert group_input.input_value() == ""
     assert not group_input.is_enabled()
-    assert page.locator(
-        'input[name="filter-group-modifier"][value="IS_NULL"]'
-    ).is_checked()
+    assert (
+        page.locator('select[name="filter-group-modifier"]').input_value() == "IS_NULL"
+    )
 
 
 @pytest.mark.django_db
 @override_settings(ROOT_URLCONF="e2e.test_string_filter_e2e")
-def test_string_filter_deselect_re_enables(live_server, page):
+def test_string_filter_modifier_switch_re_enables(live_server, page):
     page.goto(live_server.url + "/test-string-filter-empty/")
 
     name_input = page.locator('input[name="filter-name"]')
-    is_null_radio = page.locator('input[name="filter-name-modifier"][value="IS_NULL"]')
+    modifier_select = page.locator('select[name="filter-name-modifier"]')
 
-    # 1. Click "is null" -> disables input
-    is_null_radio.click()
+    # 1. Choose "is null" -> disables the text input
+    modifier_select.select_option("IS_NULL")
     assert not name_input.is_enabled()
 
-    # 2. Click "is null" again to deselect/uncheck -> should re-enable the text input
-    is_null_radio.click()
+    # 2. Switch back to a value modifier -> re-enables the text input
+    modifier_select.select_option("EQUALS")
     assert name_input.is_enabled()

--- a/e2e/test_widgets_e2e.py
+++ b/e2e/test_widgets_e2e.py
@@ -100,7 +100,7 @@ def test_number_filter_between_reveals_second_input(
     value2 = page.locator('input[name="filter-year-value2"]')
     expect(value2).to_be_hidden()
 
-    page.locator('input[name="filter-year-modifier"][value="BETWEEN"]').check()
+    page.locator('select[name="filter-year-modifier"]').select_option("BETWEEN")
     expect(value2).to_be_visible()
 
 
@@ -130,7 +130,7 @@ def test_widgets_initialize_inside_htmx_swapped_content(
 
     value2 = page.locator('input[name="filter-year-value2"]')
     expect(value2).to_be_hidden()
-    page.locator('input[name="filter-year-modifier"][value="BETWEEN"]').check()
+    page.locator('select[name="filter-year-modifier"]').select_option("BETWEEN")
     expect(value2).to_be_visible()
 
 

--- a/games/filters.py
+++ b/games/filters.py
@@ -750,6 +750,24 @@ def parse_playevent_filter(json_str: str) -> PlayEventFilter | None:
     return filter_from_json(PlayEventFilter, json_str)
 
 
+# ── Model-key → filter-class resolution ────────────────────────────────────
+
+
+def filter_for_model(model_name: str) -> type[OperatorFilter]:
+    """Resolve a model key (e.g. ``"game"``) to its ``OperatorFilter`` subclass by
+    naming convention — no registry to maintain.
+
+    The nested filter builder element carries ``model = Model._meta.model_name``;
+    every filter in this module is named ``{Model.__name__}Filter``. So
+    ``"game" → Game → GameFilter``. Raises ``LookupError`` for an unknown model and
+    ``KeyError`` if a model has no matching filter class.
+    """
+    from django.apps import apps
+
+    model = apps.get_model("games", model_name)
+    return globals()[f"{model.__name__}Filter"]
+
+
 # ── URL building (the "reverse() for filters") ─────────────────────────────
 
 

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -51,9 +51,9 @@ class FilterBarRenderingTest(TestCase):
 
     def _assert_number_filter(self, html, field_prefix):
         """Every filter bar must use the Stash-style NumberFilter: a modifier
-        radio grid plus two number inputs (value + value2), with no legacy
+        <select> plus two number inputs (value + value2), with no legacy
         RangeSlider custom element left behind."""
-        self.assertIn("data-number-modifier-radio", html)
+        self.assertIn("data-number-modifier-select", html)
         self.assertIn(f'name="{field_prefix}-modifier"', html)
         self.assertIn('value="BETWEEN"', html)
         self.assertIn('value="IS_NULL"', html)
@@ -592,7 +592,7 @@ class FilterBarRenderingTest(TestCase):
 class NumberFilterRenderTest(TestCase):
     """Render-level contract for the Stash-style NumberFilter component."""
 
-    def test_renders_all_eight_modifier_radios(self):
+    def test_renders_all_eight_modifier_options(self):
         html = str(
             NumberFilter(input_name_prefix="filter-year", path=["year_released"])
         )
@@ -607,7 +607,7 @@ class NumberFilterRenderTest(TestCase):
             "NOT_NULL",
         ):
             self.assertIn(f'value="{modifier}"', html)
-        self.assertIn("data-number-modifier-radio", html)
+        self.assertIn("data-number-modifier-select", html)
 
     def test_renders_two_number_inputs(self):
         html = str(
@@ -624,8 +624,9 @@ class NumberFilterRenderTest(TestCase):
         )
         # value2 is hidden for the default EQUALS modifier.
         self.assertRegex(html, r'data-number-value2="" class="[^"]*\bhidden\b')
-        # Inputs are not disabled by default.
-        self.assertNotIn("disabled", html)
+        # Inputs are not disabled by default (the select's class carries the
+        # `disabled:` utility variants, so match the real disabled attribute).
+        self.assertNotIn('disabled="true"', html)
 
     def test_between_shows_second_input_and_prefills_values(self):
         html = str(
@@ -652,7 +653,7 @@ class NumberFilterRenderTest(TestCase):
                 path=["year_released"],
             )
         )
-        self.assertIn("disabled", html)
+        self.assertIn('disabled="true"', html)
         self.assertIn("cursor-not-allowed", html)
         # Values are cleared while disabled.
         self.assertNotIn('value="2000"', html)
@@ -666,8 +667,8 @@ class NumberFilterRenderTest(TestCase):
                 path=["year_released"],
             )
         )
-        # EQUALS is the only checked radio when an invalid modifier is given.
-        self.assertRegex(html, r'value="EQUALS"[^>]*checked="true"')
+        # EQUALS is the selected option when an invalid modifier is given.
+        self.assertRegex(html, r'value="EQUALS"[^>]*selected')
         self.assertNotRegex(html, r'value="INCLUDES"')
 
 

--- a/timetracker/urls.py
+++ b/timetracker/urls.py
@@ -55,24 +55,12 @@ if settings.DEBUG:
     from django.http import HttpResponse
     from django.templatetags.static import static
 
-    from common.components import FilterFieldPicker, FilterGroup
-    from common.components.core import Safe
-    from games.filters import GameFilter
-
-    # Inline ES module: log the picked field's reset leaf so the field picker
-    # (#191) can be eyeballed standalone. Scoped to the [data-field-picker] marker
-    # so it never trips on another <search-select> on the page.
-    _picker_demo_script = (
-        "import { parseFieldMeta, criterionForField } from "
-        "'/static/js/dist/elements/filter-tree/operations.js';\n"
-        "document.querySelector('[data-field-picker]')"
-        ".addEventListener('search-select:change', (event) => {\n"
-        "  const meta = parseFieldMeta(event.detail.last?.data?.meta ?? '');\n"
-        "  if (meta) console.log('field-picker →', criterionForField(meta));\n"
-        "});"
-    )
+    from common.components import FilterGroup
 
     def filter_group_demo(_request: object) -> HttpResponse:
+        # The leaf rows clone search-select (field picker + set values) and
+        # date-range-picker (date values), so both element modules must load; the
+        # rest of the value widgets are plain markup wired by filter-group.js.
         page = Document(
             Html(lang="en")[
                 Head()[
@@ -85,14 +73,16 @@ if settings.DEBUG:
                     Script(
                         type="module", src=static("js/dist/elements/search-select.js")
                     ),
+                    Script(
+                        type="module",
+                        src=static("js/dist/elements/date-range-picker.js"),
+                    ),
                 ],
                 Body(class_="bg-body p-6 dark:bg-gray-900")[
                     StyledButton(
                         onclick="document.documentElement.classList.toggle('dark')"
                     )["Toggle dark"],
                     FilterGroup(model="game"),
-                    FilterFieldPicker(GameFilter, id="id_field_picker"),
-                    Script(type="module")[Safe(_picker_demo_script)],
                 ],
             ]
         )

--- a/ts/elements/date-range-picker.test.ts
+++ b/ts/elements/date-range-picker.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { DATE_RANGE_CHANGE_EVENT, type DateRangeChangeDetail } from "./date-range-picker.js";
+
+// Minimal-complete markup mirroring DateRangeField + DateRangeCalendar — only the
+// data hooks the element wires. One "min" side of day/month/year segments plus the
+// calendar scaffold createCalendarState dereferences (all queried non-null).
+function segment(part: string, side: string, width: number, placeholder: string): string {
+  return (
+    `<input data-date-part="${part}" data-date-side="${side}" ` +
+    `maxlength="${width}" placeholder="${placeholder}" />`
+  );
+}
+
+function calendarScaffold(): string {
+  return `
+    <button data-date-range-calendar-toggle></button>
+    <div data-date-range-calendar class="hidden">
+      <button data-date-range-prev></button>
+      <span data-date-range-month-label></span>
+      <button data-date-range-next></button>
+      <div data-date-range-grid></div>
+      <button data-date-range-cancel></button>
+      <button data-date-range-clear></button>
+      <button data-date-range-select></button>
+    </div>`;
+}
+
+function mount(): HTMLElement {
+  document.body.replaceChildren();
+  const picker = document.createElement("date-range-picker");
+  picker.innerHTML = `
+    <input type="hidden" data-date-range-hidden="min" />
+    <input type="hidden" data-date-range-hidden="max" />
+    <div data-date-range-field>
+      ${segment("day", "min", 2, "DD")}${segment("month", "min", 2, "MM")}${segment("year", "min", 4, "YYYY")}
+    </div>
+    ${calendarScaffold()}`;
+  document.body.appendChild(picker); // connectedCallback → initPicker
+  return picker;
+}
+
+function typeDigits(input: HTMLInputElement, digits: string): void {
+  input.focus();
+  for (const digit of digits) {
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: digit, bubbles: true }));
+  }
+}
+
+describe("date-range-picker change event (#192)", () => {
+  beforeEach(() => document.body.replaceChildren());
+
+  it("fires date-range:change with both bounds once a side completes", () => {
+    const picker = mount();
+    const details: DateRangeChangeDetail[] = [];
+    picker.addEventListener(DATE_RANGE_CHANGE_EVENT, (event) => {
+      details.push((event as CustomEvent<DateRangeChangeDetail>).detail);
+    });
+
+    const field = picker.querySelector<HTMLElement>("[data-date-range-field]")!;
+    const [day, month, year] = field.querySelectorAll<HTMLInputElement>("input[data-date-part]");
+    typeDigits(day, "15");
+    typeDigits(month, "06");
+    typeDigits(year, "2026");
+
+    // The completing keystroke (last year digit) is when the ISO becomes valid.
+    const last = details.at(-1);
+    expect(last).toEqual({ min: "2026-06-15", max: "" });
+    expect(picker.querySelector<HTMLInputElement>('[data-date-range-hidden="min"]')!.value).toBe(
+      "2026-06-15",
+    );
+  });
+
+  it("does not fire while a side is still incomplete", () => {
+    const picker = mount();
+    let fired = 0;
+    picker.addEventListener(DATE_RANGE_CHANGE_EVENT, () => (fired += 1));
+
+    const day = picker.querySelector<HTMLInputElement>('input[data-date-part="day"]')!;
+    typeDigits(day, "15"); // day only — hidden stays "", no committed change
+
+    expect(fired).toBe(0);
+  });
+});

--- a/ts/elements/date-range-picker.ts
+++ b/ts/elements/date-range-picker.ts
@@ -22,6 +22,29 @@
  */
 import { bindPopupDismiss } from "../utils.js";
 
+// Fired whenever a committed bound actually changes — segment typing or a
+// calendar/preset pick (issue #192). The flat filter bar reads the hidden inputs
+// at serialize time (pull), but the nested filter builder's date leaf needs a push
+// signal to fold the new value into its tree node. detail carries both ISO bounds
+// ("" when a side is empty) so a consumer needn't re-query the DOM.
+export const DATE_RANGE_CHANGE_EVENT = "date-range:change";
+
+export interface DateRangeChangeDetail {
+  min: string;
+  max: string;
+}
+
+function dispatchDateRangeChange(picker: HTMLElement): void {
+  const read = (side: string): string =>
+    picker.querySelector<HTMLInputElement>(`input[data-date-range-hidden="${side}"]`)?.value ?? "";
+  picker.dispatchEvent(
+    new CustomEvent<DateRangeChangeDetail>(DATE_RANGE_CHANGE_EVENT, {
+      bubbles: true,
+      detail: { min: read("min"), max: read("max") },
+    }),
+  );
+}
+
 type Anchor = "" | "start" | "end";
 
 interface CalendarState {
@@ -230,7 +253,9 @@ function syncHiddenFromSegments(picker: HTMLElement, side: string): boolean {
   } else {
     hidden.value = "";
   }
-  return hidden.value !== previousValue;
+  const changed = hidden.value !== previousValue;
+  if (changed) dispatchDateRangeChange(picker);
+  return changed;
 }
 
 /** Push an ISO value (or "") into a side's segments and hidden input. */
@@ -238,6 +263,7 @@ function setSideValue(picker: HTMLElement, side: string, isoString: string): voi
   const hidden = picker.querySelector<HTMLInputElement>(
     `input[data-date-range-hidden="${side}"]`
   )!;
+  const previousValue = hidden.value;
   hidden.value = isoString;
   let partValues: Record<string, string> = { year: "", month: "", day: "" };
   if (isoString) {
@@ -247,6 +273,7 @@ function setSideValue(picker: HTMLElement, side: string, isoString: string): voi
   segmentsForSide(picker, side).forEach((segment) => {
     setSegmentBuffer(segment, partValues[segment.dataset.datePart ?? ""]);
   });
+  if (hidden.value !== previousValue) dispatchDateRangeChange(picker);
 }
 
 function initField(picker: HTMLElement, calendarState: CalendarState): void {

--- a/ts/elements/date-range-picker.ts
+++ b/ts/elements/date-range-picker.ts
@@ -367,7 +367,7 @@ function initField(picker: HTMLElement, calendarState: CalendarState): void {
 
 function createCalendarState(
   picker: HTMLElement
-): { state: CalendarState; cleanup: () => void } {
+): { state: CalendarState; bindDismiss: () => () => void } {
   const popup = picker.querySelector<HTMLElement>("[data-date-range-calendar]")!;
   const grid = popup.querySelector<HTMLElement>("[data-date-range-grid]")!;
   const monthLabel = popup.querySelector<HTMLElement>("[data-date-range-month-label]")!;
@@ -630,26 +630,29 @@ function createCalendarState(
       closePopup();
     });
 
-  const cleanup = bindPopupDismiss({
-    host: picker,
-    isOpen: () => state.open,
-    close: closePopup,
-  });
+  // Deferred + re-callable so a reconnection (the nested filter builder moves rows,
+  // reconnecting this element) re-binds the outside-click dismiss without re-wiring
+  // the field/calendar listeners, which persist with the moved subtree.
+  const bindDismiss = (): (() => void) =>
+    bindPopupDismiss({ host: picker, isOpen: () => state.open, close: closePopup });
 
-  return { state, cleanup };
+  return { state, bindDismiss };
 }
 
-function initPicker(picker: HTMLElement): () => void {
-  const { state: calendarState, cleanup } = createCalendarState(picker);
+// One-time wiring (field + calendar listeners); returns the dismiss-binder.
+function initPicker(picker: HTMLElement): () => () => void {
+  const { state: calendarState, bindDismiss } = createCalendarState(picker);
   initField(picker, calendarState);
-  return cleanup;
+  return bindDismiss;
 }
 
 class DateRangePickerElement extends HTMLElement {
+  private bindDismiss: (() => () => void) | null = null;
   private cleanup: (() => void) | null = null;
 
   connectedCallback(): void {
-    this.cleanup = initPicker(this);
+    if (!this.bindDismiss) this.bindDismiss = initPicker(this); // one-time
+    this.cleanup = this.bindDismiss(); // (re)bind outside-click dismiss
   }
 
   disconnectedCallback(): void {

--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -7,57 +7,19 @@
  */
 import { readFilterBarProps } from "../generated/props.js";
 import { readFieldComparisonSet } from "./field-comparison-set.js";
-import { isPresenceModifier, isRangeModifier } from "./filter-tokens.js";
 import { readSearchSelect } from "./search-select.js";
-
-interface Criterion {
-  value: unknown;
-  modifier: string;
-  value2?: unknown;
-}
-
-interface PillEntry {
-  id: string;
-  label: string;
-}
+import {
+  parseJSONAttr,
+  readBoolWidget,
+  readDateWidget,
+  readNumberWidget,
+  readSetWidget,
+  readStringWidget,
+  setupModifierToggles,
+} from "./filter-widgets.js";
 
 interface DeselectableRadio extends HTMLInputElement {
   wasChecked?: boolean;
-}
-
-function criterion(value: unknown, value2: unknown, modifier: string): Criterion {
-  const result: Criterion = { value, modifier };
-  if (value2 !== null && value2 !== undefined && value2 !== "") {
-    result.value2 = value2;
-  }
-  return result;
-}
-
-function parseNumberInputValue(element: HTMLInputElement | null): number | "" {
-  if (!element || element.value === "") return "";
-  const value = parseFloat(element.value);
-  return isNaN(value) ? "" : value;
-}
-
-function buildRangeCriterion(
-  valueMin: number | string,
-  valueMax: number | string,
-): Criterion | null {
-  if (valueMin !== "" && valueMax !== "") return criterion(valueMin, valueMax, "BETWEEN");
-  if (valueMin !== "") return criterion(valueMin, null, "GREATER_THAN");
-  if (valueMax !== "") return criterion(valueMax, null, "LESS_THAN");
-  return null;
-}
-
-function parseJSONAttr<T>(element: Element, attr: string): T[] {
-  const raw = element.getAttribute(attr);
-  if (!raw) return [];
-  try {
-    return JSON.parse(raw);
-  } catch {
-    console.warn("filter-bar: malformed JSON attribute", attr, raw);
-    return [];
-  }
 }
 
 function baseUrl(): string {
@@ -130,80 +92,6 @@ function appendAnd(
 ): void {
   if (!Array.isArray(filter.AND)) filter.AND = [];
   (filter.AND as unknown[]).push(element);
-}
-
-// Per-kind readers: each is scoped to a single widget element and returns a
-// criterion object, or null to omit the field entirely. The value/modifier
-// logic is a verbatim port of the former hardcoded field loops; only the
-// element lookup changed (within the widget element instead of global [name=…]).
-
-function readStringWidget(element: HTMLElement): Record<string, unknown> | null {
-  const modifier =
-    element.querySelector<HTMLInputElement>('input[data-string-modifier-radio]:checked')
-      ?.value ?? "EQUALS";
-  if (isPresenceModifier(modifier)) {
-    return { modifier };
-  }
-  const textInput = element.querySelector<HTMLInputElement>('input[type="text"]');
-  if (textInput && textInput.value.trim()) {
-    return { value: textInput.value.trim(), modifier };
-  }
-  return null;
-}
-
-function readNumberWidget(element: HTMLElement): Criterion | Record<string, unknown> | null {
-  const modifier =
-    element.querySelector<HTMLInputElement>('input[data-number-modifier-radio]:checked')
-      ?.value ?? "EQUALS";
-  if (isPresenceModifier(modifier)) {
-    return { modifier };
-  }
-  const value = parseNumberInputValue(
-    element.querySelector<HTMLInputElement>('input[type="number"]:not([data-number-value2])'),
-  );
-  if (isRangeModifier(modifier)) {
-    const value2Marker = element.querySelector('[data-number-value2]');
-    const value2Input =
-      value2Marker instanceof HTMLInputElement
-        ? value2Marker
-        : (value2Marker?.querySelector<HTMLInputElement>("input") ?? null);
-    const value2 = parseNumberInputValue(value2Input);
-    if (value !== "") return criterion(value, value2, modifier);
-    return null;
-  }
-  if (value !== "") return criterion(value, null, modifier);
-  return null;
-}
-
-function readDateWidget(element: HTMLElement): Criterion | null {
-  const valueMin =
-    element.querySelector<HTMLInputElement>("[data-range-min]")?.value ?? "";
-  const valueMax =
-    element.querySelector<HTMLInputElement>("[data-range-max]")?.value ?? "";
-  return buildRangeCriterion(valueMin, valueMax);
-}
-
-function readBoolWidget(element: HTMLElement): Criterion | null {
-  const checked = element.querySelector<HTMLInputElement>('input[type="radio"]:checked');
-  if (!checked) return null;
-  return criterion(checked.value === "true", null, "EQUALS");
-}
-
-function readSetWidget(element: HTMLElement): Record<string, unknown> | null {
-  const included = parseJSONAttr<PillEntry>(element, "data-included");
-  const excluded = parseJSONAttr<PillEntry>(element, "data-excluded");
-  const modifier = element.getAttribute("data-modifier");
-  if (modifier && isPresenceModifier(modifier)) {
-    return { modifier };
-  }
-  if (included.length > 0 || excluded.length > 0) {
-    return {
-      value: included.map((item) => ({ id: item.id, label: item.label })),
-      excludes: excluded.map((item) => ({ id: item.id, label: item.label })),
-      modifier: modifier || "INCLUDES",
-    };
-  }
-  return null;
 }
 
 function readWidget(element: HTMLElement, kind: string | null): unknown {
@@ -351,68 +239,6 @@ function setupDeselectableRadios(root: HTMLElement): void {
     });
     if (radio.checked) {
       radio.wasChecked = true;
-    }
-  });
-}
-
-function toggleStringFilterInput(radio: HTMLInputElement): void {
-  const container = radio.closest(".flex-col");
-  if (!container) return;
-  const textInput = container.querySelector<HTMLInputElement>('input[type="text"]');
-  if (!textInput) return;
-  const checkedRadio = container.querySelector<HTMLInputElement>('input[type="radio"]:checked');
-  const value = checkedRadio ? checkedRadio.value : "";
-  if (value === "IS_NULL" || value === "NOT_NULL") {
-    textInput.disabled = true;
-    textInput.value = "";
-    textInput.classList.add("opacity-50", "cursor-not-allowed");
-  } else {
-    textInput.disabled = false;
-    textInput.classList.remove("opacity-50", "cursor-not-allowed");
-  }
-}
-
-function setupStringFilters(root: HTMLElement): void {
-  // Delegated on the persistent custom element (see setupNumberFilters) so the
-  // modifier radios keep working after an htmx swap of the inner #filter-bar.
-  root.addEventListener("change", (event) => {
-    const target = event.target as Element;
-    if (target.matches("input[data-string-modifier-radio]")) {
-      toggleStringFilterInput(target as HTMLInputElement);
-    }
-  });
-}
-
-function toggleNumberFilterInput(radio: HTMLInputElement): void {
-  const container = radio.closest(".flex-col");
-  if (!container) return;
-  const inputs = container.querySelectorAll<HTMLInputElement>('input[type="number"]');
-  const value2 = container.querySelector<HTMLInputElement>("[data-number-value2]");
-  const checkedRadio = container.querySelector<HTMLInputElement>('input[type="radio"]:checked');
-  const modifier = checkedRadio ? checkedRadio.value : "";
-  const isPresence = modifier === "IS_NULL" || modifier === "NOT_NULL";
-  const isBetween = modifier === "BETWEEN" || modifier === "NOT_BETWEEN";
-  inputs.forEach((input) => {
-    if (isPresence) {
-      input.disabled = true;
-      input.value = "";
-      input.classList.add("opacity-50", "cursor-not-allowed");
-    } else {
-      input.disabled = false;
-      input.classList.remove("opacity-50", "cursor-not-allowed");
-    }
-  });
-  if (value2) value2.classList.toggle("hidden", isPresence || !isBetween);
-}
-
-function setupNumberFilters(root: HTMLElement): void {
-  // Delegated on the persistent custom element so the modifier radios keep
-  // working after the inner #filter-bar body is htmx-swapped (connectedCallback
-  // does not re-run for inner swaps — a direct per-radio listener would be lost).
-  root.addEventListener("change", (event) => {
-    const target = event.target as Element;
-    if (target.matches("input[data-number-modifier-radio]")) {
-      toggleNumberFilterInput(target as HTMLInputElement);
     }
   });
 }
@@ -623,8 +449,7 @@ class FilterBarElement extends HTMLElement {
     });
 
     setupDeselectableRadios(this);
-    setupStringFilters(this);
-    setupNumberFilters(this);
+    setupModifierToggles(this);
     if (presetListUrl) loadPresets(this, presetListUrl);
   }
 }

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -130,20 +130,12 @@ describe("<filter-group> change event", () => {
   });
 });
 
-describe("<filter-group> inert-slot contract (2d hydration)", () => {
-  it("leaf/relation slots carry data-path and a round-trippable data-payload", () => {
+describe("<filter-group> relation slot (inert, comp 5)", () => {
+  it("relation slots carry data-path and data-node-kind", () => {
     const host = mount();
     clickAction(host, "add-relation", []); // [0]=criterion, [1]=relation
     const relationSlot = slots(host).find((slot) => slot.dataset.nodeKind === "relation")!;
     expect(relationSlot.dataset.path).toBe(JSON.stringify([1]));
-    expect(JSON.parse(relationSlot.dataset.payload!)).toMatchObject({
-      kind: "relation",
-      field: "",
-      match: "ANY",
-      negate: false,
-    });
-    const criterionSlot = slots(host).find((slot) => slot.dataset.nodeKind === "criterion")!;
-    expect(JSON.parse(criterionSlot.dataset.payload!)).toMatchObject({ kind: "criterion", negate: false });
   });
 });
 
@@ -263,3 +255,107 @@ describe("<filter-group> duplicate + event fidelity", () => {
 });
 
 type GroupNodeLike = { children: unknown[] };
+
+// ── Live criterion leaf row (#192) ──
+// The real templates come from the server (FilterGroup Python); here we synthesize
+// a minimal field-picker + one string field widget so the row wiring can be driven
+// in jsdom. The string widget mirrors StringFilter's data hooks readStringWidget reads.
+const NAME_META = {
+  name: "name",
+  label: "Name",
+  kind: "string",
+  nullable: false,
+  choices: [],
+  modifiers: ["EQUALS", "INCLUDES"],
+  relations: [],
+};
+
+function mountLive(): FilterGroupElement {
+  document.body.replaceChildren();
+  const host = document.createElement("filter-group") as FilterGroupElement;
+  host.setAttribute("model", "game");
+  host.setAttribute("fields", JSON.stringify([NAME_META]));
+  // Templates must exist before connectedCallback (captureTemplates runs there).
+  host.innerHTML = `
+    <template data-field-picker-template>
+      <div data-field-picker><search-select name="field-picker"><input data-search-select-search /></search-select></div>
+    </template>
+    <template data-field="name">
+      <div class="flex-col">
+        <input type="radio" data-string-modifier-radio value="EQUALS" checked />
+        <input type="text" />
+      </div>
+    </template>`;
+  document.body.appendChild(host); // connectedCallback → captures templates + renders
+  return host;
+}
+
+function row(host: HTMLElement, path: number[]): HTMLElement {
+  return host.querySelector<HTMLElement>(
+    `[data-node-slot][data-path="${JSON.stringify(path)}"]`,
+  )!;
+}
+
+function pickField(host: HTMLElement, path: number[], meta: object): void {
+  const picker = row(host, path).querySelector<HTMLElement>("[data-field-picker]")!;
+  picker.dispatchEvent(
+    new CustomEvent("search-select:change", {
+      bubbles: true,
+      detail: { name: "field-picker", values: [], last: { data: { meta: JSON.stringify(meta) } } },
+    }),
+  );
+}
+
+function typeValue(host: HTMLElement, path: number[], text: string): void {
+  const input = row(host, path).querySelector<HTMLInputElement>('[data-value-cell] input[type="text"]')!;
+  input.value = text;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("<filter-group> live criterion leaf row (#192)", () => {
+  it("picking a field swaps in that field's value widget", () => {
+    const host = mountLive();
+    expect(row(host, [0]).querySelector('[data-value-cell] input[type="text"]')).toBeNull();
+    pickField(host, [0], NAME_META);
+    expect(row(host, [0]).querySelector('[data-value-cell] input[type="text"]')).not.toBeNull();
+  });
+
+  it("serializeForQuery reads the live widget into the exact backend payload shape", () => {
+    const host = mountLive();
+    pickField(host, [0], NAME_META);
+    typeValue(host, [0], "Hades");
+    expect(host.serializeForQuery()).toEqual({
+      AND: [{ name: { value: "Hades", modifier: "EQUALS" } }],
+    });
+  });
+
+  it("excludes an incomplete leaf (no value) from the query + flags it", () => {
+    const host = mountLive();
+    pickField(host, [0], NAME_META); // field chosen, value still empty
+    expect(row(host, [0]).querySelector("[data-incomplete-badge]")).not.toBeNull();
+    expect(host.serializeForQuery()).toEqual({}); // pruned → matches all
+    expect(host.serialize()).not.toEqual({}); // structure still carries the leaf
+  });
+
+  it("a leaf's live value survives a structural edit elsewhere (reconcile by id)", () => {
+    const host = mountLive();
+    pickField(host, [0], NAME_META);
+    typeValue(host, [0], "Hades");
+    clickAction(host, "add-condition", []); // structural re-render of the whole tree
+    // The first row's widget DOM (and its typed value) is reused, not rebuilt.
+    const input = row(host, [0]).querySelector<HTMLInputElement>('[data-value-cell] input[type="text"]')!;
+    expect(input.value).toBe("Hades");
+  });
+
+  it("reports incompleteCount in the change event", () => {
+    const host = mountLive();
+    let last = -1;
+    host.addEventListener("filter-tree-change", (event) => {
+      last = (event as CustomEvent).detail.incompleteCount;
+    });
+    pickField(host, [0], NAME_META); // 1 incomplete (no value yet)
+    expect(last).toBe(1);
+    typeValue(host, [0], "Hades");
+    expect(last).toBe(0);
+  });
+});

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -282,7 +282,11 @@ function mountLive(): FilterGroupElement {
     </template>
     <template data-field="name">
       <div class="flex-col">
-        <input type="radio" data-string-modifier-radio value="EQUALS" checked />
+        <select data-string-modifier-select>
+          <option value="EQUALS" selected>is</option>
+          <option value="INCLUDES">includes</option>
+          <option value="IS_NULL">is null</option>
+        </select>
         <input type="text" />
       </div>
     </template>`;

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -78,9 +78,12 @@ const VALUE_CELL_CLASS = "flex-1 min-w-[12rem]";
 const VALUE_PLACEHOLDER_CLASS =
   "flex-1 min-w-[12rem] rounded border border-dashed border-gray-300 px-2 py-1 text-sm " +
   "text-gray-500 dark:border-gray-600 dark:text-gray-400";
-// Faded look + "Incomplete" badge for a leaf missing its value (excluded from the
-// count/Apply query). Applied to the whole row.
-const INCOMPLETE_ROW_CLASS = "opacity-60";
+// Incomplete-leaf cue (excluded from the count/Apply query): a subtle amber tint
+// on the row + the "Incomplete" badge. NOT `opacity` — a faded ancestor would make
+// the leaf's own field-picker dropdown 60% transparent *and* create a stacking
+// context that traps its z-10 below sibling rows/footer. A bg tint is safe on both
+// counts. Space-separated → toggled token-by-token (classList.toggle takes one).
+const INCOMPLETE_ROW_CLASS = "bg-amber-50 dark:bg-amber-500/10 rounded";
 const BADGE_CLASS =
   "rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-medium " +
   "text-amber-700 dark:border-amber-500/50 dark:bg-amber-500/10 dark:text-amber-300";
@@ -572,7 +575,7 @@ export class FilterGroupElement extends HTMLElement {
   }
 
   private applyIncompleteState(row: HTMLElement, incomplete: boolean): void {
-    row.classList.toggle(INCOMPLETE_ROW_CLASS, incomplete);
+    for (const token of INCOMPLETE_ROW_CLASS.split(" ")) row.classList.toggle(token, incomplete);
     let badge = row.querySelector<HTMLElement>("[data-incomplete-badge]");
     if (incomplete && !badge) {
       badge = element("span", BADGE_CLASS);

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -18,26 +18,40 @@
  */
 import { readFilterGroupProps } from "../generated/props.js";
 import { serialize } from "./filter-tree/serializer.js";
-import type { Connective, FilterNode, FilterTreeChangeDetail, GroupNode } from "./filter-tree/types.js";
+import type {
+  Connective,
+  CriterionLeaf,
+  FilterFieldMeta,
+  FilterNode,
+  FilterTreeChangeDetail,
+  GroupNode,
+} from "./filter-tree/types.js";
 import {
   type NodePath,
   canAddGroup,
   canAddRelation,
   canUnwrap,
   canWrap,
+  criterionForField,
   duplicateAt,
   emptyCriterion,
   emptyGroup,
   emptyRelation,
   emptyRoot,
   insertChild,
+  isCriterionComplete,
   move,
+  parseFieldMeta,
+  pruneIncomplete,
   removeAt,
+  setLeafField,
   toggleConnective,
   toggleNegate,
   unwrapGroup,
   wrapInGroup,
 } from "./filter-tree/operations.js";
+import { readLeafWidget, setupModifierToggles } from "./filter-widgets.js";
+import type { SearchSelectChangeDetail } from "./search-select.js";
 
 // Full, static class strings only — Tailwind detects complete strings, so the
 // depth palette is a fixed lookup (never `bg-depth-${n}`). ~4-shade cycle that
@@ -57,10 +71,19 @@ const FOOTER_CLASS = "flex flex-wrap gap-2";
 // chip on a group with nothing to negate or join (issue #236).
 const EMPTY_STATE_CLASS = "px-2 py-1 text-sm text-gray-500 dark:text-gray-400";
 const EMPTY_STATE_TEXT = "No conditions. This will match all items.";
-const SLOT_ROW_CLASS = "flex items-center justify-between gap-2";
-const SLOT_CLASS =
-  "flex-1 rounded border border-dashed border-gray-300 px-2 py-1 text-sm text-gray-600 " +
-  "dark:border-gray-600 dark:text-gray-300";
+const SLOT_ROW_CLASS = "flex items-center gap-2 flex-wrap";
+const FIELD_CELL_CLASS = "min-w-[12rem]";
+const VALUE_CELL_CLASS = "flex-1 min-w-[12rem]";
+// Placeholder shown in the value cell until a field is chosen.
+const VALUE_PLACEHOLDER_CLASS =
+  "flex-1 min-w-[12rem] rounded border border-dashed border-gray-300 px-2 py-1 text-sm " +
+  "text-gray-500 dark:border-gray-600 dark:text-gray-400";
+// Faded look + "Incomplete" badge for a leaf missing its value (excluded from the
+// count/Apply query). Applied to the whole row.
+const INCOMPLETE_ROW_CLASS = "opacity-60";
+const BADGE_CLASS =
+  "rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-medium " +
+  "text-amber-700 dark:border-amber-500/50 dark:bg-amber-500/10 dark:text-amber-300";
 // Connective + NOT chips (component 2, issue #190). Pill shape (rounded-full) +
 // saturated fill sets this cluster apart from the square, gray restructuring
 // buttons so it never reads as "just another button". The connective is
@@ -144,18 +167,74 @@ function slotLabel(node: FilterNode): string {
   return "comparison";
 }
 
+// A leaf's two stateful cells, cached by node id so a structural re-render reuses
+// (re-appends) them — the live value widget's DOM state survives edits elsewhere.
+interface LeafCells {
+  field: string; // the field the value cell was built for ("" = none yet)
+  fieldCell: HTMLElement;
+  valueCell: HTMLElement;
+}
+
+interface SearchSelectLike extends HTMLElement {
+  setSelected(value: string, label?: string): void;
+}
+
 export class FilterGroupElement extends HTMLElement {
   private tree: GroupNode = emptyRoot();
   private model = "";
   private wired = false;
+  // field name -> its FieldMeta (kind, label, modifiers …), from the `fields` prop.
+  private fields = new Map<string, FilterFieldMeta>();
+  // The <template> whose content is the field-picker combobox, cloned per leaf.
+  private fieldPickerTemplate: HTMLTemplateElement | null = null;
+  // field name -> its blank value-widget <template>, cloned into a leaf on field-pick.
+  private widgetTemplates = new Map<string, HTMLTemplateElement>();
+  // node id -> its cached cells (see LeafCells). Pruned to live nodes each render.
+  private rowCache = new Map<string, LeafCells>();
+  // Monotonic suffix so cloned widget/picker element ids stay unique per leaf.
+  private cloneSequence = 0;
 
   connectedCallback(): void {
-    this.model = readFilterGroupProps(this).model;
+    const props = readFilterGroupProps(this);
+    this.model = props.model;
     if (!this.wired) {
+      this.captureTemplates();
+      this.parseFields(props.fields);
       this.addEventListener("click", this.onClick);
+      // Value edits (typing, radios, set pills, date bounds, field pick) bubble
+      // here; one delegated listener updates completeness / handles field changes.
+      this.addEventListener("input", this.onValueEvent);
+      this.addEventListener("change", this.onValueEvent);
+      this.addEventListener("search-select:change", this.onValueEvent);
+      this.addEventListener("date-range:change", this.onValueEvent);
+      // Reuse the flat bar's modifier-radio enable/disable behavior for the cloned
+      // string/number widgets (presence hides value; BETWEEN reveals value2).
+      setupModifierToggles(this);
       this.wired = true;
     }
     this.render();
+  }
+
+  // Detach the server-rendered <template>s (field picker + one per field) before
+  // the first render() replaces our children, keeping references to clone from.
+  private captureTemplates(): void {
+    this.fieldPickerTemplate = this.querySelector<HTMLTemplateElement>(
+      "template[data-field-picker-template]",
+    );
+    this.querySelectorAll<HTMLTemplateElement>("template[data-field]").forEach((template) => {
+      const field = template.getAttribute("data-field");
+      if (field) this.widgetTemplates.set(field, template);
+    });
+  }
+
+  private parseFields(raw: string): void {
+    if (!raw) return;
+    try {
+      const list = JSON.parse(raw) as FilterFieldMeta[];
+      for (const meta of list) this.fields.set(meta.name, meta);
+    } catch {
+      console.warn("filter-group: malformed fields prop");
+    }
   }
 
   /** The current node tree — for 2d serialize/count. Do not mutate it: every edit
@@ -166,9 +245,52 @@ export class FilterGroupElement extends HTMLElement {
     return this.tree;
   }
 
-  /** Convenience: the canonical OperatorFilter JSON for the current tree. */
+  /** The canonical OperatorFilter JSON for the current tree structure (leaf values
+   *  are read live from the widgets — see serializeForQuery). */
   serialize(): Record<string, unknown> {
     return serialize(this.tree);
+  }
+
+  /** The JSON to actually query with: each criterion leaf's value is read from its
+   *  live widget, then incomplete leaves are pruned (excluded from the count/Apply
+   *  query). Used by the builder page (comp 10). */
+  serializeForQuery(): Record<string, unknown> {
+    return serialize(pruneIncomplete(this.fillCriteria(this.tree)));
+  }
+
+  // Clone the tree with every criterion leaf's `criterion` filled from its live
+  // value widget (empty {} when the field/widget yields nothing → pruned as
+  // incomplete). Structure/ids are preserved.
+  private fillCriteria(node: GroupNode): GroupNode {
+    return { ...node, children: node.children.map((child) => this.fillNode(child)) };
+  }
+
+  private fillNode(node: FilterNode): FilterNode {
+    if (node.kind === "group") return this.fillCriteria(node);
+    if (node.kind === "criterion") return { ...node, criterion: this.readLeaf(node) ?? {} };
+    return node; // relation/comparison unchanged (out of this slice)
+  }
+
+  // Read a criterion leaf's live value widget into a payload, or null when it has
+  // no usable value (empty field, empty widget). Keyed off the cached value cell.
+  private readLeaf(node: CriterionLeaf): Record<string, unknown> | null {
+    const meta = this.fields.get(node.field);
+    const cells = this.rowCache.get(node.id);
+    if (!meta || !cells) return null;
+    return readLeafWidget(cells.valueCell, meta.kind);
+  }
+
+  private leafComplete(node: CriterionLeaf): boolean {
+    return isCriterionComplete({ ...node, criterion: this.readLeaf(node) ?? {} });
+  }
+
+  private incompleteCount(node: GroupNode = this.tree): number {
+    let count = 0;
+    for (const child of node.children) {
+      if (child.kind === "group") count += this.incompleteCount(child);
+      else if (child.kind === "criterion" && !this.leafComplete(child)) count += 1;
+    }
+    return count;
   }
 
   private onClick = (event: Event): void => {
@@ -224,12 +346,34 @@ export class FilterGroupElement extends HTMLElement {
     }
     if (this.tree === before) return; // a guarded/boundary no-op changed nothing
     this.render();
-    const detail: FilterTreeChangeDetail = { tree: this.tree };
+    this.dispatchChange();
+  }
+
+  private dispatchChange(): void {
+    const detail: FilterTreeChangeDetail = {
+      tree: this.tree,
+      incompleteCount: this.incompleteCount(),
+    };
     this.dispatchEvent(new CustomEvent(FILTER_TREE_CHANGE_EVENT, { bubbles: true, detail }));
   }
 
   private render(): void {
     this.replaceChildren(this.renderGroup(this.tree, [], 0, 1));
+    this.pruneRowCache();
+  }
+
+  // Drop cached cells for nodes no longer in the tree (their DOM was discarded by
+  // the replaceChildren above); live nodes keep their reused cells.
+  private pruneRowCache(): void {
+    const live = new Set<string>();
+    const walk = (node: FilterNode): void => {
+      if (node.kind === "group") node.children.forEach(walk);
+      else live.add(node.id);
+    };
+    walk(this.tree);
+    for (const id of [...this.rowCache.keys()]) {
+      if (!live.has(id)) this.rowCache.delete(id);
+    }
   }
 
   private renderGroup(node: GroupNode, path: NodePath, index: number, siblingCount: number): HTMLElement {
@@ -270,19 +414,185 @@ export class FilterGroupElement extends HTMLElement {
 
   private renderChild(child: FilterNode, path: NodePath, index: number, siblingCount: number): HTMLElement {
     if (child.kind === "group") return this.renderGroup(child, path, index, siblingCount);
+    if (child.kind === "criterion") return this.renderCriterionRow(child, path, index, siblingCount);
+    return this.renderInertSlot(child, path, index, siblingCount);
+  }
+
+  // Relation/comparison leaves stay inert slots (their widgets are sibling 2c
+  // components, out of this slice); the criterion row is live below.
+  private renderInertSlot(
+    child: FilterNode,
+    path: NodePath,
+    index: number,
+    siblingCount: number,
+  ): HTMLElement {
     const row = element("div", SLOT_ROW_CLASS);
-    const slot = element("div", SLOT_CLASS);
+    const slot = element("div", VALUE_PLACEHOLDER_CLASS);
     slot.dataset.nodeSlot = "";
     slot.dataset.nodeKind = child.kind;
     slot.dataset.path = JSON.stringify(path);
-    slot.dataset.payload = JSON.stringify(child); // identity + payload for 2d hydration
     slot.textContent = slotLabel(child);
-    // NOT leads the row (leftmost), matching the group header; the slot and the
-    // restructuring controls follow.
     row.appendChild(this.negateChip(child, path));
     row.appendChild(slot);
     row.appendChild(this.controls(path, false, index, siblingCount));
     return row;
+  }
+
+  // The live criterion leaf row: [NOT] [field combobox] [value widget] [badge?]
+  // [controls]. The two stateful cells are reused across renders via rowCache so a
+  // structural edit never wipes an in-progress widget.
+  private renderCriterionRow(
+    node: CriterionLeaf,
+    path: NodePath,
+    index: number,
+    siblingCount: number,
+  ): HTMLElement {
+    const cells = this.leafCells(node);
+    const row = element("div", SLOT_ROW_CLASS);
+    row.dataset.nodeSlot = "";
+    row.dataset.nodeKind = "criterion";
+    row.dataset.path = JSON.stringify(path);
+    row.appendChild(this.negateChip(node, path));
+    row.appendChild(cells.fieldCell);
+    row.appendChild(cells.valueCell);
+    row.appendChild(this.controls(path, false, index, siblingCount));
+    // Controls are the row's last child; the badge (if any) is inserted before them.
+    this.applyIncompleteState(row, Boolean(node.field) && !this.leafComplete(node));
+    return row;
+  }
+
+  // Build or reuse a leaf's field + value cells, rebuilding the value cell only when
+  // the field changed (or first set). Cached by node id.
+  private leafCells(node: CriterionLeaf): LeafCells {
+    let cells = this.rowCache.get(node.id);
+    if (!cells) {
+      cells = { field: "", fieldCell: this.buildFieldCell(), valueCell: this.buildValueCell("") };
+      this.rowCache.set(node.id, cells);
+    }
+    if (cells.field !== node.field) {
+      cells.valueCell = this.buildValueCell(node.field);
+      cells.field = node.field;
+      if (node.field) this.showFieldSelection(cells.fieldCell, node.field);
+    }
+    return cells;
+  }
+
+  // Clone the field-picker combobox into a cell, with a unique id per leaf so
+  // multiple pickers on the page never collide.
+  private buildFieldCell(): HTMLElement {
+    const cell = element("div", FIELD_CELL_CLASS);
+    cell.dataset.fieldCell = "";
+    const content = this.fieldPickerTemplate?.content.firstElementChild;
+    if (content) {
+      const clone = content.cloneNode(true) as HTMLElement;
+      this.uniquify(clone);
+      cell.appendChild(clone);
+    }
+    return cell;
+  }
+
+  // Reflect an already-chosen field in the cloned combobox (import/rebuild). The
+  // search-select's setSelected is silent, so it won't re-fire a field-pick.
+  private showFieldSelection(fieldCell: HTMLElement, field: string): void {
+    const searchSelect = fieldCell.querySelector<SearchSelectLike>("search-select");
+    const label = this.fields.get(field)?.label ?? field;
+    searchSelect?.setSelected(field, label);
+  }
+
+  // Build a value cell for `field`: a clone of the field's blank widget template,
+  // or a placeholder prompt when no field is chosen yet.
+  private buildValueCell(field: string): HTMLElement {
+    if (!field) {
+      const placeholder = element("div", VALUE_PLACEHOLDER_CLASS);
+      placeholder.dataset.valueCell = "";
+      placeholder.textContent = "Choose a field…";
+      return placeholder;
+    }
+    const cell = element("div", VALUE_CELL_CLASS);
+    cell.dataset.valueCell = "";
+    const template = this.widgetTemplates.get(field);
+    const content = template?.content.firstElementChild;
+    if (content) {
+      const clone = content.cloneNode(true) as HTMLElement;
+      this.uniquify(clone);
+      cell.appendChild(clone);
+    }
+    return cell;
+  }
+
+  // Suffix every id/for/name in a cloned subtree so repeated clones stay valid HTML
+  // and label associations point at their own controls (the widgets query their own
+  // descendants, so functionality never depended on these being unique).
+  private uniquify(root: HTMLElement): void {
+    const suffix = `g${(this.cloneSequence += 1)}`;
+    const rewrite = (element: Element, attribute: string): void => {
+      const value = element.getAttribute(attribute);
+      if (value) element.setAttribute(attribute, `${value}-${suffix}`);
+    };
+    root.querySelectorAll<HTMLElement>("[id],[for],[name]").forEach((element) => {
+      rewrite(element, "id");
+      rewrite(element, "for");
+      rewrite(element, "name");
+    });
+  }
+
+  // A value-cell edit (or a field pick) bubbled up. Route field picks to setLeafField
+  // (re-render swaps the value widget); plain value edits just refresh completeness
+  // (the widget DOM is the source of truth, read at serialize time).
+  private onValueEvent = (event: Event): void => {
+    const target = event.target as HTMLElement;
+    const fieldPicker = target.closest<HTMLElement>("[data-field-picker]");
+    if (fieldPicker && event.type === "search-select:change") {
+      this.handleFieldPick(fieldPicker, event as CustomEvent<SearchSelectChangeDetail>);
+      return;
+    }
+    if (target.closest("[data-value-cell]")) this.refreshCompleteness(target);
+  };
+
+  private handleFieldPick(fieldPicker: HTMLElement, event: CustomEvent<SearchSelectChangeDetail>): void {
+    const row = fieldPicker.closest<HTMLElement>("[data-node-slot]");
+    if (!row?.dataset.path) return;
+    const meta = parseFieldMeta(event.detail.last?.data?.meta ?? "");
+    if (!meta) return;
+    const path = JSON.parse(row.dataset.path) as number[];
+    this.tree = setLeafField(this.tree, path, meta);
+    this.render();
+    this.dispatchChange();
+  }
+
+  // Toggle the row's incomplete badge/fade in place (no re-render → the widget the
+  // user is editing keeps focus) and report the new incomplete count.
+  private refreshCompleteness(target: HTMLElement): void {
+    const row = target.closest<HTMLElement>('[data-node-slot][data-node-kind="criterion"]');
+    if (row?.dataset.path) {
+      const node = this.nodeAtPath(JSON.parse(row.dataset.path) as number[]);
+      if (node?.kind === "criterion") this.applyIncompleteState(row, !this.leafComplete(node));
+    }
+    this.dispatchChange();
+  }
+
+  private applyIncompleteState(row: HTMLElement, incomplete: boolean): void {
+    row.classList.toggle(INCOMPLETE_ROW_CLASS, incomplete);
+    let badge = row.querySelector<HTMLElement>("[data-incomplete-badge]");
+    if (incomplete && !badge) {
+      badge = element("span", BADGE_CLASS);
+      badge.dataset.incompleteBadge = "";
+      badge.textContent = "Incomplete";
+      row.insertBefore(badge, row.lastElementChild);
+    } else if (!incomplete && badge) {
+      badge.remove();
+    }
+  }
+
+  private nodeAtPath(path: NodePath): FilterNode | null {
+    let node: FilterNode = this.tree;
+    for (const index of path) {
+      if (node.kind !== "group") return null;
+      const child: FilterNode | undefined = node.children[index];
+      if (!child) return null;
+      node = child;
+    }
+    return node;
   }
 
   // A chip-style toggle button: a restructuring action (so it rides the existing

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -207,7 +207,7 @@ export class FilterGroupElement extends HTMLElement {
       this.addEventListener("change", this.onValueEvent);
       this.addEventListener("search-select:change", this.onValueEvent);
       this.addEventListener("date-range:change", this.onValueEvent);
-      // Reuse the flat bar's modifier-radio enable/disable behavior for the cloned
+      // Reuse the flat bar's modifier-select enable/disable behavior for the cloned
       // string/number widgets (presence hides value; BETWEEN reveals value2).
       setupModifierToggles(this);
       this.wired = true;

--- a/ts/elements/filter-tree/node-id.ts
+++ b/ts/elements/filter-tree/node-id.ts
@@ -1,0 +1,21 @@
+/**
+ * Stable per-node identity for the filter tree (issue #192).
+ *
+ * Every `FilterNode` carries an `id` assigned at construction (factories +
+ * deserialize). It is a client-only handle: the serializer never reads it, so it
+ * never reaches the wire. `<filter-group>` keys its DOM reconciliation on it, so a
+ * leaf's live value widget survives structural edits (add/remove/move/negate) that
+ * rebuild the surrounding tree — the id follows the node through the immutable ops
+ * (a `{...node}` spread copies it), so the same row element is reused.
+ */
+let counter = 0;
+
+export function nextNodeId(): string {
+  counter += 1;
+  return `n${counter}`;
+}
+
+// Test seam: reset the monotonic counter so id sequences are reproducible.
+export function resetNodeIds(): void {
+  counter = 0;
+}

--- a/ts/elements/filter-tree/operations.test.ts
+++ b/ts/elements/filter-tree/operations.test.ts
@@ -21,8 +21,11 @@ import {
   move,
   nodeAt,
   parseFieldMeta,
+  pruneIncomplete,
   removeAt,
   setConnective,
+  setLeafCriterion,
+  setLeafField,
   setMatch,
   toggleConnective,
   toggleNegate,
@@ -482,5 +485,74 @@ describe("add-criterion field picker contract (#191)", () => {
         }),
       ).toBe(false);
     });
+
+    it("requires both bounds for a range modifier (#192)", () => {
+      const halfBetween: CriterionLeaf = {
+        kind: "criterion",
+        field: "year_released",
+        criterion: { modifier: "BETWEEN", value: 1990 },
+        negate: false,
+      };
+      expect(isCriterionComplete(halfBetween)).toBe(false);
+      expect(
+        isCriterionComplete({ ...halfBetween, criterion: { modifier: "BETWEEN", value: 1990, value2: 2000 } }),
+      ).toBe(true);
+    });
+  });
+});
+
+describe("leaf payload edits (#192)", () => {
+  it("setLeafField replaces the leaf with a fresh reset leaf, preserving negate", () => {
+    const tree = group("AND", [
+      { kind: "criterion", field: "name", criterion: { modifier: "EQUALS", value: "x" }, negate: true },
+    ]);
+    const next = setLeafField(tree, [0], fieldMeta({ name: "status", kind: "set" }));
+    expect(nodeAt(next, [0])).toEqual({
+      kind: "criterion",
+      field: "status",
+      criterion: { modifier: "INCLUDES" }, // value dropped, modifier reset
+      negate: true, // preserved
+    });
+  });
+
+  it("setLeafCriterion swaps the opaque payload verbatim", () => {
+    const tree = group("AND", [emptyCriterion()]);
+    const payload = { modifier: "INCLUDES", value: [{ id: "1", label: "PC" }] };
+    const next = setLeafCriterion(tree, [0], payload);
+    expect((nodeAt(next, [0]) as CriterionLeaf).criterion).toEqual(payload);
+  });
+
+  it("setLeafField / setLeafCriterion throw on a non-criterion node", () => {
+    const tree = group("AND", [emptyGroup()]);
+    expect(() => setLeafField(tree, [0], fieldMeta())).toThrow();
+    expect(() => setLeafCriterion(tree, [0], {})).toThrow();
+  });
+});
+
+describe("pruneIncomplete (#192)", () => {
+  const complete = (field: string): CriterionLeaf => ({
+    kind: "criterion",
+    field,
+    criterion: { modifier: "EQUALS", value: "v" },
+    negate: false,
+  });
+
+  it("drops incomplete criterion leaves, keeps complete ones", () => {
+    const tree = group("AND", [complete("name"), emptyCriterion()]);
+    expect(pruneIncomplete(tree)).toEqual(group("AND", [complete("name")]));
+  });
+
+  it("collapses a non-root group emptied by pruning, but keeps an empty root", () => {
+    const inner = group("OR", [emptyCriterion()]);
+    const tree = group("AND", [complete("name"), inner]);
+    expect(pruneIncomplete(tree)).toEqual(group("AND", [complete("name")]));
+    expect(pruneIncomplete(group("AND", [emptyCriterion()]))).toEqual(group("AND", []));
+  });
+
+  it("keeps a relation even if its child group empties (presence test)", () => {
+    const tree = group("AND", [relation("session_filter", group("AND", [emptyCriterion()]))]);
+    expect(pruneIncomplete(tree)).toEqual(
+      group("AND", [relation("session_filter", group("AND", []))]),
+    );
   });
 });

--- a/ts/elements/filter-tree/operations.test.ts
+++ b/ts/elements/filter-tree/operations.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { group } from "./serializer.js";
+import { nextNodeId } from "./node-id.js";
+import { ignoreNodeIds } from "./test-support.js";
 import type { CriterionLeaf, FilterNode, GroupNode } from "./types.js";
 import type { FilterFieldMeta } from "./types.js";
+
+ignoreNodeIds();
 import {
   SOFT_DEPTH_CAP,
   canAddGroup,
@@ -47,11 +51,11 @@ function fieldMeta(overrides: Partial<FilterFieldMeta> = {}): FilterFieldMeta {
 }
 
 function criterion(field: string): FilterNode {
-  return { kind: "criterion", field, criterion: { value: field, modifier: "INCLUDES" }, negate: false };
+  return { kind: "criterion", id: nextNodeId(), field, criterion: { value: field, modifier: "INCLUDES" }, negate: false };
 }
 
 function relation(field: string, child: GroupNode): FilterNode {
-  return { kind: "relation", field, match: "ANY", child, negate: false };
+  return { kind: "relation", id: nextNodeId(), field, match: "ANY", child, negate: false };
 }
 
 describe("factories", () => {
@@ -234,7 +238,9 @@ describe("error branches", () => {
 
   it("toggleNegate works on a relation node", () => {
     const tree = group("AND", [relation("sessions", group("AND", []))]);
-    expect(nodeAt(toggleNegate(tree, [0]), [0])).toMatchObject({ kind: "relation", negate: true });
+    const node = nodeAt(toggleNegate(tree, [0]), [0]);
+    expect(node.kind).toBe("relation");
+    expect(node.negate).toBe(true);
   });
 });
 
@@ -252,13 +258,16 @@ describe("setConnective / setMatch / toggleNegate", () => {
 
   it("flips a nested group's connective by path", () => {
     const tree = group("AND", [group("OR", [criterion("a")])]);
-    expect(nodeAt(toggleConnective(tree, [0]), [0])).toMatchObject({ kind: "group", connective: "AND" });
+    const node = nodeAt(toggleConnective(tree, [0]), [0]);
+    expect(node.kind).toBe("group");
+    if (node.kind === "group") expect(node.connective).toBe("AND");
   });
 
   it("sets a relation's quantifier", () => {
     const tree = group("AND", [relation("sessions", group("AND", []))]);
-    const result = setMatch(tree, [0], "NONE");
-    expect(nodeAt(result, [0])).toMatchObject({ kind: "relation", match: "NONE" });
+    const node = nodeAt(setMatch(tree, [0], "NONE"), [0]);
+    expect(node.kind).toBe("relation");
+    if (node.kind === "relation") expect(node.match).toBe("NONE");
   });
 
   it("toggles a node's negate flag", () => {
@@ -273,7 +282,9 @@ describe("setConnective / setMatch / toggleNegate", () => {
 
   it("negates a group", () => {
     const tree = group("AND", [group("OR", [criterion("a")])]);
-    expect(nodeAt(toggleNegate(tree, [0]), [0])).toMatchObject({ kind: "group", negate: true });
+    const node = nodeAt(toggleNegate(tree, [0]), [0]);
+    expect(node.kind).toBe("group");
+    expect(node.negate).toBe(true);
   });
 });
 
@@ -415,7 +426,8 @@ describe("add-criterion field picker contract (#191)", () => {
       );
       expect(leaf).toEqual({
         kind: "criterion",
-        field: "name",
+        id: "c",
+        field:"name",
         criterion: { modifier: "EQUALS" },
         negate: false,
       });
@@ -446,7 +458,8 @@ describe("add-criterion field picker contract (#191)", () => {
       expect(
         isCriterionComplete({
           kind: "criterion",
-          field: "name",
+          id: "c",
+          field:"name",
           criterion: { modifier: "EQUALS", value: "" },
           negate: false,
         }),
@@ -457,7 +470,8 @@ describe("add-criterion field picker contract (#191)", () => {
       expect(
         isCriterionComplete({
           kind: "criterion",
-          field: "name",
+          id: "c",
+          field:"name",
           criterion: { modifier: "EQUALS", value: "Hades" },
           negate: false,
         }),
@@ -468,7 +482,8 @@ describe("add-criterion field picker contract (#191)", () => {
       expect(
         isCriterionComplete({
           kind: "criterion",
-          field: "year_released",
+          id: "c",
+          field:"year_released",
           criterion: { modifier: "IS_NULL" },
           negate: false,
         }),
@@ -479,7 +494,8 @@ describe("add-criterion field picker contract (#191)", () => {
       expect(
         isCriterionComplete({
           kind: "criterion",
-          field: "platform",
+          id: "c",
+          field:"platform",
           criterion: { modifier: "INCLUDES", value: [] },
           negate: false,
         }),
@@ -489,7 +505,8 @@ describe("add-criterion field picker contract (#191)", () => {
     it("requires both bounds for a range modifier (#192)", () => {
       const halfBetween: CriterionLeaf = {
         kind: "criterion",
-        field: "year_released",
+        id: "c",
+        field:"year_released",
         criterion: { modifier: "BETWEEN", value: 1990 },
         negate: false,
       };
@@ -504,7 +521,7 @@ describe("add-criterion field picker contract (#191)", () => {
 describe("leaf payload edits (#192)", () => {
   it("setLeafField replaces the leaf with a fresh reset leaf, preserving negate", () => {
     const tree = group("AND", [
-      { kind: "criterion", field: "name", criterion: { modifier: "EQUALS", value: "x" }, negate: true },
+      { kind: "criterion", id: "c", field: "name", criterion: { modifier: "EQUALS", value: "x" }, negate: true },
     ]);
     const next = setLeafField(tree, [0], fieldMeta({ name: "status", kind: "set" }));
     expect(nodeAt(next, [0])).toEqual({
@@ -532,6 +549,7 @@ describe("leaf payload edits (#192)", () => {
 describe("pruneIncomplete (#192)", () => {
   const complete = (field: string): CriterionLeaf => ({
     kind: "criterion",
+    id: nextNodeId(),
     field,
     criterion: { modifier: "EQUALS", value: "v" },
     negate: false,

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -15,6 +15,7 @@
 import {
   type Connective,
   type CriterionLeaf,
+  type CriterionPayload,
   type FilterFieldMeta,
   type FilterNode,
   type GroupNode,
@@ -22,7 +23,7 @@ import {
   type RelationNode,
 } from "./types.js";
 import { group } from "./serializer.js";
-import { isPresenceModifier } from "../filter-tokens.js";
+import { isPresenceModifier, isRangeModifier } from "../filter-tokens.js";
 
 export type NodePath = readonly number[];
 
@@ -64,18 +65,28 @@ export function criterionForField(meta: FilterFieldMeta): CriterionLeaf {
   return { kind: "criterion", field: meta.name, criterion, negate: false };
 }
 
+// Whether a single payload slot counts as filled. A bare `""`/null/undefined or an
+// empty array is empty; anything else (incl. `0`, `false`) is present.
+function isValuePresent(value: unknown): boolean {
+  if (value === undefined || value === null || value === "") return false;
+  if (Array.isArray(value) && value.length === 0) return false;
+  return true;
+}
+
 // Whether a leaf is complete enough to query/apply: it needs a field, a modifier,
 // and a non-empty value — UNLESS the modifier is a presence test (IS_NULL /
-// NOT_NULL), which is value-less by design. Per-widget value validation (e.g. both
-// BETWEEN bounds present) layers on top of this in the leaf widgets (#192).
+// NOT_NULL), which is value-less by design. A range modifier (BETWEEN / NOT_BETWEEN)
+// additionally needs the second bound `value2`: a half-filled BETWEEN serializes to a
+// payload the backend rejects *wholesale* (`IntCriterion.to_q` raises FilterError when
+// value2 is None, and `filter_from_json` validates eagerly — so one bad leaf drops the
+// entire filter). Excluding it here keeps it out of both the count query and Apply.
 export function isCriterionComplete(leaf: CriterionLeaf): boolean {
   if (!leaf.field) return false;
   const modifier = leaf.criterion["modifier"];
   if (typeof modifier !== "string" || modifier === "") return false;
   if (isPresenceModifier(modifier)) return true;
-  const value = leaf.criterion["value"];
-  if (value === undefined || value === null || value === "") return false;
-  if (Array.isArray(value) && value.length === 0) return false;
+  if (!isValuePresent(leaf.criterion["value"])) return false;
+  if (isRangeModifier(modifier) && !isValuePresent(leaf.criterion["value2"])) return false;
   return true;
 }
 
@@ -241,6 +252,70 @@ export function setMatch(root: GroupNode, path: NodePath, match: RelationMatch):
     if (node.kind !== "relation") throw new Error(`Node at path is not a relation`);
     return { ...node, match };
   });
+}
+
+// ── Leaf payload edits (issue #192) ──────────────────────────────────────────
+
+// Pick (or change) a criterion leaf's field: replace it with a FRESH leaf for the
+// chosen field via `criterionForField` (modifier reset to the field's first valid,
+// value dropped — no silent type-coercion). The node's own `negate` flag is
+// preserved (changing the field shouldn't silently un-negate the row).
+export function setLeafField(root: GroupNode, path: NodePath, meta: FilterFieldMeta): GroupNode {
+  return replaceNodeAt(root, path, (node) => {
+    if (node.kind !== "criterion") throw new Error(`Node at path is not a criterion leaf`);
+    return { ...criterionForField(meta), negate: node.negate };
+  });
+}
+
+// Set a criterion leaf's whole opaque payload (what a value widget produced). The
+// serializer wraps it verbatim as `{field: payload}`, so the widget owns the shape.
+export function setLeafCriterion(
+  root: GroupNode,
+  path: NodePath,
+  criterion: CriterionPayload,
+): GroupNode {
+  return replaceNodeAt(root, path, (node) => {
+    if (node.kind !== "criterion") throw new Error(`Node at path is not a criterion leaf`);
+    return { ...node, criterion };
+  });
+}
+
+// ── Pruning incomplete leaves for the query (issue #192) ─────────────────────
+
+// Drop every incomplete criterion leaf (see `isCriterionComplete`) so the count /
+// Apply query never carries one (an incomplete leaf with `field === ""` serializes
+// to `{"": …}` — one key — so the serializer's empty-child filter does NOT drop it;
+// pruning is required). A non-root group emptied by pruning collapses out of its
+// parent (the #236 invariant: no rendered, NOT-able empty group); the root may sit
+// empty (→ `{}` matches-all). A full recursive walk — relations descend into their
+// child group too — and a relation is kept even if its child empties (ANY over an
+// empty group is the meaningful "has ≥1 related row" presence test).
+export function pruneIncomplete(root: GroupNode): GroupNode {
+  return pruneGroup(root);
+}
+
+function pruneGroup(node: GroupNode): GroupNode {
+  const children: FilterNode[] = [];
+  for (const child of node.children) {
+    const pruned = pruneNode(child);
+    if (pruned !== null) children.push(pruned);
+  }
+  return { ...node, children };
+}
+
+function pruneNode(node: FilterNode): FilterNode | null {
+  switch (node.kind) {
+    case "criterion":
+      return isCriterionComplete(node) ? node : null;
+    case "comparison":
+      return node; // comparison completeness lands with the field-comparison leaf
+    case "relation":
+      return { ...node, child: pruneGroup(node.child) };
+    case "group": {
+      const pruned = pruneGroup(node);
+      return pruned.children.length === 0 ? null : pruned; // collapse emptied non-root group
+    }
+  }
 }
 
 // Negation is a per-node flag, never a connective (design spec). Toggling it twice

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -23,6 +23,7 @@ import {
   type RelationNode,
 } from "./types.js";
 import { group } from "./serializer.js";
+import { nextNodeId } from "./node-id.js";
 import { isPresenceModifier, isRangeModifier } from "../filter-tokens.js";
 
 export type NodePath = readonly number[];
@@ -37,7 +38,7 @@ export const SOFT_DEPTH_CAP = 5;
 // An empty criterion leaf: field unchosen, payload empty. A leaf widget (comp 4)
 // fills `field`/`criterion` in 2d; until then it is an inert slot in the shell.
 export function emptyCriterion(): CriterionLeaf {
-  return { kind: "criterion", field: "", criterion: {}, negate: false };
+  return { kind: "criterion", id: nextNodeId(), field: "", criterion: {}, negate: false };
 }
 
 // ── Add-criterion field picker contract (issue #191) ─────────────────────────
@@ -62,7 +63,7 @@ export function parseFieldMeta(raw: string): FilterFieldMeta | null {
 export function criterionForField(meta: FilterFieldMeta): CriterionLeaf {
   const [firstModifier] = meta.modifiers;
   const criterion = firstModifier !== undefined ? { modifier: firstModifier } : {};
-  return { kind: "criterion", field: meta.name, criterion, negate: false };
+  return { kind: "criterion", id: nextNodeId(), field: meta.name, criterion, negate: false };
 }
 
 // Whether a single payload slot counts as filled. A bare `""`/null/undefined or an
@@ -93,7 +94,7 @@ export function isCriterionComplete(leaf: CriterionLeaf): boolean {
 // An empty relation descent: ANY over an empty child group is the "has ≥1 related
 // row" presence test (design spec). Relation field + quantifier are set by comp 5.
 export function emptyRelation(): RelationNode {
-  return { kind: "relation", field: "", match: "ANY", child: group("AND", []), negate: false };
+  return { kind: "relation", id: nextNodeId(), field: "", match: "ANY", child: group("AND", []), negate: false };
 }
 
 // A new sub-group seeded with one empty criterion so it is never vacuously empty
@@ -208,9 +209,18 @@ export function removeAt(root: GroupNode, path: NodePath): GroupNode {
 export function duplicateAt(root: GroupNode, path: NodePath): GroupNode {
   const { parentPath, index } = splitPath(path);
   return updateChildren(root, parentPath, (children) => {
-    const clone = structuredClone(children[index]);
+    const clone = reassignIds(structuredClone(children[index]));
     return [...children.slice(0, index + 1), clone, ...children.slice(index + 1)];
   });
+}
+
+// A duplicated subtree must get fresh ids on every node — a structuredClone copies
+// the source ids, which would collide with the originals in the shell's id→DOM map.
+function reassignIds(node: FilterNode): FilterNode {
+  node.id = nextNodeId();
+  if (node.kind === "group") node.children.forEach(reassignIds);
+  else if (node.kind === "relation") reassignIds(node.child);
+  return node;
 }
 
 // Move the node at `path` one slot earlier (-1) or later (+1) among its siblings.
@@ -263,7 +273,9 @@ export function setMatch(root: GroupNode, path: NodePath, match: RelationMatch):
 export function setLeafField(root: GroupNode, path: NodePath, meta: FilterFieldMeta): GroupNode {
   return replaceNodeAt(root, path, (node) => {
     if (node.kind !== "criterion") throw new Error(`Node at path is not a criterion leaf`);
-    return { ...criterionForField(meta), negate: node.negate };
+    // Keep the node's id (and negate): it's the same row, so the shell reuses its
+    // row element and only swaps the value widget for the new field's kind.
+    return { ...criterionForField(meta), id: node.id, negate: node.negate };
   });
 }
 

--- a/ts/elements/filter-tree/serializer.test.ts
+++ b/ts/elements/filter-tree/serializer.test.ts
@@ -6,7 +6,7 @@ import type { MetadataRegistry } from "./types.js";
 import { FilterTreeError } from "./types.js";
 
 function root(...children: FilterNode[]): GroupNode {
-  return { kind: "group", connective: "AND", negate: false, children };
+  return { kind: "group", id: "g", connective: "AND", negate: false, children };
 }
 
 describe("serialize", () => {
@@ -16,29 +16,29 @@ describe("serialize", () => {
 
   it("emits a criterion leaf under its connective", () => {
     const node = serialize(
-      root({ kind: "criterion", field: "status", criterion: { value: ["f"], modifier: "INCLUDES" }, negate: false }),
+      root({ kind: "criterion", id: "c", field: "status", criterion: { value: ["f"], modifier: "INCLUDES" }, negate: false }),
     );
     expect(node).toEqual({ AND: [{ status: { value: ["f"], modifier: "INCLUDES" } }] });
   });
 
   it("wraps a negated leaf in NOT", () => {
     const node = serialize(
-      root({ kind: "criterion", field: "name", criterion: { value: "x", modifier: "INCLUDES" }, negate: true }),
+      root({ kind: "criterion", id: "c", field: "name", criterion: { value: "x", modifier: "INCLUDES" }, negate: true }),
     );
     expect(node).toEqual({ AND: [{ NOT: [{ name: { value: "x", modifier: "INCLUDES" } }] }] });
   });
 
   it("emits a comparison leaf as field_comparisons", () => {
     const node = serialize(
-      root({ kind: "comparison", comparison: { left: "a", right: "b", modifier: "LESS_THAN" }, negate: false }),
+      root({ kind: "comparison", id: "c", comparison: { left: "a", right: "b", modifier: "LESS_THAN" }, negate: false }),
     );
     expect(node).toEqual({ AND: [{ field_comparisons: [{ left: "a", right: "b", modifier: "LESS_THAN" }] }] });
   });
 
   it("emits an OR group nested under the AND root", () => {
     const orGroup = group("OR", [
-      { kind: "criterion", field: "status", criterion: { value: ["f"], modifier: "INCLUDES" }, negate: false },
-      { kind: "criterion", field: "status", criterion: { value: ["p"], modifier: "INCLUDES" }, negate: false },
+      { kind: "criterion", id: "c", field: "status", criterion: { value: ["f"], modifier: "INCLUDES" }, negate: false },
+      { kind: "criterion", id: "c", field: "status", criterion: { value: ["p"], modifier: "INCLUDES" }, negate: false },
     ]);
     expect(serialize(root(orGroup))).toEqual({
       AND: [{ OR: [{ status: { value: ["f"], modifier: "INCLUDES" } }, { status: { value: ["p"], modifier: "INCLUDES" } }] }],
@@ -48,10 +48,11 @@ describe("serialize", () => {
   it("merges match onto a relation child group, omitting ANY", () => {
     const relationAny: FilterNode = {
       kind: "relation",
+      id: "r",
       field: "session_filter",
       match: "ANY",
-      child: { kind: "group", connective: "AND", negate: false, children: [
-        { kind: "criterion", field: "device", criterion: { value: [1], modifier: "INCLUDES" }, negate: false },
+      child: { kind: "group", id: "g", connective: "AND", negate: false, children: [
+        { kind: "criterion", id: "c", field: "device", criterion: { value: [1], modifier: "INCLUDES" }, negate: false },
       ] },
       negate: false,
     };
@@ -63,28 +64,30 @@ describe("serialize", () => {
   it("keeps an empty relation child (presence test) and emits NONE", () => {
     const relationNone: FilterNode = {
       kind: "relation",
+      id: "r",
       field: "session_filter",
       match: "NONE",
-      child: { kind: "group", connective: "AND", negate: false, children: [] },
+      child: { kind: "group", id: "g", connective: "AND", negate: false, children: [] },
       negate: false,
     };
     expect(serialize(root(relationNone))).toEqual({ AND: [{ session_filter: { match: "NONE" } }] });
   });
 
   it("drops empty children but never a relation", () => {
-    const emptyGroup: FilterNode = { kind: "group", connective: "AND", negate: false, children: [] };
+    const emptyGroup: FilterNode = { kind: "group", id: "g", connective: "AND", negate: false, children: [] };
     const relationAnyEmpty: FilterNode = {
       kind: "relation",
+      id: "r",
       field: "session_filter",
       match: "ANY",
-      child: { kind: "group", connective: "AND", negate: false, children: [] },
+      child: { kind: "group", id: "g", connective: "AND", negate: false, children: [] },
       negate: false,
     };
     expect(serialize(root(emptyGroup, relationAnyEmpty))).toEqual({ AND: [{ session_filter: {} }] });
   });
 
   it("does not wrap an empty negated group", () => {
-    const negatedEmpty: GroupNode = { kind: "group", connective: "AND", negate: true, children: [] };
+    const negatedEmpty: GroupNode = { kind: "group", id: "g", connective: "AND", negate: true, children: [] };
     expect(serialize(negatedEmpty)).toEqual({});
   });
 

--- a/ts/elements/filter-tree/serializer.ts
+++ b/ts/elements/filter-tree/serializer.ts
@@ -17,11 +17,12 @@ import {
   MAX_FILTER_DEPTH,
   RESERVED_KEYS,
 } from "./types.js";
+import { nextNodeId } from "./node-id.js";
 
 type Json = Record<string, unknown>;
 
 export function group(connective: Connective, children: FilterNode[], negate = false): GroupNode {
-  return { kind: "group", connective, negate, children };
+  return { kind: "group", id: nextNodeId(), connective, negate, children };
 }
 
 // ── Export ─────────────────────────────────────────────────────────────────
@@ -92,7 +93,7 @@ function deserializeNode(json: Json, modelKey: string, registry: MetadataRegistr
     // for well-formed metadata, so order only matters if a key ever appears in both.
     if (meta.fields.has(key)) {
       if (isObject(value)) {
-        baseChildren.push({ kind: "criterion", field: key, criterion: value, negate: false });
+        baseChildren.push({ kind: "criterion", id: nextNodeId(), field: key, criterion: value, negate: false });
       }
     } else if (key in meta.relations) {
       if (isObject(value)) {
@@ -138,7 +139,7 @@ function deserializeNode(json: Json, modelKey: string, registry: MetadataRegistr
         "INVALID_FIELD_COMPARISON",
       );
     }
-    tail.push({ kind: "comparison", comparison, negate: false });
+    tail.push({ kind: "comparison", id: nextNodeId(), comparison, negate: false });
   }
 
   if (!tail.length) return core;
@@ -159,7 +160,7 @@ function relationNode(
   const match = parseMatch(sub.match);
   delete sub.match;
   const child = asGroup(deserializeNode(sub, targetModel, registry, depth + 1));
-  return { kind: "relation", field, match, child, negate: false };
+  return { kind: "relation", id: nextNodeId(), field, match, child, negate: false };
 }
 
 function parseMatch(value: unknown): RelationMatch {

--- a/ts/elements/filter-tree/test-support.ts
+++ b/ts/elements/filter-tree/test-support.ts
@@ -1,0 +1,27 @@
+import { expect } from "vitest";
+
+// A node carries a per-construction `id` (node-id.ts) that two independently-built
+// trees never share, so a structural `toEqual` would spuriously fail on it. Register
+// a vitest equality tester that compares two nodes ignoring `id` (recursing on the
+// rest — children re-trigger the tester). `id` is only meaningful to <filter-group>'s
+// DOM reconciliation, never to tree-shape assertions. Call once per test file.
+function isNode(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value) && "kind" in value;
+}
+
+export function ignoreNodeIds(): void {
+  expect.addEqualityTesters([
+    function (a, b, customTesters) {
+      if (!isNode(a) || !isNode(b)) return undefined; // defer to default equality
+      // Compare every key except `id`, recursing per-value through this.equals so
+      // child nodes re-trigger the tester (and drop their own id). Comparing the
+      // sub-values — never the node objects themselves — avoids infinite recursion,
+      // and works whether or not either side carries an id (expected literals omit it).
+      const keys = new Set([...Object.keys(a), ...Object.keys(b)].filter((key) => key !== "id"));
+      for (const key of keys) {
+        if (!this.equals(a[key], b[key], customTesters)) return false;
+      }
+      return true;
+    },
+  ]);
+}

--- a/ts/elements/filter-tree/types.test.ts
+++ b/ts/elements/filter-tree/types.test.ts
@@ -31,8 +31,8 @@ describe("types module", () => {
   });
 
   it("GroupNode children are mutable and connective is assignable", () => {
-    const node: GroupNode = { kind: "group", connective: "AND", negate: false, children: [] };
-    const inner: GroupNode = { kind: "group", connective: "OR", negate: false, children: [] };
+    const node: GroupNode = { kind: "group", id: "g1", connective: "AND", negate: false, children: [] };
+    const inner: GroupNode = { kind: "group", id: "g2", connective: "OR", negate: false, children: [] };
     node.children.push(inner);
     expect(node.children).toHaveLength(1);
     expect((node.children[0] as GroupNode).connective).toBe("OR");

--- a/ts/elements/filter-tree/types.ts
+++ b/ts/elements/filter-tree/types.ts
@@ -57,8 +57,13 @@ export type CriterionPayload = Record<string, unknown>;
 // Opaque to the serializer: whatever a field-comparison widget produced.
 export type ComparisonPayload = Record<string, unknown>;
 
+// Every node carries a stable client-only `id` (see node-id.ts): the serializer
+// ignores it (never reaches the wire); <filter-group> reconciles DOM on it so a
+// leaf's live widget survives structural edits. Assigned at construction by the
+// factories + deserialize; preserved through the immutable ops via `{...node}`.
 export interface GroupNode {
   kind: "group";
+  id: string;
   connective: Connective; // negation is a separate flag, never a connective
   // negate on a group with no children is meaningless and serializes away
   // (wrapNegate returns identity for an empty dict). The builder never lets that
@@ -71,6 +76,7 @@ export interface GroupNode {
 
 export interface CriterionLeaf {
   kind: "criterion";
+  id: string;
   field: string;
   criterion: CriterionPayload;
   negate: boolean;
@@ -78,12 +84,14 @@ export interface CriterionLeaf {
 
 export interface ComparisonLeaf {
   kind: "comparison";
+  id: string;
   comparison: ComparisonPayload;
   negate: boolean;
 }
 
 export interface RelationNode {
   kind: "relation";
+  id: string;
   field: string;
   match: RelationMatch;
   child: GroupNode; // exactly one canonical group

--- a/ts/elements/filter-tree/types.ts
+++ b/ts/elements/filter-tree/types.ts
@@ -106,6 +106,10 @@ export type FilterNode = GroupNode | CriterionLeaf | ComparisonLeaf | RelationNo
 // mirroring the OpenMenuDetail precedent in menu-behavior.ts.
 export interface FilterTreeChangeDetail {
   tree: GroupNode;
+  // How many criterion leaves are incomplete (no field, or a value widget with no
+  // usable value / a half-filled BETWEEN). The builder page (#192 comp 10) disables
+  // Apply while this is > 0; incomplete leaves are excluded from serializeForQuery.
+  incompleteCount: number;
 }
 
 // Per-model metadata the importer consumes to classify a JSON key as a relation

--- a/ts/elements/filter-widgets.ts
+++ b/ts/elements/filter-widgets.ts
@@ -1,0 +1,223 @@
+/**
+ * Shared filter value-widget logic — the per-kind readers (DOM → criterion JSON)
+ * and the modifier-radio enable/disable behaviors, used by BOTH the flat filter
+ * bar (filter-bar.ts) and the nested filter builder's leaf row (filter-group.ts,
+ * #192). Extracted verbatim from filter-bar.ts so the tree reuses the exact same
+ * widget contract the bars produce via the Python `field_widget` builder (#242).
+ */
+import { isPresenceModifier, isRangeModifier } from "./filter-tokens.js";
+import { readFilterSelect } from "./search-select.js";
+
+export interface Criterion {
+  value: unknown;
+  modifier: string;
+  value2?: unknown;
+}
+
+export interface PillEntry {
+  id: string;
+  label: string;
+}
+
+export function criterion(value: unknown, value2: unknown, modifier: string): Criterion {
+  const result: Criterion = { value, modifier };
+  if (value2 !== null && value2 !== undefined && value2 !== "") {
+    result.value2 = value2;
+  }
+  return result;
+}
+
+export function parseNumberInputValue(element: HTMLInputElement | null): number | "" {
+  if (!element || element.value === "") return "";
+  const value = parseFloat(element.value);
+  return isNaN(value) ? "" : value;
+}
+
+export function buildRangeCriterion(
+  valueMin: number | string,
+  valueMax: number | string,
+): Criterion | null {
+  if (valueMin !== "" && valueMax !== "") return criterion(valueMin, valueMax, "BETWEEN");
+  if (valueMin !== "") return criterion(valueMin, null, "GREATER_THAN");
+  if (valueMax !== "") return criterion(valueMax, null, "LESS_THAN");
+  return null;
+}
+
+export function parseJSONAttr<T>(element: Element, attr: string): T[] {
+  const raw = element.getAttribute(attr);
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw);
+  } catch {
+    console.warn("filter-widgets: malformed JSON attribute", attr, raw);
+    return [];
+  }
+}
+
+// ── Per-kind readers: each scoped to a single widget element, returns a criterion
+// object or null to omit the field. ──
+
+export function readStringWidget(element: HTMLElement): Record<string, unknown> | null {
+  const modifier =
+    element.querySelector<HTMLInputElement>('input[data-string-modifier-radio]:checked')
+      ?.value ?? "EQUALS";
+  if (isPresenceModifier(modifier)) {
+    return { modifier };
+  }
+  const textInput = element.querySelector<HTMLInputElement>('input[type="text"]');
+  if (textInput && textInput.value.trim()) {
+    return { value: textInput.value.trim(), modifier };
+  }
+  return null;
+}
+
+export function readNumberWidget(element: HTMLElement): Criterion | Record<string, unknown> | null {
+  const modifier =
+    element.querySelector<HTMLInputElement>('input[data-number-modifier-radio]:checked')
+      ?.value ?? "EQUALS";
+  if (isPresenceModifier(modifier)) {
+    return { modifier };
+  }
+  const value = parseNumberInputValue(
+    element.querySelector<HTMLInputElement>('input[type="number"]:not([data-number-value2])'),
+  );
+  if (isRangeModifier(modifier)) {
+    const value2Marker = element.querySelector('[data-number-value2]');
+    const value2Input =
+      value2Marker instanceof HTMLInputElement
+        ? value2Marker
+        : (value2Marker?.querySelector<HTMLInputElement>("input") ?? null);
+    const value2 = parseNumberInputValue(value2Input);
+    if (value !== "") return criterion(value, value2, modifier);
+    return null;
+  }
+  if (value !== "") return criterion(value, null, modifier);
+  return null;
+}
+
+export function readDateWidget(element: HTMLElement): Criterion | null {
+  const valueMin =
+    element.querySelector<HTMLInputElement>("[data-range-min]")?.value ?? "";
+  const valueMax =
+    element.querySelector<HTMLInputElement>("[data-range-max]")?.value ?? "";
+  return buildRangeCriterion(valueMin, valueMax);
+}
+
+export function readBoolWidget(element: HTMLElement): Criterion | null {
+  const checked = element.querySelector<HTMLInputElement>('input[type="radio"]:checked');
+  if (!checked) return null;
+  return criterion(checked.value === "true", null, "EQUALS");
+}
+
+// Build a set criterion from already-read include/exclude/modifier state.
+export function buildSetCriterion(
+  included: PillEntry[],
+  excluded: PillEntry[],
+  modifier: string | null,
+): Record<string, unknown> | null {
+  if (modifier && isPresenceModifier(modifier)) {
+    return { modifier };
+  }
+  if (included.length > 0 || excluded.length > 0) {
+    return {
+      value: included.map((item) => ({ id: item.id, label: item.label })),
+      excludes: excluded.map((item) => ({ id: item.id, label: item.label })),
+      modifier: modifier || "INCLUDES",
+    };
+  }
+  return null;
+}
+
+// Flat-bar set reader: reads the data-* attributes the global readSearchSelect
+// pass writes onto the <search-select> container.
+export function readSetWidget(element: HTMLElement): Record<string, unknown> | null {
+  return buildSetCriterion(
+    parseJSONAttr<PillEntry>(element, "data-included"),
+    parseJSONAttr<PillEntry>(element, "data-excluded"),
+    element.getAttribute("data-modifier"),
+  );
+}
+
+// Tree set reader: self-serializing, no global pass — reads the <search-select>
+// inside `valueCell` straight from its pills (issue #192's FilterSelect rework).
+export function readTreeSetWidget(valueCell: HTMLElement): Record<string, unknown> | null {
+  const searchSelect = valueCell.querySelector<HTMLElement>("search-select");
+  if (!searchSelect) return null;
+  const { included, excluded, modifier } = readFilterSelect(searchSelect);
+  return buildSetCriterion(included, excluded, modifier);
+}
+
+// Read one leaf value cell into a criterion payload by kind — the nested builder's
+// entry point. For `set` it self-serializes; for the scalar kinds it reuses the
+// shared readers. Returns null when the widget carries no usable value (incomplete).
+export function readLeafWidget(valueCell: HTMLElement, kind: string): Record<string, unknown> | null {
+  switch (kind) {
+    case "string":
+      return readStringWidget(valueCell);
+    case "number":
+      return readNumberWidget(valueCell) as Record<string, unknown> | null;
+    case "date":
+      return readDateWidget(valueCell) as Record<string, unknown> | null;
+    case "bool":
+      return readBoolWidget(valueCell) as Record<string, unknown> | null;
+    case "set":
+      return readTreeSetWidget(valueCell);
+    default:
+      return null;
+  }
+}
+
+// ── Modifier-radio behaviors: enable/disable the value input(s) as the string /
+// number modifier changes (presence → no value; number BETWEEN → reveal value2). ──
+
+export function toggleStringFilterInput(radio: HTMLInputElement): void {
+  const container = radio.closest(".flex-col");
+  if (!container) return;
+  const textInput = container.querySelector<HTMLInputElement>('input[type="text"]');
+  if (!textInput) return;
+  const checkedRadio = container.querySelector<HTMLInputElement>('input[type="radio"]:checked');
+  const value = checkedRadio ? checkedRadio.value : "";
+  if (value === "IS_NULL" || value === "NOT_NULL") {
+    textInput.disabled = true;
+    textInput.value = "";
+    textInput.classList.add("opacity-50", "cursor-not-allowed");
+  } else {
+    textInput.disabled = false;
+    textInput.classList.remove("opacity-50", "cursor-not-allowed");
+  }
+}
+
+export function toggleNumberFilterInput(radio: HTMLInputElement): void {
+  const container = radio.closest(".flex-col");
+  if (!container) return;
+  const inputs = container.querySelectorAll<HTMLInputElement>('input[type="number"]');
+  const value2 = container.querySelector<HTMLInputElement>("[data-number-value2]");
+  const checkedRadio = container.querySelector<HTMLInputElement>('input[type="radio"]:checked');
+  const modifier = checkedRadio ? checkedRadio.value : "";
+  const isPresence = modifier === "IS_NULL" || modifier === "NOT_NULL";
+  const isBetween = modifier === "BETWEEN" || modifier === "NOT_BETWEEN";
+  inputs.forEach((input) => {
+    if (isPresence) {
+      input.disabled = true;
+      input.value = "";
+      input.classList.add("opacity-50", "cursor-not-allowed");
+    } else {
+      input.disabled = false;
+      input.classList.remove("opacity-50", "cursor-not-allowed");
+    }
+  });
+  if (value2) value2.classList.toggle("hidden", isPresence || !isBetween);
+}
+
+// Delegated change handler wiring both string + number modifier toggles on a
+// persistent root (the filter bar, or a filter-group leaf container).
+export function setupModifierToggles(root: HTMLElement): void {
+  root.addEventListener("change", (event) => {
+    const target = event.target as Element;
+    if (target.matches("input[data-string-modifier-radio]")) {
+      toggleStringFilterInput(target as HTMLInputElement);
+    } else if (target.matches("input[data-number-modifier-radio]")) {
+      toggleNumberFilterInput(target as HTMLInputElement);
+    }
+  });
+}

--- a/ts/elements/filter-widgets.ts
+++ b/ts/elements/filter-widgets.ts
@@ -1,6 +1,6 @@
 /**
  * Shared filter value-widget logic — the per-kind readers (DOM → criterion JSON)
- * and the modifier-radio enable/disable behaviors, used by BOTH the flat filter
+ * and the modifier-select enable/disable behaviors, used by BOTH the flat filter
  * bar (filter-bar.ts) and the nested filter builder's leaf row (filter-group.ts,
  * #192). Extracted verbatim from filter-bar.ts so the tree reuses the exact same
  * widget contract the bars produce via the Python `field_widget` builder (#242).
@@ -59,8 +59,8 @@ export function parseJSONAttr<T>(element: Element, attr: string): T[] {
 
 export function readStringWidget(element: HTMLElement): Record<string, unknown> | null {
   const modifier =
-    element.querySelector<HTMLInputElement>('input[data-string-modifier-radio]:checked')
-      ?.value ?? "EQUALS";
+    element.querySelector<HTMLSelectElement>("select[data-string-modifier-select]")?.value ??
+    "EQUALS";
   if (isPresenceModifier(modifier)) {
     return { modifier };
   }
@@ -73,8 +73,8 @@ export function readStringWidget(element: HTMLElement): Record<string, unknown> 
 
 export function readNumberWidget(element: HTMLElement): Criterion | Record<string, unknown> | null {
   const modifier =
-    element.querySelector<HTMLInputElement>('input[data-number-modifier-radio]:checked')
-      ?.value ?? "EQUALS";
+    element.querySelector<HTMLSelectElement>("select[data-number-modifier-select]")?.value ??
+    "EQUALS";
   if (isPresenceModifier(modifier)) {
     return { modifier };
   }
@@ -167,16 +167,15 @@ export function readLeafWidget(valueCell: HTMLElement, kind: string): Record<str
   }
 }
 
-// ── Modifier-radio behaviors: enable/disable the value input(s) as the string /
+// ── Modifier-select behaviors: enable/disable the value input(s) as the string /
 // number modifier changes (presence → no value; number BETWEEN → reveal value2). ──
 
-export function toggleStringFilterInput(radio: HTMLInputElement): void {
-  const container = radio.closest(".flex-col");
+export function toggleStringFilterInput(select: HTMLSelectElement): void {
+  const container = select.closest(".flex-col");
   if (!container) return;
   const textInput = container.querySelector<HTMLInputElement>('input[type="text"]');
   if (!textInput) return;
-  const checkedRadio = container.querySelector<HTMLInputElement>('input[type="radio"]:checked');
-  const value = checkedRadio ? checkedRadio.value : "";
+  const value = select.value;
   if (value === "IS_NULL" || value === "NOT_NULL") {
     textInput.disabled = true;
     textInput.value = "";
@@ -187,13 +186,12 @@ export function toggleStringFilterInput(radio: HTMLInputElement): void {
   }
 }
 
-export function toggleNumberFilterInput(radio: HTMLInputElement): void {
-  const container = radio.closest(".flex-col");
+export function toggleNumberFilterInput(select: HTMLSelectElement): void {
+  const container = select.closest(".flex-col");
   if (!container) return;
   const inputs = container.querySelectorAll<HTMLInputElement>('input[type="number"]');
   const value2 = container.querySelector<HTMLInputElement>("[data-number-value2]");
-  const checkedRadio = container.querySelector<HTMLInputElement>('input[type="radio"]:checked');
-  const modifier = checkedRadio ? checkedRadio.value : "";
+  const modifier = select.value;
   const isPresence = modifier === "IS_NULL" || modifier === "NOT_NULL";
   const isBetween = modifier === "BETWEEN" || modifier === "NOT_BETWEEN";
   inputs.forEach((input) => {
@@ -214,10 +212,10 @@ export function toggleNumberFilterInput(radio: HTMLInputElement): void {
 export function setupModifierToggles(root: HTMLElement): void {
   root.addEventListener("change", (event) => {
     const target = event.target as Element;
-    if (target.matches("input[data-string-modifier-radio]")) {
-      toggleStringFilterInput(target as HTMLInputElement);
-    } else if (target.matches("input[data-number-modifier-radio]")) {
-      toggleNumberFilterInput(target as HTMLInputElement);
+    if (target.matches("select[data-string-modifier-select]")) {
+      toggleStringFilterInput(target as HTMLSelectElement);
+    } else if (target.matches("select[data-number-modifier-select]")) {
+      toggleNumberFilterInput(target as HTMLSelectElement);
     }
   });
 }

--- a/ts/elements/search-select.api.test.ts
+++ b/ts/elements/search-select.api.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { readFilterSelect } from "./search-select.js"; // also: customElements.define
+
+Element.prototype.scrollIntoView = () => {};
+
+interface SearchSelectLike extends HTMLElement {
+  setSelected(value: string, label?: string): void;
+}
+
+function mountSingle(): SearchSelectLike {
+  document.body.replaceChildren();
+  const host = document.createElement("search-select") as SearchSelectLike;
+  host.setAttribute("name", "field-picker");
+  host.setAttribute("multi", "false");
+  host.innerHTML = `
+    <div data-search-select-pills></div>
+    <input data-search-select-search />
+    <div data-search-select-options></div>
+  `;
+  document.body.appendChild(host); // connectedCallback → initWidget
+  return host;
+}
+
+// A filter-mode pill, as FilterSelect renders one. Modifier pills carry
+// data-search-select-modifier; exclude pills carry data-search-select-type.
+function pill(attrs: string): string {
+  return `<span data-pill ${attrs}><button data-pill-remove></button></span>`;
+}
+
+function mountFilter(pills: string): HTMLElement {
+  document.body.replaceChildren();
+  const host = document.createElement("search-select");
+  host.setAttribute("name", "platform");
+  host.setAttribute("filter-mode", "true");
+  host.innerHTML = `
+    <div data-search-select-pills>${pills}</div>
+    <input data-search-select-search />
+    <div data-search-select-options></div>
+  `;
+  document.body.appendChild(host);
+  return host;
+}
+
+describe("<search-select> setSelected (#192)", () => {
+  beforeEach(() => document.body.replaceChildren());
+
+  it("seeds a single-select value + label without firing change", () => {
+    const host = mountSingle();
+    let changes = 0;
+    host.addEventListener("search-select:change", () => (changes += 1));
+
+    host.setSelected("name", "Name");
+
+    expect(host.querySelector<HTMLInputElement>("[data-search-select-search]")!.value).toBe("Name");
+    const hidden = host.querySelector<HTMLInputElement>('[data-search-select-pills] input[type="hidden"]');
+    expect(hidden?.value).toBe("name");
+    expect(changes).toBe(0); // silent restore — no loop back into the consumer
+  });
+
+  it("falls back to the value as label when none is given", () => {
+    const host = mountSingle();
+    host.setSelected("year_released");
+    expect(host.querySelector<HTMLInputElement>("[data-search-select-search]")!.value).toBe("year_released");
+  });
+});
+
+describe("readFilterSelect (#192)", () => {
+  beforeEach(() => document.body.replaceChildren());
+
+  it("reads include / exclude pills and the modifier", () => {
+    const host = mountFilter(
+      pill('data-value="1" data-label="PC"') +
+        pill('data-value="2" data-label="Switch" data-search-select-type="exclude"') +
+        pill('data-search-select-modifier="INCLUDES_ALL"'),
+    );
+    expect(readFilterSelect(host)).toEqual({
+      included: [{ id: "1", label: "PC" }],
+      excluded: [{ id: "2", label: "Switch" }],
+      modifier: "INCLUDES_ALL",
+    });
+  });
+
+  it("returns empty arrays + blank modifier for no pills", () => {
+    expect(readFilterSelect(mountFilter(""))).toEqual({ included: [], excluded: [], modifier: "" });
+  });
+});

--- a/ts/elements/search-select.ts
+++ b/ts/elements/search-select.ts
@@ -41,6 +41,7 @@ export interface SearchSelectChangeDetail {
 interface SearchSelectContainer extends HTMLElement {
   _searchSelectLabel?: string;
   _searchSelectDirty?: boolean;
+  _searchSelectSetSelected?: (value: string, label?: string) => void;
 }
 
 interface OptionRow extends HTMLElement {
@@ -570,7 +571,11 @@ const initWidget = (containerElement: Element) => {
     };
   };
 
-  const selectOption = (option: SearchSelectOption) => {
+  // `emit` lets a programmatic restore (setSelected) seed the selection WITHOUT
+  // firing search-select:change — otherwise restoring a value after a re-render
+  // would re-trigger the consumer's on-change logic (e.g. the leaf row's field
+  // reset), looping. User-driven picks pass emit=true (the default).
+  const selectOption = (option: SearchSelectOption, emit = true) => {
     if (multi) {
       if (!pills.querySelector(`input[value="${cssEscape(option.value)}"]`)) {
         addPill(option);
@@ -586,7 +591,14 @@ const initWidget = (containerElement: Element) => {
       container._searchSelectDirty = false;
       hidePanel();
     }
-    emitChange(option);
+    if (emit) emitChange(option);
+  };
+
+  // Public programmatic setter (issue #192): restore/seed a selection from code
+  // without a round-trip through the option list or a change event. Used by the
+  // nested filter builder to show a leaf's already-chosen field after a re-render.
+  container._searchSelectSetSelected = (value: string, label?: string) => {
+    selectOption({ value, label: label ?? value, data: {} }, false);
   };
 
   const addPill = (option: SearchSelectOption) => {
@@ -705,39 +717,56 @@ const initWidget = (containerElement: Element) => {
 /** Minimal escape for use inside an attribute-value selector. */
 const cssEscape = (value: string | null): string => String(value).replace(/["\\]/g, "\\$&");
 
+// The current include/exclude/modifier state of one filter-mode <search-select>,
+// read straight from its pills. Self-contained per element (no flat form) so the
+// nested filter builder's leaf row can serialize a single widget on its
+// search-select:change — issue #192. `modifier` is "" when no modifier pill is set.
+export interface FilterSelectValue {
+  included: FilterPillEntry[];
+  excluded: FilterPillEntry[];
+  modifier: string;
+}
+
+export function readFilterSelect(container: HTMLElement): FilterSelectValue {
+  const pills = container.querySelector<HTMLElement>("[data-search-select-pills]");
+  const included: FilterPillEntry[] = [];
+  const excluded: FilterPillEntry[] = [];
+  let modifier = "";
+  if (pills) {
+    pills.querySelectorAll<HTMLElement>("[data-pill]").forEach(pill => {
+      const pillModifier = pill.getAttribute("data-search-select-modifier");
+      if (pillModifier) {
+        modifier = pillModifier;  // last modifier pill wins
+        return;                    // skip value extraction for this pill
+      }
+      const value = pill.getAttribute("data-value") ?? "";
+      const label = pill.getAttribute("data-label") || "";
+      if (pill.getAttribute("data-search-select-type") === "exclude") {
+        excluded.push({ id: value, label });
+      } else {
+        included.push({ id: value, label });
+      }
+    });
+  }
+  return { included, excluded, modifier };
+}
+
 // Serialise each widget's current state onto data-* attributes for the caller.
 // Form widgets expose data-values (the submitted hidden-input values); filter
 // widgets expose data-included / data-excluded / data-modifier for the filter
-// bar to read.
+// bar to read. (The legacy flat filter bar's whole-form pass; the nested builder
+// uses readFilterSelect per widget instead.)
 export function readSearchSelect(form: HTMLElement): void {
   form.querySelectorAll<HTMLElement>("search-select").forEach(container => {
-    const pills = container.querySelector<HTMLElement>("[data-search-select-pills]");
     if (container.getAttribute("filter-mode") === "true") {
-      const included: FilterPillEntry[] = [];
-      const excluded: FilterPillEntry[] = [];
-      let modifier = "";
-      if (pills) {
-        pills.querySelectorAll<HTMLElement>("[data-pill]").forEach(pill => {
-          const pillModifier = pill.getAttribute("data-search-select-modifier");
-          if (pillModifier) {
-            modifier = pillModifier;  // last modifier pill wins
-            return;                    // skip value extraction for this pill
-          }
-          const value = pill.getAttribute("data-value") ?? "";
-          const label = pill.getAttribute("data-label") || "";
-          if (pill.getAttribute("data-search-select-type") === "exclude") {
-            excluded.push({ id: value, label });
-          } else {
-            included.push({ id: value, label });
-          }
-        });
-      }
+      const { included, excluded, modifier } = readFilterSelect(container);
       container.setAttribute("data-included", JSON.stringify(included));
       container.setAttribute("data-excluded", JSON.stringify(excluded));
       if (modifier) container.setAttribute("data-modifier", modifier);
       else container.removeAttribute("data-modifier");
       return;
     }
+    const pills = container.querySelector<HTMLElement>("[data-search-select-pills]");
     const values = pills
       ? Array.from(pills.querySelectorAll<HTMLInputElement>('input[type="hidden"]')).map(input => input.value)
       : [];
@@ -745,14 +774,17 @@ export function readSearchSelect(form: HTMLElement): void {
   });
 }
 
-// Keep as window global for filter_bar.ts until it is converted to a custom element.
-window.readSearchSelect = readSearchSelect;
-
 class SearchSelectElement extends HTMLElement {
   private onDocumentClick: ((event: MouseEvent) => void) | null = null;
 
   connectedCallback(): void {
     this.onDocumentClick = initWidget(this) as ((event: MouseEvent) => void) | null;
+  }
+
+  /** Programmatically set a single-select value without firing a change event
+   *  (issue #192). No-op until the widget has initialised. */
+  setSelected(value: string, label?: string): void {
+    (this as SearchSelectContainer)._searchSelectSetSelected?.(value, label);
   }
 
   disconnectedCallback(): void {

--- a/ts/elements/search-select.ts
+++ b/ts/elements/search-select.ts
@@ -776,8 +776,19 @@ export function readSearchSelect(form: HTMLElement): void {
 
 class SearchSelectElement extends HTMLElement {
   private onDocumentClick: ((event: MouseEvent) => void) | null = null;
+  private initialized = false;
 
   connectedCallback(): void {
+    // Idempotent across DOM moves (the nested filter builder reconciles rows by
+    // re-appending them, which reconnects this element). The inner element
+    // listeners persist with the moved subtree, so re-running initWidget would
+    // double-bind them — instead just re-attach the outside-click listener that
+    // disconnectedCallback removed.
+    if (this.initialized) {
+      if (this.onDocumentClick) document.addEventListener("click", this.onDocumentClick);
+      return;
+    }
+    this.initialized = true;
     this.onDocumentClick = initWidget(this) as ((event: MouseEvent) => void) | null;
   }
 
@@ -788,10 +799,8 @@ class SearchSelectElement extends HTMLElement {
   }
 
   disconnectedCallback(): void {
-    if (this.onDocumentClick) {
-      document.removeEventListener("click", this.onDocumentClick);
-      this.onDocumentClick = null;
-    }
+    // Keep the handler reference so a reconnection can re-attach it (see above).
+    if (this.onDocumentClick) document.removeEventListener("click", this.onDocumentClick);
   }
 }
 

--- a/ts/globals.d.ts
+++ b/ts/globals.d.ts
@@ -4,6 +4,5 @@ declare global {
   interface Window {
     fetchWithHtmxTriggers(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
     toast(message: string, type?: string): void;
-    readSearchSelect(form: HTMLElement): void;
   }
 }


### PR DESCRIPTION
Part of #192 (nested filter builder, phase 2c) — the **criterion-leaf slice**. Builds on the merged #242 (per-field `field_widget` builder).

## What lands
Turns the builder's inert leaf slots into **live `[field][value]` rows** (string / number / date / bool / set):

- **Field picker** combobox per leaf; picking runs `setLeafField`, cloning that field's `field_widget` template into the value cell.
- **Value widgets** read via a shared `ts/elements/filter-widgets.ts` (extracted from the flat bar); **set self-serializes** through the new `readFilterSelect` (no global pass).
- **Reconcile by stable node id** — a leaf's live widget survives structural edits (add/remove/move/negate).
- **Incomplete leaves** flagged (amber tint + "Incomplete" badge) and excluded from `serializeForQuery` (prunes them); change event carries `incompleteCount`.
- Shared elements gained real APIs (not workarounds): `search-select.setSelected`, `date-range-picker` `date-range:change` event, both made idempotent across DOM moves; every `FilterNode` now has a stable client-only `id` (serializer ignores it).
- **Modifier control → compact `<select>`** (string/number), replacing the 8-radio grid — flat bar too (uniform).
- Fix: the incomplete-leaf fade used `opacity`, which made the field-picker dropdown translucent + trapped its `z-index` — swapped for a bg tint.

## Verification
Full `make check` green (mypy, ts-check, vitest 160, pytest 1346 incl. e2e). Verified in-browser on `/filter-group-demo/`: all kinds compose to exact backend payloads; widget values survive structural edits; incomplete leaves excluded.

## Deferred (follow-ups)
- **Field-comparison leaf** (`[left][op][right]`) — #192 slice 2.
- Leaf-row e2e (needs a real page mounting `<filter-group>` — comp 10; the demo is DEBUG-only).
- Codegen the `FilterFieldMeta` TS type from Python `FieldMeta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)