### PR TITLE
feat(filters): field-comparison leaf in the nested builder (#246)

### DIFF
--- a/common/components/custom_elements.py
+++ b/common/components/custom_elements.py
@@ -207,7 +207,12 @@ def FilterGroup(*, model: str) -> Node:
 
     from django.apps import apps
 
-    from common.components.filters import FilterFieldPicker, field_widget_templates
+    from common.components.filters import (
+        FilterFieldPicker,
+        comparison_row_template,
+        field_widget_templates,
+        has_comparable_group,
+    )
     from common.components.primitives import Template
     from common.criteria import comparable_columns, field_metadata
     from games.filters import filter_for_model
@@ -216,18 +221,24 @@ def FilterGroup(*, model: str) -> Node:
     # comparable_columns() enumerates the Django model's columns (not the filter
     # class); resolve the model the same way filter_for_model does.
     model_cls = apps.get_model("games", model)
+    columns = comparable_columns(model_cls)
     # One blank value-widget <template data-field="name"> per leaf field, cloned
     # into a leaf's value cell on field-pick, plus the field-picker combobox
     # template cloned into every leaf's field cell (id-less → the TS assigns a
-    # unique id per clone).
+    # unique id per clone), plus — when the model admits a field comparison — one
+    # blank comparison-row <template> cloned into every comparison leaf (#246).
     widget_templates = list(field_widget_templates(filter_cls).values())
+    comparison_template: list[Node] = (
+        [comparison_row_template(columns)] if has_comparable_group(columns) else []
+    )
     return _FilterGroup(
         model=model,
         fields=json.dumps(field_metadata(filter_cls)),
-        columns=json.dumps(comparable_columns(model_cls)),
+        columns=json.dumps(columns),
     )[
         Template(data_field_picker_template="")[FilterFieldPicker(filter_cls)],
         *widget_templates,
+        *comparison_template,
     ]
 
 

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -894,6 +894,33 @@ def FieldComparisonSet(
     ]
 
 
+def comparison_row_template(columns: list[ComparableColumn]) -> Node:
+    """A blank field-comparison ``<template>`` for the nested builder (#246).
+
+    The nested builder (``<filter-group>``) clones this into each comparison leaf's
+    value cell, reusing the single-row widget — the *same* ``_field_comparison_row``
+    markup ``FieldComparisonSet`` uses, minus the set container and its AND/OR mode
+    toggle (the enclosing group owns the connective now). The row's own ``✕`` remove
+    button is dropped client-side; the group's controls own removal."""
+    from games.forms import SELECT_CLASS
+
+    return Template(data_fc_row_template="")[
+        _field_comparison_row(columns, None, SELECT_CLASS)
+    ]
+
+
+def has_comparable_group(columns: list[ComparableColumn]) -> bool:
+    """Whether ``columns`` admits at least one field comparison: some comparison
+    group with ≥2 columns (a comparison needs two columns of the SAME group). The
+    same gate ``_field_comparison_section`` uses to decide whether to show the flat
+    bar's comparison field — reused so the builder's ``+ comparison`` affordance
+    appears under identical conditions."""
+    group_counts: dict[str, int] = {}
+    for column in columns:
+        group_counts[column["group"]] = group_counts.get(column["group"], 0) + 1
+    return any(count >= 2 for count in group_counts.values())
+
+
 def _field_comparison_section(
     existing: dict, model: type[models.Model] | None
 ) -> Node | None:
@@ -905,10 +932,7 @@ def _field_comparison_section(
     if model is None:
         return None
     columns = comparable_columns(model)
-    group_counts: dict[str, int] = {}
-    for column in columns:
-        group_counts[column["group"]] = group_counts.get(column["group"], 0) + 1
-    if not any(count >= 2 for count in group_counts.values()):
+    if not has_comparable_group(columns):
         return None
     rows, mode = _field_comparison_rows(existing)
     return _filter_field(

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -771,3 +771,62 @@ class FieldComparisonWidgetTest(TestCase):
         html = str(SessionFilterBar(filter_json=filter_json))
         self.assertRegex(html, r'value="OR"[^>]*checked="true"')
         self.assertIn('data-selected="LESS_THAN"', html)
+
+
+class HasComparableGroupTest(TestCase):
+    """The ≥2-columns-of-one-group gate shared by the flat bar's comparison field
+    and the nested builder's `+ comparison` affordance / row template (#246)."""
+
+    def _column(self, value, group):
+        return {"value": value, "label": value.title(), "group": group, "operators": []}
+
+    def test_empty_is_false(self):
+        from common.components.filters import has_comparable_group
+
+        self.assertFalse(has_comparable_group([]))
+
+    def test_single_column_is_false(self):
+        from common.components.filters import has_comparable_group
+
+        self.assertFalse(has_comparable_group([self._column("a", "number")]))
+
+    def test_two_columns_different_groups_is_false(self):
+        from common.components.filters import has_comparable_group
+
+        columns = [self._column("a", "number"), self._column("b", "datetime")]
+        self.assertFalse(has_comparable_group(columns))
+
+    def test_two_columns_same_group_is_true(self):
+        from common.components.filters import has_comparable_group
+
+        columns = [self._column("a", "number"), self._column("b", "number")]
+        self.assertTrue(has_comparable_group(columns))
+
+
+class FilterGroupComparisonTest(TestCase):
+    """The nested-builder shell (#246): the `columns` prop + the blank
+    comparison-row `<template>` it emits for the field-comparison leaf."""
+
+    def test_columns_prop_carries_comparable_columns(self):
+        from common.components import FilterGroup
+
+        html = str(FilterGroup(model="session"))
+        self.assertIn("columns=", html)
+        # Session's datetime pair — the issue's driving use case.
+        self.assertIn("timestamp_start", html)
+        self.assertIn("timestamp_end", html)
+
+    def test_emits_comparison_row_template_when_model_has_comparable_group(self):
+        from common.components import FilterGroup
+
+        html = str(FilterGroup(model="session"))
+        self.assertIn("data-fc-row-template", html)
+        # The reused single row's hooks reach the cloned template.
+        self.assertIn("data-fc-left", html)
+
+    def test_columns_prop_has_no_double_escaped_markup(self):
+        from common.components import FilterGroup
+
+        html = str(FilterGroup(model="session"))
+        for marker in _ESCAPED_TAG_MARKERS:
+            self.assertNotIn(marker, html)

--- a/ts/elements/field-comparison-set.ts
+++ b/ts/elements/field-comparison-set.ts
@@ -13,7 +13,7 @@
  */
 import { readFieldComparisonSetProps } from "../generated/props.js";
 
-interface Column {
+export interface Column {
   value: string;
   label: string;
   group: string;
@@ -67,8 +67,9 @@ function fillSelect(
 }
 
 /** Rebuild a row's operator + right-column options from its left column. The
- * reusable single-row unit (see file header). */
-function refreshRow(row: HTMLElement, columns: Column[]): void {
+ * reusable single-row unit (see file header) — the nested builder's comparison
+ * leaf (#246) calls this directly on a standalone row. */
+export function refreshRow(row: HTMLElement, columns: Column[]): void {
   const left = row.querySelector<HTMLSelectElement>("[data-fc-left]");
   const operator = row.querySelector<HTMLSelectElement>("[data-fc-op]");
   const right = row.querySelector<HTMLSelectElement>("[data-fc-right]");
@@ -129,6 +130,23 @@ function wireRow(row: HTMLElement, columns: Column[]): void {
     ?.addEventListener("click", () => row.remove());
 }
 
+/** Read one comparison row into its complete value, or null when incomplete (a
+ * missing column/operator, or the two columns equal). The reusable single-row read
+ * the set folds over — the nested builder's comparison leaf (#246) reads its lone
+ * row directly. `granularity` is emitted only when the by-day toggle is on AND
+ * visible (a datetime operand), keeping the filter JSON compact. */
+export function readComparisonRow(row: HTMLElement): ComparisonRow | null {
+  const left = row.querySelector<HTMLSelectElement>("[data-fc-left]")?.value ?? "";
+  const modifier = row.querySelector<HTMLSelectElement>("[data-fc-op]")?.value ?? "";
+  const right = row.querySelector<HTMLSelectElement>("[data-fc-right]")?.value ?? "";
+  if (!left || !right || !modifier || left === right) return null;
+  const byDay = row.querySelector<HTMLInputElement>("[data-fc-granularity]");
+  const byDayWrap = row.querySelector<HTMLElement>("[data-fc-granularity-wrap]");
+  const entry: ComparisonRow = { left, right, modifier };
+  if (byDay?.checked && byDayWrap && !byDayWrap.hidden) entry.granularity = "date";
+  return entry;
+}
+
 /** Read the set's mode + complete rows for filter-bar.ts serialization. */
 export function readFieldComparisonSet(element: HTMLElement): {
   mode: string;
@@ -140,17 +158,8 @@ export function readFieldComparisonSet(element: HTMLElement): {
       : "AND";
   const comparisons: ComparisonRow[] = [];
   element.querySelectorAll<HTMLElement>("[data-fc-row]").forEach((row) => {
-    const left = row.querySelector<HTMLSelectElement>("[data-fc-left]")?.value ?? "";
-    const modifier = row.querySelector<HTMLSelectElement>("[data-fc-op]")?.value ?? "";
-    const right = row.querySelector<HTMLSelectElement>("[data-fc-right]")?.value ?? "";
-    const byDay = row.querySelector<HTMLInputElement>("[data-fc-granularity]");
-    const byDayWrap = row.querySelector<HTMLElement>("[data-fc-granularity-wrap]");
-    const isDate = Boolean(byDay?.checked && byDayWrap && !byDayWrap.hidden);
-    if (left && right && modifier && left !== right) {
-      const entry: ComparisonRow = { left, right, modifier };
-      if (isDate) entry.granularity = "date";
-      comparisons.push(entry);
-    }
+    const entry = readComparisonRow(row);
+    if (entry) comparisons.push(entry);
   });
   return { mode, comparisons };
 }

--- a/ts/elements/field-comparison-set.ts
+++ b/ts/elements/field-comparison-set.ts
@@ -12,19 +12,17 @@
  * container so the nested boolean builder (#168) can reuse it inside a group.
  */
 import { readFieldComparisonSetProps } from "../generated/props.js";
+import type { ComparisonRow } from "./filter-tree/types.js";
+
+// The row shape lives in filter-tree/types.ts (shared with the serializer +
+// completeness check); re-exported here for the widget's existing consumers.
+export type { ComparisonRow };
 
 export interface Column {
   value: string;
   label: string;
   group: string;
   operators: string[]; // server-supplied allowed operators (#152)
-}
-
-export interface ComparisonRow {
-  left: string;
-  right: string;
-  modifier: string;
-  granularity?: "date"; // omitted when "raw" to keep filter JSON compact
 }
 
 // Presentation-only glyphs for the operator tokens the server sends. Not a

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -371,6 +371,8 @@ describe("<filter-group> live criterion leaf row (#192)", () => {
 const COLUMNS = [
   { value: "year_released", label: "Year", group: "number", operators: ["EQUALS", "LESS_THAN"] },
   { value: "original_year_released", label: "Orig", group: "number", operators: ["EQUALS", "LESS_THAN"] },
+  { value: "created_at", label: "Created", group: "datetime", operators: ["EQUALS", "LESS_THAN"] },
+  { value: "updated_at", label: "Updated", group: "datetime", operators: ["EQUALS", "LESS_THAN"] },
 ];
 
 function mountComparison(): FilterGroupElement {
@@ -386,6 +388,8 @@ function mountComparison(): FilterGroupElement {
           <option value="">column…</option>
           <option value="year_released">Year</option>
           <option value="original_year_released">Orig</option>
+          <option value="created_at">Created</option>
+          <option value="updated_at">Updated</option>
         </select>
         <select data-fc-op data-selected></select>
         <select data-fc-right data-selected></select>
@@ -466,5 +470,52 @@ describe("<filter-group> live field-comparison leaf (#246)", () => {
     clickAction(host, "add-condition", []); // structural re-render
     const left = row(host, [1]).querySelector<HTMLSelectElement>("[data-fc-left]")!;
     expect(left.value).toBe("year_released");
+  });
+
+  it("negating a comparison leaf serializes to {NOT:[{field_comparisons:…}]}", () => {
+    const host = mountComparison();
+    clickAction(host, "remove", [0]);
+    clickAction(host, "add-comparison", []);
+    setSelect(host, [0], "data-fc-left", "year_released");
+    setSelect(host, [0], "data-fc-op", "LESS_THAN");
+    setSelect(host, [0], "data-fc-right", "original_year_released");
+    clickAction(host, "toggle-negate", [0]);
+    expect(button(host, "toggle-negate", [0])?.getAttribute("aria-pressed")).toBe("true");
+    expect(host.serializeForQuery()).toEqual({
+      AND: [{ NOT: [{ field_comparisons: [{ left: "year_released", right: "original_year_released", modifier: "LESS_THAN" }] }] }],
+    });
+  });
+
+  it("emits granularity:\"date\" only when the by-day toggle is checked and visible", () => {
+    const host = mountComparison();
+    clickAction(host, "remove", [0]);
+    clickAction(host, "add-comparison", []);
+    // A datetime left column unhides the by-day wrapper (refreshRow); check it.
+    setSelect(host, [0], "data-fc-left", "created_at");
+    setSelect(host, [0], "data-fc-op", "LESS_THAN");
+    setSelect(host, [0], "data-fc-right", "updated_at");
+    const wrap = row(host, [0]).querySelector<HTMLElement>("[data-fc-granularity-wrap]")!;
+    expect(wrap.hidden).toBe(false); // datetime operand → toggle shown
+    const byDay = row(host, [0]).querySelector<HTMLInputElement>("[data-fc-granularity]")!;
+    byDay.checked = true;
+    byDay.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(host.serializeForQuery()).toEqual({
+      AND: [{ field_comparisons: [{ left: "created_at", right: "updated_at", modifier: "LESS_THAN", granularity: "date" }] }],
+    });
+  });
+
+  it("drops granularity when the by-day wrapper is hidden (non-datetime operand)", () => {
+    const host = mountComparison();
+    clickAction(host, "remove", [0]);
+    clickAction(host, "add-comparison", []);
+    setSelect(host, [0], "data-fc-left", "year_released"); // number group → wrapper stays hidden
+    setSelect(host, [0], "data-fc-op", "LESS_THAN");
+    setSelect(host, [0], "data-fc-right", "original_year_released");
+    // Force the checkbox on even though the wrapper is hidden — readComparisonRow
+    // must still omit granularity (guards the `!byDayWrap.hidden` condition).
+    const byDay = row(host, [0]).querySelector<HTMLInputElement>("[data-fc-granularity]")!;
+    byDay.checked = true;
+    const payload = (host.serializeForQuery() as { AND: { field_comparisons: object[] }[] }).AND[0].field_comparisons[0];
+    expect(payload).not.toHaveProperty("granularity");
   });
 });

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -363,3 +363,108 @@ describe("<filter-group> live criterion leaf row (#192)", () => {
     expect(last).toBe(0);
   });
 });
+
+// ── Live field-comparison leaf row (#246) ──
+// Two number columns of the same group so a comparison is buildable. The synthetic
+// row template mirrors _field_comparison_row's data hooks (data-fc-left/op/right +
+// the by-day granularity toggle) so the reused refreshRow/readComparisonRow drive it.
+const COLUMNS = [
+  { value: "year_released", label: "Year", group: "number", operators: ["EQUALS", "LESS_THAN"] },
+  { value: "original_year_released", label: "Orig", group: "number", operators: ["EQUALS", "LESS_THAN"] },
+];
+
+function mountComparison(): FilterGroupElement {
+  document.body.replaceChildren();
+  const host = document.createElement("filter-group") as FilterGroupElement;
+  host.setAttribute("model", "game");
+  host.setAttribute("fields", JSON.stringify([]));
+  host.setAttribute("columns", JSON.stringify(COLUMNS));
+  host.innerHTML = `
+    <template data-fc-row-template>
+      <div data-fc-row>
+        <select data-fc-left>
+          <option value="">column…</option>
+          <option value="year_released">Year</option>
+          <option value="original_year_released">Orig</option>
+        </select>
+        <select data-fc-op data-selected></select>
+        <select data-fc-right data-selected></select>
+        <label data-fc-granularity-wrap hidden><input type="checkbox" data-fc-granularity /></label>
+        <button data-fc-remove>✕</button>
+      </div>
+    </template>`;
+  document.body.appendChild(host);
+  return host;
+}
+
+function setSelect(host: HTMLElement, path: number[], hook: string, value: string): void {
+  const select = row(host, path).querySelector<HTMLSelectElement>(`[data-value-cell] [${hook}]`)!;
+  select.value = value;
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+describe("<filter-group> live field-comparison leaf (#246)", () => {
+  it("shows + comparison only when the model has a comparable group", () => {
+    expect(button(mountComparison(), "add-comparison", [])).not.toBeNull();
+    // no columns → no comparison affordance
+    const host = mount(); // model "game" but no columns attribute → hasComparableGroup false
+    expect(button(host, "add-comparison", [])).toBeNull();
+  });
+
+  it("+ comparison adds a live comparison row (not an inert slot)", () => {
+    const host = mountComparison();
+    clickAction(host, "add-comparison", []);
+    const slot = slots(host).find((s) => s.dataset.nodeKind === "comparison")!;
+    expect(slot).toBeDefined();
+    expect(slot.querySelector("[data-fc-row]")).not.toBeNull();
+    // the row's own ✕ is dropped — the group's controls own removal
+    expect(slot.querySelector("[data-fc-remove]")).toBeNull();
+  });
+
+  it("serializeForQuery emits the backend field_comparisons payload", () => {
+    const host = mountComparison();
+    clickAction(host, "remove", [0]); // drop the seed criterion so only the comparison remains
+    clickAction(host, "add-comparison", []);
+    setSelect(host, [0], "data-fc-left", "year_released"); // refreshRow fills op + right
+    setSelect(host, [0], "data-fc-op", "LESS_THAN");
+    setSelect(host, [0], "data-fc-right", "original_year_released");
+    expect(host.serializeForQuery()).toEqual({
+      AND: [{ field_comparisons: [{ left: "year_released", right: "original_year_released", modifier: "LESS_THAN" }] }],
+    });
+  });
+
+  it("excludes an incomplete comparison (only left chosen) from the query + flags it", () => {
+    const host = mountComparison();
+    clickAction(host, "remove", [0]);
+    clickAction(host, "add-comparison", []);
+    setSelect(host, [0], "data-fc-left", "year_released"); // right/op still empty
+    expect(row(host, [0]).querySelector("[data-incomplete-badge]")).not.toBeNull();
+    expect(host.serializeForQuery()).toEqual({}); // pruned → matches all
+  });
+
+  it("reports the incomplete comparison in incompleteCount", () => {
+    const host = mountComparison();
+    clickAction(host, "remove", [0]);
+    let last = -1;
+    host.addEventListener("filter-tree-change", (event) => {
+      last = (event as CustomEvent).detail.incompleteCount;
+    });
+    clickAction(host, "add-comparison", []); // added empty → 1 incomplete
+    expect(last).toBe(1);
+    setSelect(host, [0], "data-fc-left", "year_released");
+    setSelect(host, [0], "data-fc-op", "LESS_THAN");
+    setSelect(host, [0], "data-fc-right", "original_year_released");
+    expect(last).toBe(0);
+  });
+
+  it("a comparison's live value survives a structural edit elsewhere (reconcile by id)", () => {
+    const host = mountComparison();
+    clickAction(host, "add-comparison", []); // [0]=criterion seed, [1]=comparison
+    setSelect(host, [1], "data-fc-left", "year_released");
+    setSelect(host, [1], "data-fc-op", "LESS_THAN");
+    setSelect(host, [1], "data-fc-right", "original_year_released");
+    clickAction(host, "add-condition", []); // structural re-render
+    const left = row(host, [1]).querySelector<HTMLSelectElement>("[data-fc-left]")!;
+    expect(left.value).toBe("year_released");
+  });
+});

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -19,6 +19,7 @@
 import { readFilterGroupProps } from "../generated/props.js";
 import { serialize } from "./filter-tree/serializer.js";
 import type {
+  ComparisonLeaf,
   Connective,
   CriterionLeaf,
   FilterFieldMeta,
@@ -34,11 +35,13 @@ import {
   canWrap,
   criterionForField,
   duplicateAt,
+  emptyComparison,
   emptyCriterion,
   emptyGroup,
   emptyRelation,
   emptyRoot,
   insertChild,
+  isComparisonComplete,
   isCriterionComplete,
   move,
   parseFieldMeta,
@@ -50,6 +53,11 @@ import {
   unwrapGroup,
   wrapInGroup,
 } from "./filter-tree/operations.js";
+import {
+  type Column,
+  readComparisonRow,
+  refreshRow,
+} from "./field-comparison-set.js";
 import { readLeafWidget, setupModifierToggles } from "./filter-widgets.js";
 import type { SearchSelectChangeDetail } from "./search-select.js";
 
@@ -117,6 +125,7 @@ const BUTTON_CLASS =
 // side fails tsc instead of silently no-op'ing.
 type TreeAction =
   | "add-condition"
+  | "add-comparison"
   | "add-group"
   | "add-relation"
   | "remove"
@@ -188,12 +197,24 @@ export class FilterGroupElement extends HTMLElement {
   private wired = false;
   // field name -> its FieldMeta (kind, label, modifiers …), from the `fields` prop.
   private fields = new Map<string, FilterFieldMeta>();
+  // The model's comparable columns (from the `columns` prop), driving each
+  // comparison leaf's row widget (#246). `hasComparableGroup` gates the
+  // `+ comparison` affordance on the same rule as the flat bar (a group with ≥2
+  // columns — otherwise no valid comparison row could be built).
+  private columns: Column[] = [];
+  private hasComparableGroup = false;
   // The <template> whose content is the field-picker combobox, cloned per leaf.
   private fieldPickerTemplate: HTMLTemplateElement | null = null;
   // field name -> its blank value-widget <template>, cloned into a leaf on field-pick.
   private widgetTemplates = new Map<string, HTMLTemplateElement>();
+  // The <template> whose content is a blank field-comparison row, cloned per
+  // comparison leaf (#246). Absent when the model admits no comparison.
+  private comparisonRowTemplate: HTMLTemplateElement | null = null;
   // node id -> its cached cells (see LeafCells). Pruned to live nodes each render.
   private rowCache = new Map<string, LeafCells>();
+  // node id -> a comparison leaf's cached row cell, reused across structural
+  // re-renders so an in-progress comparison survives edits elsewhere.
+  private comparisonCache = new Map<string, HTMLElement>();
   // Monotonic suffix so cloned widget/picker element ids stay unique per leaf.
   private cloneSequence = 0;
 
@@ -203,6 +224,7 @@ export class FilterGroupElement extends HTMLElement {
     if (!this.wired) {
       this.captureTemplates();
       this.parseFields(props.fields);
+      this.parseColumns(props.columns);
       this.addEventListener("click", this.onClick);
       // Value edits (typing, radios, set pills, date bounds, field pick) bubble
       // here; one delegated listener updates completeness / handles field changes.
@@ -228,6 +250,9 @@ export class FilterGroupElement extends HTMLElement {
       const field = template.getAttribute("data-field");
       if (field) this.widgetTemplates.set(field, template);
     });
+    this.comparisonRowTemplate = this.querySelector<HTMLTemplateElement>(
+      "template[data-fc-row-template]",
+    );
   }
 
   private parseFields(raw: string): void {
@@ -238,6 +263,24 @@ export class FilterGroupElement extends HTMLElement {
     } catch {
       console.warn("filter-group: malformed fields prop");
     }
+  }
+
+  // Parse the `columns` prop and precompute whether any comparison is possible: a
+  // comparison needs two columns of the SAME group, so a group with ≥2 members.
+  private parseColumns(raw: string): void {
+    if (raw) {
+      try {
+        this.columns = JSON.parse(raw) as Column[];
+      } catch {
+        console.warn("filter-group: malformed columns prop");
+        this.columns = [];
+      }
+    }
+    const groupCounts = new Map<string, number>();
+    for (const column of this.columns) {
+      groupCounts.set(column.group, (groupCounts.get(column.group) ?? 0) + 1);
+    }
+    this.hasComparableGroup = [...groupCounts.values()].some((count) => count >= 2);
   }
 
   /** The current node tree — for 2d serialize/count. Do not mutate it: every edit
@@ -271,7 +314,8 @@ export class FilterGroupElement extends HTMLElement {
   private fillNode(node: FilterNode): FilterNode {
     if (node.kind === "group") return this.fillCriteria(node);
     if (node.kind === "criterion") return { ...node, criterion: this.readLeaf(node) ?? {} };
-    return node; // relation/comparison unchanged (out of this slice)
+    if (node.kind === "comparison") return { ...node, comparison: this.readComparison(node) ?? {} };
+    return node; // relation unchanged (its widget is a sibling 2c component)
   }
 
   // Read a criterion leaf's live value widget into a payload, or null when it has
@@ -287,11 +331,33 @@ export class FilterGroupElement extends HTMLElement {
     return isCriterionComplete({ ...node, criterion: this.readLeaf(node) ?? {} });
   }
 
+  // Read a comparison leaf's live row into its {left, right, modifier, granularity?}
+  // payload, or null when the row is incomplete. Keyed off the cached row cell.
+  private readComparison(node: ComparisonLeaf): Record<string, unknown> | null {
+    const cell = this.comparisonCache.get(node.id);
+    const row = cell ? readComparisonRow(cell) : null;
+    // ComparisonRow → the opaque ComparisonPayload the serializer wraps verbatim.
+    return row as Record<string, unknown> | null;
+  }
+
+  private comparisonComplete(node: ComparisonLeaf): boolean {
+    return isComparisonComplete({ ...node, comparison: this.readComparison(node) ?? {} });
+  }
+
+  // Whether the user has picked the row's left column yet — the "touched" signal
+  // that gates the Incomplete badge, mirroring how a criterion row shows no badge
+  // until a field is chosen (a pristine comparison row shouldn't nag).
+  private comparisonTouched(node: ComparisonLeaf): boolean {
+    const left = this.comparisonCache.get(node.id)?.querySelector<HTMLSelectElement>("[data-fc-left]");
+    return Boolean(left?.value);
+  }
+
   private incompleteCount(node: GroupNode = this.tree): number {
     let count = 0;
     for (const child of node.children) {
       if (child.kind === "group") count += this.incompleteCount(child);
       else if (child.kind === "criterion" && !this.leafComplete(child)) count += 1;
+      else if (child.kind === "comparison" && !this.comparisonComplete(child)) count += 1;
     }
     return count;
   }
@@ -308,6 +374,9 @@ export class FilterGroupElement extends HTMLElement {
     switch (action) {
       case "add-condition":
         this.tree = insertChild(this.tree, path, emptyCriterion());
+        break;
+      case "add-comparison":
+        this.tree = insertChild(this.tree, path, emptyComparison());
         break;
       case "add-group":
         if (canAddGroup(this.tree, path)) this.tree = insertChild(this.tree, path, emptyGroup());
@@ -377,6 +446,9 @@ export class FilterGroupElement extends HTMLElement {
     for (const id of [...this.rowCache.keys()]) {
       if (!live.has(id)) this.rowCache.delete(id);
     }
+    for (const id of [...this.comparisonCache.keys()]) {
+      if (!live.has(id)) this.comparisonCache.delete(id);
+    }
   }
 
   private renderGroup(node: GroupNode, path: NodePath, index: number, siblingCount: number): HTMLElement {
@@ -418,11 +490,12 @@ export class FilterGroupElement extends HTMLElement {
   private renderChild(child: FilterNode, path: NodePath, index: number, siblingCount: number): HTMLElement {
     if (child.kind === "group") return this.renderGroup(child, path, index, siblingCount);
     if (child.kind === "criterion") return this.renderCriterionRow(child, path, index, siblingCount);
+    if (child.kind === "comparison") return this.renderComparisonRow(child, path, index, siblingCount);
     return this.renderInertSlot(child, path, index, siblingCount);
   }
 
-  // Relation/comparison leaves stay inert slots (their widgets are sibling 2c
-  // components, out of this slice); the criterion row is live below.
+  // The relation leaf stays an inert slot (its widget is a sibling 2c component,
+  // out of this slice); the criterion + comparison rows are live below.
   private renderInertSlot(
     child: FilterNode,
     path: NodePath,
@@ -523,6 +596,57 @@ export class FilterGroupElement extends HTMLElement {
     return cell;
   }
 
+  // The live field-comparison leaf row (#246): [NOT] [left op right (by-day?)]
+  // [controls]. The reused single-row widget lives in a cached cell so a structural
+  // edit never wipes an in-progress comparison.
+  private renderComparisonRow(
+    node: ComparisonLeaf,
+    path: NodePath,
+    index: number,
+    siblingCount: number,
+  ): HTMLElement {
+    const cell = this.comparisonCells(node);
+    const row = element("div", SLOT_ROW_CLASS);
+    row.dataset.nodeSlot = "";
+    row.dataset.nodeKind = "comparison";
+    row.dataset.path = JSON.stringify(path);
+    row.appendChild(this.negateChip(node, path));
+    row.appendChild(cell);
+    row.appendChild(this.controls(path, false, index, siblingCount));
+    this.applyIncompleteState(row, this.comparisonTouched(node) && !this.comparisonComplete(node));
+    return row;
+  }
+
+  // Build or reuse a comparison leaf's row cell (cached by node id). Clones the
+  // blank field-comparison row template, drops its ✕ (the group's controls own
+  // removal), and wires the left-column change to rebuild its dependent
+  // operator/right-column options via the reused refreshRow.
+  private comparisonCells(node: ComparisonLeaf): HTMLElement {
+    let cell = this.comparisonCache.get(node.id);
+    if (!cell) {
+      cell = this.buildComparisonCell();
+      this.comparisonCache.set(node.id, cell);
+    }
+    return cell;
+  }
+
+  private buildComparisonCell(): HTMLElement {
+    const cell = element("div", VALUE_CELL_CLASS);
+    cell.dataset.valueCell = "";
+    const content = this.comparisonRowTemplate?.content.firstElementChild;
+    if (content) {
+      const row = content.cloneNode(true) as HTMLElement;
+      row.querySelector("[data-fc-remove]")?.remove(); // the group's controls own removal
+      this.uniquify(row);
+      cell.appendChild(row);
+      refreshRow(row, this.columns); // seed operator/right options from the (blank) left
+      row
+        .querySelector<HTMLSelectElement>("[data-fc-left]")
+        ?.addEventListener("change", () => refreshRow(row, this.columns));
+    }
+    return cell;
+  }
+
   // Suffix every id/for/name in a cloned subtree so repeated clones stay valid HTML
   // and label associations point at their own controls (the widgets query their own
   // descendants, so functionality never depended on these being unique).
@@ -566,10 +690,14 @@ export class FilterGroupElement extends HTMLElement {
   // Toggle the row's incomplete badge/fade in place (no re-render → the widget the
   // user is editing keeps focus) and report the new incomplete count.
   private refreshCompleteness(target: HTMLElement): void {
-    const row = target.closest<HTMLElement>('[data-node-slot][data-node-kind="criterion"]');
+    const row = target.closest<HTMLElement>("[data-node-slot]");
     if (row?.dataset.path) {
       const node = this.nodeAtPath(JSON.parse(row.dataset.path) as number[]);
-      if (node?.kind === "criterion") this.applyIncompleteState(row, !this.leafComplete(node));
+      if (node?.kind === "criterion") {
+        this.applyIncompleteState(row, !this.leafComplete(node));
+      } else if (node?.kind === "comparison") {
+        this.applyIncompleteState(row, this.comparisonTouched(node) && !this.comparisonComplete(node));
+      }
     }
     this.dispatchChange();
   }
@@ -678,6 +806,15 @@ export class FilterGroupElement extends HTMLElement {
         title: capReached ? "Max nesting reached" : "Add a relation descent",
       }),
     );
+    // A comparison is a leaf (no nesting), so it is never depth-gated — only shown
+    // when the model admits one (a comparison group with ≥2 columns).
+    if (this.hasComparableGroup) {
+      footer.appendChild(
+        actionButton("add-comparison", "+ comparison", path, {
+          title: "Add a field-to-field comparison",
+        }),
+      );
+    }
     return footer;
   }
 }

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -20,6 +20,7 @@ import { readFilterGroupProps } from "../generated/props.js";
 import { serialize } from "./filter-tree/serializer.js";
 import type {
   ComparisonLeaf,
+  ComparisonPayload,
   Connective,
   CriterionLeaf,
   FilterFieldMeta,
@@ -173,10 +174,12 @@ function actionButton(
   return button;
 }
 
+// Only relation leaves reach the inert slot now (criterion + comparison render live);
+// kept general for the two node kinds that carry a field label.
 function slotLabel(node: FilterNode): string {
-  if (node.kind === "criterion") return node.field ? `condition · ${node.field}` : "condition · (unset)";
   if (node.kind === "relation") return node.field ? `relation · ${node.field}` : "relation · (unset)";
-  return "comparison";
+  if (node.kind === "criterion") return node.field ? `condition · ${node.field}` : "condition · (unset)";
+  return node.kind;
 }
 
 // A leaf's two stateful cells, cached by node id so a structural re-render reuses
@@ -333,11 +336,9 @@ export class FilterGroupElement extends HTMLElement {
 
   // Read a comparison leaf's live row into its {left, right, modifier, granularity?}
   // payload, or null when the row is incomplete. Keyed off the cached row cell.
-  private readComparison(node: ComparisonLeaf): Record<string, unknown> | null {
+  private readComparison(node: ComparisonLeaf): ComparisonPayload | null {
     const cell = this.comparisonCache.get(node.id);
-    const row = cell ? readComparisonRow(cell) : null;
-    // ComparisonRow → the opaque ComparisonPayload the serializer wraps verbatim.
-    return row as Record<string, unknown> | null;
+    return cell ? readComparisonRow(cell) : null;
   }
 
   private comparisonComplete(node: ComparisonLeaf): boolean {

--- a/ts/elements/filter-tree/operations.test.ts
+++ b/ts/elements/filter-tree/operations.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { group } from "./serializer.js";
 import { nextNodeId } from "./node-id.js";
 import { ignoreNodeIds } from "./test-support.js";
-import type { CriterionLeaf, FilterNode, GroupNode } from "./types.js";
+import type { ComparisonLeaf, CriterionLeaf, FilterNode, GroupNode } from "./types.js";
 import type { FilterFieldMeta } from "./types.js";
 
 ignoreNodeIds();
@@ -15,12 +15,14 @@ import {
   criterionForField,
   deepestGroupDepth,
   duplicateAt,
+  emptyComparison,
   emptyCriterion,
   emptyGroup,
   emptyRelation,
   emptyRoot,
   groupDepthAt,
   insertChild,
+  isComparisonComplete,
   isCriterionComplete,
   move,
   nodeAt,
@@ -516,6 +518,30 @@ describe("add-criterion field picker contract (#191)", () => {
       ).toBe(true);
     });
   });
+
+  describe("isComparisonComplete (#246)", () => {
+    const leaf = (comparison: Record<string, unknown>): ComparisonLeaf => ({
+      kind: "comparison",
+      id: "x",
+      comparison,
+      negate: false,
+    });
+
+    it("is incomplete when a column or modifier is missing", () => {
+      expect(isComparisonComplete(emptyComparison())).toBe(false);
+      expect(isComparisonComplete(leaf({ left: "a", modifier: "LESS_THAN" }))).toBe(false);
+      expect(isComparisonComplete(leaf({ left: "a", right: "b" }))).toBe(false);
+      expect(isComparisonComplete(leaf({ left: "", right: "b", modifier: "LESS_THAN" }))).toBe(false);
+    });
+
+    it("is incomplete when the two columns are equal (self-comparison)", () => {
+      expect(isComparisonComplete(leaf({ left: "a", right: "a", modifier: "EQUALS" }))).toBe(false);
+    });
+
+    it("is complete with two distinct columns and a modifier", () => {
+      expect(isComparisonComplete(leaf({ left: "a", right: "b", modifier: "LESS_THAN" }))).toBe(true);
+    });
+  });
 });
 
 describe("leaf payload edits (#192)", () => {
@@ -572,5 +598,16 @@ describe("pruneIncomplete (#192)", () => {
     expect(pruneIncomplete(tree)).toEqual(
       group("AND", [relation("session_filter", group("AND", []))]),
     );
+  });
+
+  it("drops an incomplete comparison leaf, keeps a complete one (#246)", () => {
+    const complete: ComparisonLeaf = {
+      kind: "comparison",
+      id: nextNodeId(),
+      comparison: { left: "a", right: "b", modifier: "LESS_THAN" },
+      negate: false,
+    };
+    const tree = group("AND", [complete, emptyComparison()]);
+    expect(pruneIncomplete(tree)).toEqual(group("AND", [complete]));
   });
 });

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -97,15 +97,11 @@ export function isCriterionComplete(leaf: CriterionLeaf): boolean {
 // compared to itself is meaningless — the row widget never offers it). Mirrors
 // isCriterionComplete: an incomplete comparison is excluded from the count/Apply query
 // (a half-filled field_comparisons entry the backend rejects wholesale — see
-// pruneIncomplete). The payload is opaque to the serializer, so this is the one place
-// its shape (left/right/modifier — see field-comparison-set.ts ComparisonRow) is read.
+// pruneIncomplete). This is the single place the serializer layer reads the payload's
+// shape; `ComparisonPayload` (Partial<ComparisonRow>) makes the field access typo-safe.
 export function isComparisonComplete(leaf: ComparisonLeaf): boolean {
-  const left = leaf.comparison["left"];
-  const right = leaf.comparison["right"];
-  const modifier = leaf.comparison["modifier"];
-  if (typeof left !== "string" || left === "") return false;
-  if (typeof right !== "string" || right === "") return false;
-  if (typeof modifier !== "string" || modifier === "") return false;
+  const { left, right, modifier } = leaf.comparison;
+  if (!left || !right || !modifier) return false;
   return left !== right;
 }
 

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -13,6 +13,7 @@
  * so a group reached at path `P` always sits at group-nesting depth `P.length`.
  */
 import {
+  type ComparisonLeaf,
   type Connective,
   type CriterionLeaf,
   type CriterionPayload,
@@ -89,6 +90,30 @@ export function isCriterionComplete(leaf: CriterionLeaf): boolean {
   if (!isValuePresent(leaf.criterion["value"])) return false;
   if (isRangeModifier(modifier) && !isValuePresent(leaf.criterion["value2"])) return false;
   return true;
+}
+
+// Whether a field-comparison leaf is complete enough to query/apply: it needs a left
+// column, a right column, and a modifier, and the two columns must DIFFER (a column
+// compared to itself is meaningless — the row widget never offers it). Mirrors
+// isCriterionComplete: an incomplete comparison is excluded from the count/Apply query
+// (a half-filled field_comparisons entry the backend rejects wholesale — see
+// pruneIncomplete). The payload is opaque to the serializer, so this is the one place
+// its shape (left/right/modifier — see field-comparison-set.ts ComparisonRow) is read.
+export function isComparisonComplete(leaf: ComparisonLeaf): boolean {
+  const left = leaf.comparison["left"];
+  const right = leaf.comparison["right"];
+  const modifier = leaf.comparison["modifier"];
+  if (typeof left !== "string" || left === "") return false;
+  if (typeof right !== "string" || right === "") return false;
+  if (typeof modifier !== "string" || modifier === "") return false;
+  return left !== right;
+}
+
+// An empty comparison leaf: no columns/modifier chosen. The field-comparison row
+// widget (#246) fills `comparison` with {left, right, modifier, granularity?} read
+// live from its row; until then it is a structurally-incomplete slot.
+export function emptyComparison(): ComparisonLeaf {
+  return { kind: "comparison", id: nextNodeId(), comparison: {}, negate: false };
 }
 
 // An empty relation descent: ANY over an empty child group is the "has ≥1 related
@@ -320,7 +345,7 @@ function pruneNode(node: FilterNode): FilterNode | null {
     case "criterion":
       return isCriterionComplete(node) ? node : null;
     case "comparison":
-      return node; // comparison completeness lands with the field-comparison leaf
+      return isComparisonComplete(node) ? node : null;
     case "relation":
       return { ...node, child: pruneGroup(node.child) };
     case "group": {

--- a/ts/elements/filter-tree/types.ts
+++ b/ts/elements/filter-tree/types.ts
@@ -54,8 +54,23 @@ export interface FilterFieldMeta {
 // Opaque to the serializer: whatever a leaf widget produced. Never inspected.
 export type CriterionPayload = Record<string, unknown>;
 
-// Opaque to the serializer: whatever a field-comparison widget produced.
-export type ComparisonPayload = Record<string, unknown>;
+// The concrete shape one field-comparison row produces (issue #246): two column
+// names + a modifier, plus an optional day-granularity flag (omitted → "raw", so
+// the filter JSON stays compact). Lives here — not the DOM widget module — so the
+// widget, the serializer, and the completeness check share one definition.
+export interface ComparisonRow {
+  left: string;
+  right: string;
+  modifier: ModifierToken;
+  granularity?: "date";
+}
+
+// What a field-comparison leaf carries: a Partial while the user fills it (a fresh
+// leaf is `{}`), a full ComparisonRow once complete. The serializer wraps it
+// verbatim into `field_comparisons: [payload]` and never inspects it;
+// `isComparisonComplete` (operations.ts) is the single place its shape is read, and
+// `Partial<ComparisonRow>` makes that read typo-checked (a renamed field fails tsc).
+export type ComparisonPayload = Partial<ComparisonRow>;
 
 // Every node carries a stable client-only `id` (see node-id.ts): the serializer
 // ignores it (never reaches the wire); <filter-group> reconciles DOM on it so a


### PR DESCRIPTION
Closes #246. Slice 2 of #192 / phase 2c of #168, **PR2 of 2** (stacked on #248).

Makes the builder's `comparison` node a live `[left][op][right]` leaf — the last piece of #192. The serializer already emits/imports `comparison` nodes, so no serializer change.

## What
- **Reuses the single-row widget** from `field-comparison-set.ts`: exported `refreshRow` + a new `readComparisonRow` (extracted from `readFieldComparisonSet`, which now folds it). Embedded in a comparison leaf cell — **no AND/OR mode toggle** (the enclosing group owns the connective) and **no ✕** (the group's controls own removal).
- **operations.ts**: `emptyComparison()` factory, `isComparisonComplete()` (left + right + modifier, `left ≠ right`), and `pruneNode` now drops an incomplete comparison instead of passing it through — a half-filled `field_comparisons` entry (rejected wholesale by the backend) never reaches count/Apply.
- **filter-group.ts**: parse the `columns` prop (from #248); a `+ comparison` footer button gated on a comparable group (≥2 columns of one group); render + read the reused row into the node's opaque payload; cache the row by node id so an in-progress comparison survives structural edits; incomplete cue + `incompleteCount`.
- **filters.py**: `comparison_row_template()` + `has_comparable_group()` helpers; `FilterGroup` emits the blank row `<template>` when the model admits a comparison. `_field_comparison_section` reuses the gate helper.

## Out of scope (own issues)
Import-hydration of a comparison row (needs the builder page, comp 10); malformed-`columns` hardening (#232); cross-model field-to-field (#169); FieldMeta↔TS codegen contract (#247/#240).

## Verification
- `direnv exec . make check` green — mypy + ts-check + **170 vitest** (new `operations.test.ts` completeness/prune + `filter-group.test.ts` DOM cases: add, fill → backend payload, incomplete prune+badge, reconcile-by-id) + full pytest incl. real-Chromium e2e (**1346 passed**).
- **Real-browser end-to-end** on the `/filter-group-demo/` page: `+ comparison` renders a live row, picking `Year Released` rebuilds operators (=, ≠, >, <, ≥, ≤) and filters the right column to the same group, completion clears the badge, and `serializeForQuery()` emits `{AND:[{field_comparisons:[{left:"year_released",right:"original_year_released",modifier:"LESS_THAN"}]}]}`.

## Merge order
Stacked on #248. Merge #248 first, then this retargets to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)