### PR TITLE
refactor(components): share TypedDictClass alias across TS codegen registries (#253)

### DIFF
--- a/common/components/custom_elements.py
+++ b/common/components/custom_elements.py
@@ -10,7 +10,7 @@ reader so drift fails ``tsc``.
 
 import warnings
 from dataclasses import dataclass
-from typing import Literal, NamedTuple, TypedDict, get_type_hints
+from typing import Literal, NamedTuple, TypedDict, get_type_hints, is_typeddict
 
 from common.components.core import (
     BaseComponent,
@@ -37,18 +37,23 @@ from common.components.primitives import (
 )
 
 
+type TypedDictClass = type  # a TypedDict subclass, e.g. FieldMeta
+
+
 @dataclass(frozen=True)
 class ElementSpec:
     tag: str  # e.g. "drop-down"
     ts_name: str  # e.g. "Dropdown"
-    props: type  # a TypedDict subclass
+    props: TypedDictClass
 
 
 ELEMENT_REGISTRY: list[ElementSpec] = []
 
 
-def register_element(tag: str, ts_name: str, props: type) -> None:
+def register_element(tag: str, ts_name: str, props: TypedDictClass) -> None:
     """Register an element so codegen can emit its TS contract."""
+    if not is_typeddict(props):
+        raise TypeError(f"register_element: {props!r} is not a TypedDict")
     ELEMENT_REGISTRY.append(ElementSpec(tag, ts_name, props))
 
 

--- a/common/components/ts_codegen.py
+++ b/common/components/ts_codegen.py
@@ -28,9 +28,8 @@ from typing import (
     is_typeddict,
 )
 
-from common.components.custom_elements import _TYPE_MAP
+from common.components.custom_elements import _TYPE_MAP, TypedDictClass
 
-type TypedDictClass = type  # a TypedDict subclass, e.g. FieldMeta
 type TsName = str  # a TS interface/alias identifier, e.g. "FieldMeta"
 type TsTypeExpr = str  # a rendered TS type expression, e.g. "ChoiceMeta[]"
 

--- a/tests/test_custom_elements.py
+++ b/tests/test_custom_elements.py
@@ -57,6 +57,16 @@ class RegistryTest(unittest.TestCase):
         self.assertEqual(len(ELEMENT_REGISTRY), before + 1)
         self.assertEqual(ELEMENT_REGISTRY[-1].tag, "x-reg-test")
 
+    def test_register_rejects_non_typeddict(self):
+        # The TypedDictClass alias is transparent, so this guard is the only
+        # enforcement that a registered props class is actually a TypedDict.
+        from common.components.custom_elements import ELEMENT_REGISTRY
+
+        before = len(ELEMENT_REGISTRY)
+        with self.assertRaises(TypeError):
+            register_element("x-bad", "XBad", dict)
+        self.assertEqual(len(ELEMENT_REGISTRY), before)  # nothing registered
+
 
 class GameStatusSelectorRenderTest(unittest.TestCase):
     def test_emits_listbox_and_patch_config(self):


### PR DESCRIPTION
Closes #253.

Follow-up from #252 (#247). The element-props codegen documented "props is really a TypedDict" as a repeated inline comment in three places:

- `ts_codegen.py:33` — the `TypedDictClass` alias
- `custom_elements.py:44` — `props: type  # a TypedDict subclass` (ElementSpec)
- `custom_elements.py:50` — `register_element(..., props: type)`

## Changes

- Promote the transparent `type TypedDictClass = type` alias to `custom_elements.py`, respecting the existing `ts_codegen → custom_elements` import arrow (hosting it in `ts_codegen.py` would be a circular import). Shared the same way `_TYPE_MAP` already is.
- Use it at both `ElementSpec.props` and `register_element`; drop the redundant comments.
- Add a fail-loud `is_typeddict` guard to `register_element`, mirroring `render_filter_metadata_module`'s `register_interface` guard.

Intent named once instead of a comment in three places. No runtime or codegen-output change (the alias is transparent).

## Verification

- `make check` green (lint, format-check, mypy, ts-check, vitest, pytest + e2e — 1366 passed).
- Guard fires: `register_element("x", "X", dict)` raises `TypeError: register_element: <class 'dict'> is not a TypedDict`.
- `gen_element_types` produces byte-identical `ts/generated/` output (no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)