### PR TITLE
feat(filters): relation-descent + quantifier picker in the nested builder (#193)

### DIFF
--- a/common/components/custom_elements.py
+++ b/common/components/custom_elements.py
@@ -176,17 +176,16 @@ _FieldComparisonSet = custom_element_builder("field-comparison-set")
 
 
 class FilterGroupProps(TypedDict):
-    # Root model key (e.g. "game"); the deserializer selects its serialization
-    # model from it.
+    # Root model key (e.g. "game"); the deserializer selects its serialization model
+    # from it and the client reads the root bundle as ``models[model]``.
     model: str
-    # JSON of the model's field_metadata() — the leaf row (#192) reads it to build
-    # each criterion's modifier dropdown + value widget client-side. Mirrors the
-    # FieldComparisonSetProps.columns precedent (JSON in a str-typed prop).
-    fields: str
-    # JSON of the model's comparable_columns() — the field-comparison leaf (#246)
-    # reads it to build each comparison row's left/right column pickers client-side.
-    # Same precedent as FieldComparisonSetProps.columns.
-    columns: str
+    # JSON of ``model_field_registry(model)`` — a ``{modelKey: {fields, columns}}``
+    # bundle for every relation-reachable model (#193). One normalized source: the
+    # leaf row (#192) reads ``fields``, the field-comparison leaf (#246) reads
+    # ``columns``, and each relation's child group (#193) reads the *target* model's
+    # bundle. Mirrors the FieldComparisonSetProps.columns precedent (JSON in a str
+    # prop).
+    models: str
 
 
 register_element("filter-group", "FilterGroup", FilterGroupProps)
@@ -200,14 +199,21 @@ def FilterGroup(*, model: str) -> Node:
     group and owns the whole `FilterNode` tree in JS, re-rendering on each
     restructuring op. Behavior + DOM live in ``ts/elements/filter-group.ts``.
 
-    Carries three things the leaf rows need client-side: the model's
-    ``field_metadata`` (as the ``fields`` JSON prop) for criterion leaves (#192),
-    the model's ``comparable_columns`` (as the ``columns`` JSON prop) for the
-    field-comparison leaf (#246), and an **id-less** ``FilterFieldPicker`` in a
-    ``<template>`` the shell clones into each leaf's field cell (id-less so per-leaf
-    clones don't collide; the TS assigns a unique id per clone). The filter class is
-    resolved from ``model`` by convention (``filter_for_model``) — no registry. Media
-    is auto-attached by ``custom_element_builder``."""
+    Carries the whole relation-reachable metadata graph client-side: the ``models``
+    JSON prop (``model_field_registry`` — one ``{fields, columns}`` bundle per model
+    reachable via relations, #193), plus, **per reachable model**, the templates the
+    shell clones when it renders that model's leaves and relation child groups —
+    tagged ``data-model`` so the client buckets them by model:
+
+    - an id-less ``FilterFieldPicker`` in a ``<template data-field-picker-template>``
+      (id-less so per-leaf clones don't collide; the TS assigns a unique id per clone),
+    - one blank value-widget ``<template data-field="name">`` per leaf field (#192),
+    - one blank comparison-row ``<template>`` when the model admits a field comparison
+      (#246).
+
+    The root filter class is resolved from ``model`` by convention
+    (``filter_for_model``) — no registry. Media is auto-attached by
+    ``custom_element_builder``."""
     import json
 
     from django.apps import apps
@@ -219,32 +225,27 @@ def FilterGroup(*, model: str) -> Node:
         has_comparable_group,
     )
     from common.components.primitives import Template
-    from common.criteria import comparable_columns, field_metadata
-    from games.filters import filter_for_model
+    from common.criteria import comparable_columns
+    from games.filters import model_field_registry, reachable_models
 
-    filter_cls = filter_for_model(model)
-    # comparable_columns() enumerates the Django model's columns (not the filter
-    # class); resolve the model the same way filter_for_model does.
-    model_cls = apps.get_model("games", model)
-    columns = comparable_columns(model_cls)
-    # One blank value-widget <template data-field="name"> per leaf field, cloned
-    # into a leaf's value cell on field-pick, plus the field-picker combobox
-    # template cloned into every leaf's field cell (id-less → the TS assigns a
-    # unique id per clone), plus — when the model admits a field comparison — one
-    # blank comparison-row <template> cloned into every comparison leaf (#246).
-    widget_templates = list(field_widget_templates(filter_cls).values())
-    comparison_template: list[Node] = (
-        [comparison_row_template(columns)] if has_comparable_group(columns) else []
-    )
+    templates: list[Node] = []
+    for model_key, filter_cls in reachable_models(model).items():
+        # comparable_columns() enumerates the Django model's columns (not the filter
+        # class); resolve the model the same way filter_for_model does.
+        columns = comparable_columns(apps.get_model("games", model_key))
+        templates.append(
+            Template({"data-model": model_key}, data_field_picker_template="")[
+                FilterFieldPicker(filter_cls)
+            ]
+        )
+        templates.extend(field_widget_templates(filter_cls, model=model_key).values())
+        if has_comparable_group(columns):
+            templates.append(comparison_row_template(columns, model=model_key))
+
     return _FilterGroup(
         model=model,
-        fields=json.dumps(field_metadata(filter_cls)),
-        columns=json.dumps(columns),
-    )[
-        Template(data_field_picker_template="")[FilterFieldPicker(filter_cls)],
-        *widget_templates,
-        *comparison_template,
-    ]
+        models=json.dumps(model_field_registry(model)),
+    )[*templates]
 
 
 # The <sort-header> builder lives in primitives.py (next to StyledTable, which

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -629,8 +629,8 @@ def field_widget_templates(
 
 def _model_attr(model: str) -> dict[str, str]:
     """A dynamic ``data-model`` attribute (positional slot) for a template, or nothing
-    when ``model`` is empty — so single-model flat callers stay byte-for-byte
-    unchanged (#193)."""
+    when ``model`` is empty — so single-model flat callers render no ``data-model`` and
+    their output is unchanged (#193)."""
     return {"data-model": model} if model else {}
 
 

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -611,16 +611,27 @@ def field_widget(
 
 def field_widget_templates(
     filter_cls: type[OperatorFilter],
+    *,
+    model: str = "",
 ) -> dict[AttrName, Node]:
     """One blank value-widget ``<template>`` per non-relation leaf field, keyed by
-    field name — what ``<filter-group>`` (#192) embeds and clones on field-pick."""
+    field name — what ``<filter-group>`` (#192) embeds and clones on field-pick. When
+    ``model`` is given, each template is tagged ``data-model`` so the multi-model
+    builder (#193) can bucket templates by the model whose child group they belong to."""
     return {
-        meta["name"]: Template(data_field=meta["name"])[
+        meta["name"]: Template(_model_attr(model), data_field=meta["name"])[
             field_widget(filter_cls, meta["name"])
         ]
         for meta in field_metadata(filter_cls)
         if meta["kind"] != "relation"
     }
+
+
+def _model_attr(model: str) -> dict[str, str]:
+    """A dynamic ``data-model`` attribute (positional slot) for a template, or nothing
+    when ``model`` is empty — so single-model flat callers stay byte-for-byte
+    unchanged (#193)."""
+    return {"data-model": model} if model else {}
 
 
 _FILTER_FORM_ID = "filter-bar-form"
@@ -894,17 +905,20 @@ def FieldComparisonSet(
     ]
 
 
-def comparison_row_template(columns: list[ComparableColumn]) -> Node:
+def comparison_row_template(
+    columns: list[ComparableColumn], *, model: str = ""
+) -> Node:
     """A blank field-comparison ``<template>`` for the nested builder (#246).
 
     The nested builder (``<filter-group>``) clones this into each comparison leaf's
     value cell, reusing the single-row widget — the *same* ``_field_comparison_row``
     markup ``FieldComparisonSet`` uses, minus the set container and its AND/OR mode
     toggle (the enclosing group owns the connective now). The row's own ``✕`` remove
-    button is dropped client-side; the group's controls own removal."""
+    button is dropped client-side; the group's controls own removal. ``model`` tags the
+    template ``data-model`` so the multi-model builder (#193) buckets it by model."""
     from games.forms import SELECT_CLASS
 
-    return Template(data_fc_row_template="")[
+    return Template(data_fc_row_template="", **_model_attr(model))[
         _field_comparison_row(columns, None, SELECT_CLASS)
     ]
 

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -1745,6 +1745,7 @@ def comparable_columns(model: type[models.Model]) -> list[ComparableColumn]:
 
 type FieldMetaKind = LeafWidgetKind | Literal["relation"]
 type ModelName = str  # a Django model class name, e.g. "Session"
+type ModelKey = str  # a Django model _meta.model_name, e.g. "session"
 type FilterClassName = str  # an OperatorFilter subclass name, e.g. "SessionFilter"
 type ModifierToken = str  # a Modifier value, e.g. "EQUALS"
 
@@ -1792,6 +1793,16 @@ class FieldMeta(TypedDict):
     # from the resolved model field, not stored on ``FilterField``.
     search_url: str
     is_m2m: bool
+
+
+class ModelFieldBundle(TypedDict):
+    """One model's client-side filter metadata: its leaf/relation ``field_metadata``
+    plus its ``comparable_columns``. The nested builder (#193) carries one bundle per
+    relation-reachable model so a relation's child group renders offline from the
+    target model's fields — see ``games.filters.model_field_registry``."""
+
+    fields: list[FieldMeta]
+    columns: list[ComparableColumn]
 
 
 def _resolve_model_field(

--- a/games/filters.py
+++ b/games/filters.py
@@ -36,13 +36,17 @@ from common.criteria import (
     FloatCriterion,
     IntCriterion,
     Modifier,
+    ModelFieldBundle,
+    ModelKey,
     MultiCriterion,
     OperatorFilter,
     StringCriterion,
     aggregate_to_q,
     bool_isnull_handler,
     bool_nonzero_duration_handler,
+    comparable_columns,
     duration_hours_handler,
+    field_metadata,
     filter_from_json,
     filter_to_json,
     relation_to_q,
@@ -766,6 +770,46 @@ def filter_for_model(model_name: str) -> type[OperatorFilter]:
 
     model = apps.get_model("games", model_name)
     return globals()[f"{model.__name__}Filter"]
+
+
+def reachable_models(root_model: str) -> dict[ModelKey, type[OperatorFilter]]:
+    """The closed set of models reachable from ``root_model`` via relation descents,
+    each mapped to its ``OperatorFilter`` subclass (BFS over ``field_metadata``'s
+    relation entries). Relation fields cycle (game↔session, game↔purchase, …), so the
+    result covers every model the nested builder can descend into from the root — the
+    metadata the client needs to render any child group offline (#193)."""
+    from collections import deque
+
+    result: dict[ModelKey, type[OperatorFilter]] = {}
+    queue: deque[ModelKey] = deque([root_model])
+    while queue:
+        key = queue.popleft()
+        if key in result:
+            continue
+        filter_cls = filter_for_model(key)
+        result[key] = filter_cls
+        for meta in field_metadata(filter_cls):
+            for relation in meta["relations"]:
+                target_key = relation["model"].lower()
+                if target_key not in result:
+                    queue.append(target_key)
+    return result
+
+
+def model_field_registry(root_model: str) -> dict[ModelKey, ModelFieldBundle]:
+    """Per-model ``{fields, columns}`` bundles for every model reachable from
+    ``root_model`` (#193). Serialized as ``<filter-group>``'s ``models`` prop; the
+    client keys off it to render each relation's child group from the target model's
+    own field metadata and comparison columns."""
+    from django.apps import apps
+
+    return {
+        key: ModelFieldBundle(
+            fields=field_metadata(filter_cls),
+            columns=comparable_columns(apps.get_model("games", key)),
+        )
+        for key, filter_cls in reachable_models(root_model).items()
+    }
 
 
 # ── URL building (the "reverse() for filters") ─────────────────────────────

--- a/games/filters.py
+++ b/games/filters.py
@@ -757,7 +757,7 @@ def parse_playevent_filter(json_str: str) -> PlayEventFilter | None:
 # ── Model-key → filter-class resolution ────────────────────────────────────
 
 
-def filter_for_model(model_name: str) -> type[OperatorFilter]:
+def filter_for_model(model_name: ModelKey) -> type[OperatorFilter]:
     """Resolve a model key (e.g. ``"game"``) to its ``OperatorFilter`` subclass by
     naming convention — no registry to maintain.
 
@@ -772,7 +772,7 @@ def filter_for_model(model_name: str) -> type[OperatorFilter]:
     return globals()[f"{model.__name__}Filter"]
 
 
-def reachable_models(root_model: str) -> dict[ModelKey, type[OperatorFilter]]:
+def reachable_models(root_model: ModelKey) -> dict[ModelKey, type[OperatorFilter]]:
     """The closed set of models reachable from ``root_model`` via relation descents,
     each mapped to its ``OperatorFilter`` subclass (BFS over ``field_metadata``'s
     relation entries). Relation fields cycle (game↔session, game↔purchase, …), so the
@@ -796,7 +796,7 @@ def reachable_models(root_model: str) -> dict[ModelKey, type[OperatorFilter]]:
     return result
 
 
-def model_field_registry(root_model: str) -> dict[ModelKey, ModelFieldBundle]:
+def model_field_registry(root_model: ModelKey) -> dict[ModelKey, ModelFieldBundle]:
     """Per-model ``{fields, columns}`` bundles for every model reachable from
     ``root_model`` (#193). Serialized as ``<filter-group>``'s ``models`` prop; the
     client keys off it to render each relation's child group from the target model's

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -803,18 +803,69 @@ class HasComparableGroupTest(TestCase):
         self.assertTrue(has_comparable_group(columns))
 
 
-class FilterGroupComparisonTest(TestCase):
-    """The nested-builder shell (#246): the `columns` prop + the blank
-    comparison-row `<template>` it emits for the field-comparison leaf."""
+class ReachableModelsTest(TestCase):
+    """The relation-reachable model set the nested builder needs to render any
+    relation's child group offline (#193)."""
 
-    def test_columns_prop_carries_comparable_columns(self):
+    def test_reachable_models_is_the_closed_relation_set(self):
+        from games.filters import reachable_models
+
+        self.assertEqual(
+            set(reachable_models("game")),
+            {"game", "session", "purchase", "playevent", "platform", "device"},
+        )
+
+    def test_reachable_models_maps_keys_to_filter_classes(self):
+        from games.filters import GameFilter, SessionFilter, reachable_models
+
+        models = reachable_models("game")
+        self.assertIs(models["game"], GameFilter)
+        self.assertIs(models["session"], SessionFilter)
+
+    def test_registry_bundles_fields_and_columns_per_model(self):
+        from games.filters import model_field_registry
+
+        registry = model_field_registry("game")
+        self.assertEqual(
+            set(registry),
+            {"game", "session", "purchase", "playevent", "platform", "device"},
+        )
+        session = registry["session"]
+        self.assertIn("fields", session)
+        self.assertIn("columns", session)
+        # Session's datetime pair reaches the comparison columns.
+        column_names = {column["value"] for column in session["columns"]}
+        self.assertLessEqual({"timestamp_start", "timestamp_end"}, column_names)
+        # The relation entries are discoverable in the field metadata (game→session).
+        game_relations = {
+            relation["field"]
+            for meta in registry["game"]["fields"]
+            if meta["kind"] == "relation"
+            for relation in meta["relations"]
+        }
+        self.assertIn("session_filter", game_relations)
+
+
+class FilterGroupComparisonTest(TestCase):
+    """The nested-builder shell (#246, #193): the multi-model `models` prop + the
+    per-model, namespaced templates it emits for the leaf and relation rows."""
+
+    def test_models_prop_carries_every_reachable_model(self):
         from common.components import FilterGroup
 
-        html = str(FilterGroup(model="session"))
-        self.assertIn("columns=", html)
-        # Session's datetime pair — the issue's driving use case.
+        html = str(FilterGroup(model="game"))
+        self.assertIn("models=", html)
+        # Session's datetime pair — the field-comparison driving use case — reaches
+        # the child-model bundle even though the root is game.
         self.assertIn("timestamp_start", html)
         self.assertIn("timestamp_end", html)
+
+    def test_emits_model_namespaced_templates_for_each_reachable_model(self):
+        from common.components import FilterGroup
+
+        html = str(FilterGroup(model="game"))
+        for key in ("game", "session", "purchase", "playevent", "platform", "device"):
+            self.assertIn(f'data-model="{key}"', html)
 
     def test_emits_comparison_row_template_when_model_has_comparable_group(self):
         from common.components import FilterGroup

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -845,6 +845,35 @@ class ReachableModelsTest(TestCase):
         }
         self.assertIn("session_filter", game_relations)
 
+    def test_reachable_set_is_the_same_from_any_root(self):
+        """The relation graph is strongly connected, so the builder reaches the whole
+        model set regardless of which list it is opened from (game/session/…)."""
+        from games.filters import reachable_models
+
+        full = {"game", "session", "purchase", "playevent", "platform", "device"}
+        for root in full:
+            self.assertEqual(set(reachable_models(root)), full, f"root={root}")
+
+    def test_registry_covers_every_reachable_model_and_relation_target(self):
+        """The server invariant the client's bundle() fallback relies on: every
+        reachable model has a bundle, and every relation target named in any bundle is
+        itself a registry key — so a relation descent never lands on a missing model
+        (which the client would otherwise silently paper over with the root bundle)."""
+        from games.filters import model_field_registry, reachable_models
+
+        for root in ["game", "session", "purchase", "playevent", "platform", "device"]:
+            registry = model_field_registry(root)
+            self.assertEqual(set(registry), set(reachable_models(root)), f"root={root}")
+            for key, bundle in registry.items():
+                for meta in bundle["fields"]:
+                    for relation in meta["relations"]:
+                        self.assertIn(
+                            relation["model"].lower(),
+                            registry,
+                            f"root={root}: relation target {relation['model']!r} "
+                            f"(from {key}.{meta['name']}) missing from registry",
+                        )
+
 
 class FilterGroupComparisonTest(TestCase):
     """The nested-builder shell (#246, #193): the multi-model `models` prop + the

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -3,21 +3,49 @@ import { describe, it, expect } from "vitest";
 import "./filter-group.js"; // side-effect: customElements.define("filter-group", …)
 import type { FilterGroupElement } from "./filter-group.js";
 
+// A node path: group-child indices plus the "child" sentinel for descending into a
+// relation's child group (RELATION_CHILD, #193).
+type Path = (number | string)[];
+
+// One relation-descent field on the game model, pointing at the session model. Gives
+// the base `mount()` a model with a relation so the `+ relation` affordance shows.
+const SESSION_RELATION = {
+  name: "session_filter",
+  label: "Sessions",
+  kind: "relation",
+  nullable: false,
+  choices: [],
+  modifiers: [],
+  relations: [{ field: "session_filter", filter: "SessionFilter", model: "Session" }],
+  search_url: "",
+  is_m2m: false,
+};
+
+// The minimal multi-model `models` prop for the structural (chrome) tests: game has a
+// relation into session; session is present (empty) so the descent resolves.
+const MODELS_BASE = {
+  game: { fields: [SESSION_RELATION], columns: [] },
+  session: { fields: [], columns: [] },
+};
+
 function mount(): FilterGroupElement {
   document.body.replaceChildren();
   const host = document.createElement("filter-group") as FilterGroupElement;
   host.setAttribute("model", "game");
+  host.setAttribute("models", JSON.stringify(MODELS_BASE));
   document.body.appendChild(host); // connectedCallback → initial render
   return host;
 }
 
-function button(host: HTMLElement, action: string, path: number[]): HTMLButtonElement | null {
+// Single-quote the data-path attribute value: JSON.stringify uses double quotes
+// internally (e.g. the "child" sentinel), so a single-quoted CSS value stays valid.
+function button(host: HTMLElement, action: string, path: Path): HTMLButtonElement | null {
   return host.querySelector<HTMLButtonElement>(
-    `button[data-action="${action}"][data-path="${JSON.stringify(path)}"]`,
+    `button[data-action="${action}"][data-path='${JSON.stringify(path)}']`,
   );
 }
 
-function clickAction(host: HTMLElement, action: string, path: number[]): void {
+function clickAction(host: HTMLElement, action: string, path: Path): void {
   const target = button(host, action, path);
   if (!target) throw new Error(`no ${action} button at ${JSON.stringify(path)}`);
   target.click();
@@ -130,12 +158,118 @@ describe("<filter-group> change event", () => {
   });
 });
 
-describe("<filter-group> relation slot (inert, comp 5)", () => {
-  it("relation slots carry data-path and data-node-kind", () => {
-    const host = mount();
-    clickAction(host, "add-relation", []); // [0]=criterion, [1]=relation
-    const relationSlot = slots(host).find((slot) => slot.dataset.nodeKind === "relation")!;
-    expect(relationSlot.dataset.path).toBe(JSON.stringify([1]));
+// ── Relation-descent block (component 5, #193) ──
+// game → session relation + a session `name` field, with field-picker + widget
+// templates for both models (namespaced by data-model) so the child group can be
+// driven live in jsdom.
+function mountRelation(): FilterGroupElement {
+  document.body.replaceChildren();
+  const host = document.createElement("filter-group") as FilterGroupElement;
+  host.setAttribute("model", "game");
+  host.setAttribute(
+    "models",
+    JSON.stringify({
+      game: { fields: [SESSION_RELATION], columns: [] },
+      session: { fields: [NAME_META], columns: [] },
+    }),
+  );
+  host.innerHTML = `
+    <template data-model="game" data-field-picker-template>
+      <div data-field-picker><search-select name="field-picker"><input data-search-select-search /></search-select></div>
+    </template>
+    <template data-model="session" data-field-picker-template>
+      <div data-field-picker><search-select name="field-picker"><input data-search-select-search /></search-select></div>
+    </template>
+    <template data-model="session" data-field="name">
+      <div class="flex-col">
+        <select data-string-modifier-select>
+          <option value="EQUALS" selected>is</option>
+          <option value="INCLUDES">includes</option>
+        </select>
+        <input type="text" />
+      </div>
+    </template>`;
+  document.body.appendChild(host);
+  return host;
+}
+
+function relationSelect(host: HTMLElement, path: Path, hook: string): HTMLSelectElement {
+  return host.querySelector<HTMLSelectElement>(
+    `[data-node-slot][data-path='${JSON.stringify(path)}'] [${hook}]`,
+  )!;
+}
+
+function pickRelation(host: HTMLElement, path: Path, field: string): void {
+  const select = relationSelect(host, path, "data-relation-field");
+  select.value = field;
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+describe("<filter-group> relation descent (component 5, #193)", () => {
+  it("+ relation adds a live accent block with quantifier + relation pickers", () => {
+    const host = mountRelation();
+    clickAction(host, "add-relation", []); // [0]=seed criterion, [1]=relation
+    const card = slots(host).find((slot) => slot.dataset.nodeKind === "relation")!;
+    expect(card.dataset.path).toBe(JSON.stringify([1]));
+    expect(card.querySelector("[data-relation-match]")).not.toBeNull();
+    expect(card.querySelector("[data-relation-field]")).not.toBeNull();
+    // Unset field → incomplete until a relation is chosen.
+    expect(card.querySelector("[data-incomplete-badge]")).not.toBeNull();
+  });
+
+  it("the quantifier picker lists ANY/NONE/ALL and defaults to ANY", () => {
+    const host = mountRelation();
+    clickAction(host, "add-relation", []);
+    const match = relationSelect(host, [1], "data-relation-match");
+    expect([...match.options].map((option) => option.value)).toEqual(["ANY", "NONE", "ALL"]);
+    expect(match.value).toBe("ANY");
+  });
+
+  it("picking a relation opens a child group built from the target model", () => {
+    const host = mountRelation();
+    clickAction(host, "add-relation", []);
+    pickRelation(host, [1], "session_filter");
+    // The child group is addressable at [1,"child"] and offers its own footer.
+    expect(host.querySelector(`[data-kind="group"][data-path='${JSON.stringify([1, "child"])}']`)).not.toBeNull();
+    expect(button(host, "add-condition", [1, "child"])).not.toBeNull();
+    // No longer incomplete once a relation is chosen (empty child = presence test).
+    const card = slots(host).find((slot) => slot.dataset.nodeKind === "relation")!;
+    expect(card.querySelector("[data-incomplete-badge]")).toBeNull();
+  });
+
+  it("serializeForQuery emits {relation:{match, …child}} with a live child leaf", () => {
+    const host = mountRelation();
+    clickAction(host, "add-relation", []);
+    pickRelation(host, [1], "session_filter");
+    relationSelect(host, [1], "data-relation-match").value = "ALL";
+    relationSelect(host, [1], "data-relation-match").dispatchEvent(new Event("change", { bubbles: true }));
+    clickAction(host, "add-condition", [1, "child"]); // child criterion at [1,"child",0]
+    pickField(host, [1, "child", 0], NAME_META); // session's `name` field
+    typeValue(host, [1, "child", 0], "Hades");
+    expect(host.serializeForQuery()).toEqual({
+      AND: [
+        {
+          session_filter: {
+            match: "ALL",
+            AND: [{ name: { value: "Hades", modifier: "EQUALS" } }],
+          },
+        },
+      ],
+    });
+  });
+
+  it("an unset relation is pruned from the query (never serializes to {\"\":…})", () => {
+    const host = mountRelation();
+    clickAction(host, "add-relation", []); // field still unset
+    expect(host.serializeForQuery()).toEqual({}); // seed criterion + unset relation both pruned
+  });
+
+  it("does not offer + relation for a model with no relations", () => {
+    const host = mountRelation();
+    clickAction(host, "add-relation", []);
+    pickRelation(host, [1], "session_filter");
+    // session has no relation fields here → its child group shows no + relation.
+    expect(button(host, "add-relation", [1, "child"])).toBeNull();
   });
 });
 
@@ -274,13 +408,14 @@ function mountLive(): FilterGroupElement {
   document.body.replaceChildren();
   const host = document.createElement("filter-group") as FilterGroupElement;
   host.setAttribute("model", "game");
-  host.setAttribute("fields", JSON.stringify([NAME_META]));
-  // Templates must exist before connectedCallback (captureTemplates runs there).
+  host.setAttribute("models", JSON.stringify({ game: { fields: [NAME_META], columns: [] } }));
+  // Templates must exist before connectedCallback (captureTemplates runs there),
+  // tagged data-model so the multi-model builder buckets them (#193).
   host.innerHTML = `
-    <template data-field-picker-template>
+    <template data-model="game" data-field-picker-template>
       <div data-field-picker><search-select name="field-picker"><input data-search-select-search /></search-select></div>
     </template>
-    <template data-field="name">
+    <template data-model="game" data-field="name">
       <div class="flex-col">
         <select data-string-modifier-select>
           <option value="EQUALS" selected>is</option>
@@ -294,13 +429,13 @@ function mountLive(): FilterGroupElement {
   return host;
 }
 
-function row(host: HTMLElement, path: number[]): HTMLElement {
+function row(host: HTMLElement, path: Path): HTMLElement {
   return host.querySelector<HTMLElement>(
-    `[data-node-slot][data-path="${JSON.stringify(path)}"]`,
+    `[data-node-slot][data-path='${JSON.stringify(path)}']`,
   )!;
 }
 
-function pickField(host: HTMLElement, path: number[], meta: object): void {
+function pickField(host: HTMLElement, path: Path, meta: object): void {
   const picker = row(host, path).querySelector<HTMLElement>("[data-field-picker]")!;
   picker.dispatchEvent(
     new CustomEvent("search-select:change", {
@@ -310,7 +445,7 @@ function pickField(host: HTMLElement, path: number[], meta: object): void {
   );
 }
 
-function typeValue(host: HTMLElement, path: number[], text: string): void {
+function typeValue(host: HTMLElement, path: Path, text: string): void {
   const input = row(host, path).querySelector<HTMLInputElement>('[data-value-cell] input[type="text"]')!;
   input.value = text;
   input.dispatchEvent(new Event("input", { bubbles: true }));
@@ -379,10 +514,9 @@ function mountComparison(): FilterGroupElement {
   document.body.replaceChildren();
   const host = document.createElement("filter-group") as FilterGroupElement;
   host.setAttribute("model", "game");
-  host.setAttribute("fields", JSON.stringify([]));
-  host.setAttribute("columns", JSON.stringify(COLUMNS));
+  host.setAttribute("models", JSON.stringify({ game: { fields: [], columns: COLUMNS } }));
   host.innerHTML = `
-    <template data-fc-row-template>
+    <template data-model="game" data-fc-row-template>
       <div data-fc-row>
         <select data-fc-left>
           <option value="">column…</option>
@@ -401,7 +535,7 @@ function mountComparison(): FilterGroupElement {
   return host;
 }
 
-function setSelect(host: HTMLElement, path: number[], hook: string, value: string): void {
+function setSelect(host: HTMLElement, path: Path, hook: string, value: string): void {
   const select = row(host, path).querySelector<HTMLSelectElement>(`[data-value-cell] [${hook}]`)!;
   select.value = value;
   select.dispatchEvent(new Event("change", { bubbles: true }));

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -264,6 +264,37 @@ describe("<filter-group> relation descent (component 5, #193)", () => {
     expect(host.serializeForQuery()).toEqual({}); // seed criterion + unset relation both pruned
   });
 
+  it("NOT on the relation wraps the whole descent, keeping the live child leaf", () => {
+    const host = mountRelation();
+    clickAction(host, "add-relation", []);
+    pickRelation(host, [1], "session_filter");
+    clickAction(host, "toggle-negate", [1]); // negate the relation node
+    clickAction(host, "add-condition", [1, "child"]);
+    pickField(host, [1, "child", 0], NAME_META);
+    typeValue(host, [1, "child", 0], "Hades");
+    expect(host.serializeForQuery()).toEqual({
+      AND: [
+        { NOT: [{ session_filter: { AND: [{ name: { value: "Hades", modifier: "EQUALS" } }] } }] },
+      ],
+    });
+  });
+
+  it("counts a field-set/value-empty child leaf as incomplete under the target model", () => {
+    const host = mountRelation();
+    let last = -1;
+    host.addEventListener("filter-tree-change", (event) => {
+      last = (event as CustomEvent).detail.incompleteCount;
+    });
+    clickAction(host, "add-relation", []);
+    clickAction(host, "remove", [0]); // drop the seed criterion so only the relation counts
+    pickRelation(host, [0], "session_filter"); // relation complete (field set)
+    clickAction(host, "add-condition", [0, "child"]);
+    pickField(host, [0, "child", 0], NAME_META); // session `name` chosen, value still empty
+    expect(last).toBe(1); // the child leaf is incomplete, resolved against the session bundle
+    typeValue(host, [0, "child", 0], "Hades");
+    expect(last).toBe(0);
+  });
+
   it("does not offer + relation for a model with no relations", () => {
     const host = mountRelation();
     clickAction(host, "add-relation", []);

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -27,9 +27,12 @@ import type {
   FilterNode,
   FilterTreeChangeDetail,
   GroupNode,
+  RelationMatch,
+  RelationNode,
 } from "./filter-tree/types.js";
 import {
   type NodePath,
+  RELATION_CHILD,
   canAddGroup,
   canAddRelation,
   canUnwrap,
@@ -49,6 +52,8 @@ import {
   pruneIncomplete,
   removeAt,
   setLeafField,
+  setMatch,
+  setRelationField,
   toggleConnective,
   toggleNegate,
   unwrapGroup,
@@ -80,6 +85,9 @@ const FOOTER_CLASS = "flex flex-wrap gap-2";
 // chip on a group with nothing to negate or join (issue #236).
 const EMPTY_STATE_CLASS = "px-2 py-1 text-sm text-gray-500 dark:text-gray-400";
 const EMPTY_STATE_TEXT = "No conditions. This will match all items.";
+// Shown for an empty relation child group: an empty child is the presence test
+// (ANY = has ≥1 related row, NONE = has none) rather than an error (#193).
+const RELATION_EMPTY_TEXT = "No conditions — matches on the related row's existence.";
 const SLOT_ROW_CLASS = "flex items-center gap-2 flex-wrap";
 const FIELD_CELL_CLASS = "min-w-[12rem]";
 const VALUE_CELL_CLASS = "flex-1 min-w-[12rem]";
@@ -120,6 +128,18 @@ const NEGATE_ON_CLASS =
 const BUTTON_CLASS =
   "rounded border border-gray-200 px-2 py-1 text-xs hover:bg-gray-100 disabled:cursor-not-allowed " +
   "disabled:opacity-50 dark:border-gray-700 dark:hover:bg-gray-700";
+// Relation-descent accent block (component 5, #193): a left-accented indigo card set
+// apart from the gray group chrome so the Game→Session model switch reads explicitly
+// (Filter-Forge ↳ INTO). Header carries the `↳ [quantifier] of [relation] where` row.
+const RELATION_CARD_CLASS =
+  "flex flex-col gap-2 rounded-lg border border-l-4 border-indigo-200 border-l-indigo-400 " +
+  "bg-indigo-50/50 p-2 dark:border-indigo-500/40 dark:border-l-indigo-500/70 dark:bg-indigo-500/10";
+const RELATION_HEADER_CLASS = "flex items-center gap-2 flex-wrap";
+const RELATION_ARROW_CLASS = "text-indigo-500 dark:text-indigo-300 font-semibold";
+const RELATION_LABEL_CLASS = "text-sm text-gray-600 dark:text-gray-300";
+const RELATION_SELECT_CLASS =
+  "rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-800 " +
+  "disabled:opacity-50 disabled:cursor-not-allowed";
 
 // The closed set of restructuring actions a button can carry; producer
 // (actionButton) and consumer (applyAction's switch) share it so a typo on either
@@ -143,6 +163,16 @@ export const FILTER_TREE_CHANGE_EVENT = "filter-tree-change";
 
 function depthBackground(depth: number): string {
   return DEPTH_BACKGROUNDS[depth % DEPTH_BACKGROUNDS.length];
+}
+
+// A comparison needs two columns of the SAME comparison group; a model admits one
+// only when some group has ≥2 columns. Mirrors the server's has_comparable_group.
+function hasComparableGroup(columns: Column[]): boolean {
+  const groupCounts = new Map<string, number>();
+  for (const column of columns) {
+    groupCounts.set(column.group, (groupCounts.get(column.group) ?? 0) + 1);
+  }
+  return [...groupCounts.values()].some((count) => count >= 2);
 }
 
 function element<K extends keyof HTMLElementTagNameMap>(
@@ -174,14 +204,6 @@ function actionButton(
   return button;
 }
 
-// Only relation leaves reach the inert slot now (criterion + comparison render live);
-// kept general for the two node kinds that carry a field label.
-function slotLabel(node: FilterNode): string {
-  if (node.kind === "relation") return node.field ? `relation · ${node.field}` : "relation · (unset)";
-  if (node.kind === "criterion") return node.field ? `condition · ${node.field}` : "condition · (unset)";
-  return node.kind;
-}
-
 // A leaf's two stateful cells, cached by node id so a structural re-render reuses
 // (re-appends) them — the live value widget's DOM state survives edits elsewhere.
 interface LeafCells {
@@ -194,25 +216,47 @@ interface SearchSelectLike extends HTMLElement {
   setSelected(value: string, label?: string): void;
 }
 
+// One relation-descent option for the relation picker (#193): the sub-filter field
+// name + its human label. Derived from a model's `kind === "relation"` FieldMeta.
+interface RelationOption {
+  field: string;
+  label: string;
+}
+
+// One model's client-side filter metadata + templates. The builder carries a bundle
+// per relation-reachable model (#193) so a relation's child group renders from the
+// TARGET model's fields/columns/templates, never the root's.
+interface ModelBundle {
+  fields: Map<string, FilterFieldMeta>;
+  columns: Column[];
+  hasComparableGroup: boolean;
+  relations: RelationOption[];
+  fieldPickerTemplate: HTMLTemplateElement | null;
+  widgetTemplates: Map<string, HTMLTemplateElement>;
+  comparisonRowTemplate: HTMLTemplateElement | null;
+}
+
+// The RelationMatch quantifiers, ordered for the picker. ANY is the default/first.
+const RELATION_MATCHES: RelationMatch[] = ["ANY", "NONE", "ALL"];
+const RELATION_MATCH_LABELS: Record<RelationMatch, string> = {
+  ANY: "any",
+  NONE: "none",
+  ALL: "all",
+};
+
+// The shape of one model's bundle in the `models` prop JSON (mirrors ModelFieldBundle).
+interface ModelFieldBundleJson {
+  fields: FilterFieldMeta[];
+  columns: Column[];
+}
+
 export class FilterGroupElement extends HTMLElement {
   private tree: GroupNode = emptyRoot();
   private model = "";
   private wired = false;
-  // field name -> its FieldMeta (kind, label, modifiers …), from the `fields` prop.
-  private fields = new Map<string, FilterFieldMeta>();
-  // The model's comparable columns (from the `columns` prop), driving each
-  // comparison leaf's row widget (#246). `hasComparableGroup` gates the
-  // `+ comparison` affordance on the same rule as the flat bar (a group with ≥2
-  // columns — otherwise no valid comparison row could be built).
-  private columns: Column[] = [];
-  private hasComparableGroup = false;
-  // The <template> whose content is the field-picker combobox, cloned per leaf.
-  private fieldPickerTemplate: HTMLTemplateElement | null = null;
-  // field name -> its blank value-widget <template>, cloned into a leaf on field-pick.
-  private widgetTemplates = new Map<string, HTMLTemplateElement>();
-  // The <template> whose content is a blank field-comparison row, cloned per
-  // comparison leaf (#246). Absent when the model admits no comparison.
-  private comparisonRowTemplate: HTMLTemplateElement | null = null;
+  // model key -> its metadata + templates bundle (#193). The root model is
+  // `models.get(this.model)`; relation child groups read the target model's bundle.
+  private models = new Map<string, ModelBundle>();
   // node id -> its cached cells (see LeafCells). Pruned to live nodes each render.
   private rowCache = new Map<string, LeafCells>();
   // node id -> a comparison leaf's cached row cell, reused across structural
@@ -225,9 +269,8 @@ export class FilterGroupElement extends HTMLElement {
     const props = readFilterGroupProps(this);
     this.model = props.model;
     if (!this.wired) {
+      this.parseModels(props.models);
       this.captureTemplates();
-      this.parseFields(props.fields);
-      this.parseColumns(props.columns);
       this.addEventListener("click", this.onClick);
       // Value edits (typing, radios, set pills, date bounds, field pick) bubble
       // here; one delegated listener updates completeness / handles field changes.
@@ -243,47 +286,68 @@ export class FilterGroupElement extends HTMLElement {
     this.render();
   }
 
-  // Detach the server-rendered <template>s (field picker + one per field) before
-  // the first render() replaces our children, keeping references to clone from.
-  private captureTemplates(): void {
-    this.fieldPickerTemplate = this.querySelector<HTMLTemplateElement>(
-      "template[data-field-picker-template]",
-    );
-    this.querySelectorAll<HTMLTemplateElement>("template[data-field]").forEach((template) => {
-      const field = template.getAttribute("data-field");
-      if (field) this.widgetTemplates.set(field, template);
-    });
-    this.comparisonRowTemplate = this.querySelector<HTMLTemplateElement>(
-      "template[data-fc-row-template]",
-    );
-  }
-
-  private parseFields(raw: string): void {
-    if (!raw) return;
-    try {
-      const list = JSON.parse(raw) as FilterFieldMeta[];
-      for (const meta of list) this.fields.set(meta.name, meta);
-    } catch {
-      console.warn("filter-group: malformed fields prop");
-    }
-  }
-
-  // Parse the `columns` prop and precompute whether any comparison is possible: a
-  // comparison needs two columns of the SAME group, so a group with ≥2 members.
-  private parseColumns(raw: string): void {
+  // Build one ModelBundle per model in the `models` prop: its field map, comparison
+  // columns (+ whether a comparison is possible), and relation-descent options
+  // (derived from its `kind === "relation"` fields). Templates are attached later by
+  // captureTemplates.
+  private parseModels(raw: string): void {
+    let bundles: Record<string, ModelFieldBundleJson> = {};
     if (raw) {
       try {
-        this.columns = JSON.parse(raw) as Column[];
+        bundles = JSON.parse(raw) as Record<string, ModelFieldBundleJson>;
       } catch {
-        console.warn("filter-group: malformed columns prop");
-        this.columns = [];
+        console.warn("filter-group: malformed models prop");
       }
     }
-    const groupCounts = new Map<string, number>();
-    for (const column of this.columns) {
-      groupCounts.set(column.group, (groupCounts.get(column.group) ?? 0) + 1);
+    for (const [key, bundle] of Object.entries(bundles)) {
+      const fields = new Map<string, FilterFieldMeta>();
+      const relations: RelationOption[] = [];
+      for (const meta of bundle.fields) {
+        fields.set(meta.name, meta);
+        if (meta.kind === "relation") relations.push({ field: meta.name, label: meta.label });
+      }
+      this.models.set(key, {
+        fields,
+        columns: bundle.columns,
+        // A comparison needs two columns of the SAME group, so a group with ≥2 members.
+        hasComparableGroup: hasComparableGroup(bundle.columns),
+        relations,
+        fieldPickerTemplate: null,
+        widgetTemplates: new Map(),
+        comparisonRowTemplate: null,
+      });
     }
-    this.hasComparableGroup = [...groupCounts.values()].some((count) => count >= 2);
+  }
+
+  // Detach the server-rendered <template>s (field picker + one per field + comparison
+  // row) before the first render() replaces our children, bucketing each into its
+  // model's bundle by the template's `data-model` tag (#193).
+  private captureTemplates(): void {
+    this.querySelectorAll<HTMLTemplateElement>("template[data-model]").forEach((template) => {
+      const bundle = this.models.get(template.getAttribute("data-model") ?? "");
+      if (!bundle) return;
+      if (template.hasAttribute("data-field-picker-template")) {
+        bundle.fieldPickerTemplate = template;
+      } else if (template.hasAttribute("data-fc-row-template")) {
+        bundle.comparisonRowTemplate = template;
+      } else {
+        const field = template.getAttribute("data-field");
+        if (field) bundle.widgetTemplates.set(field, template);
+      }
+    });
+  }
+
+  // The bundle for a model key, or the root model's as a defensive fallback so a
+  // stale/unknown key never throws mid-render.
+  private bundle(model: string): ModelBundle | undefined {
+    return this.models.get(model) ?? this.models.get(this.model);
+  }
+
+  // The target model key a relation field descends into, resolved from `model`'s
+  // metadata (RelationTarget.model is a Django model name → lower-cased key).
+  private targetModel(model: string, field: string): string {
+    const target = this.bundle(model)?.fields.get(field)?.relations[0]?.model;
+    return target ? target.toLowerCase() : model;
   }
 
   /** The current node tree — for 2d serialize/count. Do not mutate it: every edit
@@ -304,34 +368,36 @@ export class FilterGroupElement extends HTMLElement {
    *  live widget, then incomplete leaves are pruned (excluded from the count/Apply
    *  query). Used by the builder page (comp 10). */
   serializeForQuery(): Record<string, unknown> {
-    return serialize(pruneIncomplete(this.fillCriteria(this.tree)));
+    return serialize(pruneIncomplete(this.fillCriteria(this.tree, this.model)));
   }
 
   // Clone the tree with every criterion leaf's `criterion` filled from its live
   // value widget (empty {} when the field/widget yields nothing → pruned as
-  // incomplete). Structure/ids are preserved.
-  private fillCriteria(node: GroupNode): GroupNode {
-    return { ...node, children: node.children.map((child) => this.fillNode(child)) };
+  // incomplete). Structure/ids are preserved. `model` is the active model at this
+  // group (switches to the target model inside each relation's child group, #193).
+  private fillCriteria(node: GroupNode, model: string): GroupNode {
+    return { ...node, children: node.children.map((child) => this.fillNode(child, model)) };
   }
 
-  private fillNode(node: FilterNode): FilterNode {
-    if (node.kind === "group") return this.fillCriteria(node);
-    if (node.kind === "criterion") return { ...node, criterion: this.readLeaf(node) ?? {} };
+  private fillNode(node: FilterNode, model: string): FilterNode {
+    if (node.kind === "group") return this.fillCriteria(node, model);
+    if (node.kind === "criterion") return { ...node, criterion: this.readLeaf(node, model) ?? {} };
     if (node.kind === "comparison") return { ...node, comparison: this.readComparison(node) ?? {} };
-    return node; // relation unchanged (its widget is a sibling 2c component)
+    // relation: its child group's leaves are live too — fill them under the target model.
+    return { ...node, child: this.fillCriteria(node.child, this.targetModel(model, node.field)) };
   }
 
   // Read a criterion leaf's live value widget into a payload, or null when it has
   // no usable value (empty field, empty widget). Keyed off the cached value cell.
-  private readLeaf(node: CriterionLeaf): Record<string, unknown> | null {
-    const meta = this.fields.get(node.field);
+  private readLeaf(node: CriterionLeaf, model: string): Record<string, unknown> | null {
+    const meta = this.bundle(model)?.fields.get(node.field);
     const cells = this.rowCache.get(node.id);
     if (!meta || !cells) return null;
     return readLeafWidget(cells.valueCell, meta.kind);
   }
 
-  private leafComplete(node: CriterionLeaf): boolean {
-    return isCriterionComplete({ ...node, criterion: this.readLeaf(node) ?? {} });
+  private leafComplete(node: CriterionLeaf, model: string): boolean {
+    return isCriterionComplete({ ...node, criterion: this.readLeaf(node, model) ?? {} });
   }
 
   // Read a comparison leaf's live row into its {left, right, modifier, granularity?}
@@ -353,12 +419,18 @@ export class FilterGroupElement extends HTMLElement {
     return Boolean(left?.value);
   }
 
-  private incompleteCount(node: GroupNode = this.tree): number {
+  private incompleteCount(node: GroupNode = this.tree, model: string = this.model): number {
     let count = 0;
     for (const child of node.children) {
-      if (child.kind === "group") count += this.incompleteCount(child);
-      else if (child.kind === "criterion" && !this.leafComplete(child)) count += 1;
+      if (child.kind === "group") count += this.incompleteCount(child, model);
+      else if (child.kind === "criterion" && !this.leafComplete(child, model)) count += 1;
       else if (child.kind === "comparison" && !this.comparisonComplete(child)) count += 1;
+      else if (child.kind === "relation") {
+        // A field-unset relation is incomplete (would serialize to `{"": …}`); its
+        // child group's leaves count under the target model.
+        if (child.field === "") count += 1;
+        count += this.incompleteCount(child.child, this.targetModel(model, child.field));
+      }
     }
     return count;
   }
@@ -366,7 +438,7 @@ export class FilterGroupElement extends HTMLElement {
   private onClick = (event: Event): void => {
     const button = (event.target as HTMLElement).closest<HTMLElement>("[data-action]");
     if (!button || button.dataset.action === undefined || button.dataset.path === undefined) return;
-    const path: NodePath = JSON.parse(button.dataset.path) as number[];
+    const path = JSON.parse(button.dataset.path) as NodePath;
     this.applyAction(button.dataset.action as TreeAction, path);
   };
 
@@ -441,7 +513,7 @@ export class FilterGroupElement extends HTMLElement {
   // widget when render() runs and the loss is not observable. Revisit (and build real
   // keyed reconciliation) only if an edit can ever fire while a leaf widget is focused.
   private render(): void {
-    this.replaceChildren(this.renderGroup(this.tree, [], 0, 1));
+    this.replaceChildren(this.renderGroup(this.tree, [], 0, 1, this.model, 0));
     this.pruneRowCache();
   }
 
@@ -451,6 +523,7 @@ export class FilterGroupElement extends HTMLElement {
     const live = new Set<string>();
     const walk = (node: FilterNode): void => {
       if (node.kind === "group") node.children.forEach(walk);
+      else if (node.kind === "relation") walk(node.child); // its child group's leaves stay live
       else live.add(node.id);
     };
     walk(this.tree);
@@ -462,19 +535,32 @@ export class FilterGroupElement extends HTMLElement {
     }
   }
 
-  private renderGroup(node: GroupNode, path: NodePath, index: number, siblingCount: number): HTMLElement {
-    const card = element("div", `${CARD_CLASS} ${depthBackground(path.length)}`);
+  // `model` is the active model at this group; `depth` is the true group-nesting
+  // depth for coloring (path length is no longer a proxy — a relation's child group
+  // is +1 depth but +2 path steps, #193). A relation's child group is rendered here
+  // too but without its own restructuring controls (the relation node owns them).
+  private renderGroup(
+    node: GroupNode,
+    path: NodePath,
+    index: number,
+    siblingCount: number,
+    model: string,
+    depth: number,
+  ): HTMLElement {
+    const isRelationChild = path[path.length - 1] === RELATION_CHILD;
+    const card = element("div", `${CARD_CLASS} ${depthBackground(depth)}`);
     card.dataset.kind = "group";
     card.dataset.path = JSON.stringify(path);
 
-    // Only the root may be empty (non-root groups auto-collapse on their last
-    // child's removal). A header-less "matches all" state keeps an empty group
-    // off the NOT/connective chips it has nothing to apply to (issue #236).
-    if (path.length === 0 && node.children.length === 0) {
+    // The root and every relation child group may sit empty — the root serializes to
+    // {} (matches all), a relation's empty child is the ANY/NONE presence test. A
+    // header-less state keeps an empty group off the NOT/connective chips it has
+    // nothing to apply to (issue #236).
+    if ((path.length === 0 || isRelationChild) && node.children.length === 0) {
       const emptyState = element("div", EMPTY_STATE_CLASS);
-      emptyState.textContent = EMPTY_STATE_TEXT;
+      emptyState.textContent = isRelationChild ? RELATION_EMPTY_TEXT : EMPTY_STATE_TEXT;
       card.appendChild(emptyState);
-      card.appendChild(this.footer(path));
+      card.appendChild(this.footer(path, model));
       return card;
     }
 
@@ -485,44 +571,121 @@ export class FilterGroupElement extends HTMLElement {
     connectiveCluster.appendChild(this.negateChip(node, path));
     connectiveCluster.appendChild(this.connectiveChip(node.connective, path));
     header.appendChild(connectiveCluster);
-    if (path.length > 0) header.appendChild(this.controls(path, true, index, siblingCount));
+    // A relation child group is owned by its relation (not a list sibling), so it
+    // carries no up/down/wrap/unwrap/duplicate/remove — only the relation node does.
+    if (path.length > 0 && !isRelationChild) {
+      header.appendChild(this.controls(path, true, index, siblingCount));
+    }
     card.appendChild(header);
 
     const childrenBox = element("div", CHILDREN_CLASS);
     node.children.forEach((child, childIndex) => {
-      childrenBox.appendChild(this.renderChild(child, [...path, childIndex], childIndex, node.children.length));
+      childrenBox.appendChild(
+        this.renderChild(child, [...path, childIndex], childIndex, node.children.length, model, depth),
+      );
     });
     card.appendChild(childrenBox);
 
-    card.appendChild(this.footer(path));
+    card.appendChild(this.footer(path, model));
     return card;
   }
 
-  private renderChild(child: FilterNode, path: NodePath, index: number, siblingCount: number): HTMLElement {
-    if (child.kind === "group") return this.renderGroup(child, path, index, siblingCount);
-    if (child.kind === "criterion") return this.renderCriterionRow(child, path, index, siblingCount);
-    if (child.kind === "comparison") return this.renderComparisonRow(child, path, index, siblingCount);
-    return this.renderInertSlot(child, path, index, siblingCount);
-  }
-
-  // The relation leaf stays an inert slot (its widget is a sibling 2c component,
-  // out of this slice); the criterion + comparison rows are live below.
-  private renderInertSlot(
+  private renderChild(
     child: FilterNode,
     path: NodePath,
     index: number,
     siblingCount: number,
+    model: string,
+    depth: number,
   ): HTMLElement {
-    const row = element("div", SLOT_ROW_CLASS);
-    const slot = element("div", VALUE_PLACEHOLDER_CLASS);
-    slot.dataset.nodeSlot = "";
-    slot.dataset.nodeKind = child.kind;
-    slot.dataset.path = JSON.stringify(path);
-    slot.textContent = slotLabel(child);
-    row.appendChild(this.negateChip(child, path));
-    row.appendChild(slot);
-    row.appendChild(this.controls(path, false, index, siblingCount));
-    return row;
+    if (child.kind === "group") {
+      return this.renderGroup(child, path, index, siblingCount, model, depth + 1);
+    }
+    if (child.kind === "criterion") return this.renderCriterionRow(child, path, index, siblingCount, model);
+    if (child.kind === "comparison") {
+      return this.renderComparisonRow(child, path, index, siblingCount, model);
+    }
+    return this.renderRelationRow(child, path, index, siblingCount, model, depth);
+  }
+
+  // The relation-descent accent block (component 5, #193):
+  //   [NOT] ↳ [quantifier ▾] of [relation ▾] where …  [controls]
+  //   └ nested child group (built from the TARGET model's fields)
+  // An unset relation field marks the block incomplete (pruned from the query).
+  private renderRelationRow(
+    node: RelationNode,
+    path: NodePath,
+    index: number,
+    siblingCount: number,
+    model: string,
+    depth: number,
+  ): HTMLElement {
+    const card = element("div", RELATION_CARD_CLASS);
+    card.dataset.nodeSlot = "";
+    card.dataset.nodeKind = "relation";
+    card.dataset.path = JSON.stringify(path);
+    card.dataset.model = model;
+
+    const header = element("div", RELATION_HEADER_CLASS);
+    header.appendChild(this.negateChip(node, path));
+    const arrow = element("span", RELATION_ARROW_CLASS);
+    arrow.textContent = "↳";
+    header.appendChild(arrow);
+    header.appendChild(this.relationMatchSelect(node));
+    header.appendChild(this.relationLabel("of"));
+    header.appendChild(this.relationFieldSelect(node, model));
+    header.appendChild(this.relationLabel("where"));
+    header.appendChild(this.controls(path, false, index, siblingCount));
+    card.appendChild(header);
+
+    // The child group is built from the target model; it descends one depth level.
+    const childModel = this.targetModel(model, node.field);
+    card.appendChild(
+      this.renderGroup(node.child, [...path, RELATION_CHILD], 0, 1, childModel, depth + 1),
+    );
+    this.applyIncompleteState(card, node.field === "");
+    return card;
+  }
+
+  private relationLabel(text: string): HTMLElement {
+    const span = element("span", RELATION_LABEL_CLASS);
+    span.textContent = text;
+    return span;
+  }
+
+  // The ANY/NONE/ALL quantifier picker; change dispatches setMatch.
+  private relationMatchSelect(node: RelationNode): HTMLSelectElement {
+    const select = element("select", RELATION_SELECT_CLASS);
+    select.dataset.relationMatch = "";
+    for (const match of RELATION_MATCHES) {
+      const option = element("option");
+      option.value = match;
+      option.textContent = RELATION_MATCH_LABELS[match];
+      option.selected = match === node.match;
+      select.appendChild(option);
+    }
+    return select;
+  }
+
+  // The relation-field picker: the current model's relation options; change
+  // dispatches setRelationField (which resets the child group on a model change).
+  private relationFieldSelect(node: RelationNode, model: string): HTMLSelectElement {
+    const select = element("select", RELATION_SELECT_CLASS);
+    select.dataset.relationField = "";
+    const placeholder = element("option");
+    placeholder.value = "";
+    placeholder.textContent = "a relation…";
+    placeholder.disabled = true;
+    placeholder.selected = node.field === "";
+    select.appendChild(placeholder);
+    for (const relation of this.bundle(model)?.relations ?? []) {
+      const option = element("option");
+      option.value = relation.field;
+      option.textContent = relation.label;
+      option.selected = relation.field === node.field;
+      select.appendChild(option);
+    }
+    return select;
   }
 
   // The live criterion leaf row: [NOT] [field combobox] [value widget] [badge?]
@@ -533,43 +696,50 @@ export class FilterGroupElement extends HTMLElement {
     path: NodePath,
     index: number,
     siblingCount: number,
+    model: string,
   ): HTMLElement {
-    const cells = this.leafCells(node);
+    const cells = this.leafCells(node, model);
     const row = element("div", SLOT_ROW_CLASS);
     row.dataset.nodeSlot = "";
     row.dataset.nodeKind = "criterion";
     row.dataset.path = JSON.stringify(path);
+    row.dataset.model = model;
     row.appendChild(this.negateChip(node, path));
     row.appendChild(cells.fieldCell);
     row.appendChild(cells.valueCell);
     row.appendChild(this.controls(path, false, index, siblingCount));
     // Controls are the row's last child; the badge (if any) is inserted before them.
-    this.applyIncompleteState(row, Boolean(node.field) && !this.leafComplete(node));
+    this.applyIncompleteState(row, Boolean(node.field) && !this.leafComplete(node, model));
     return row;
   }
 
   // Build or reuse a leaf's field + value cells, rebuilding the value cell only when
-  // the field changed (or first set). Cached by node id.
-  private leafCells(node: CriterionLeaf): LeafCells {
+  // the field changed (or first set). Cached by node id. `model` picks the field
+  // picker + value-widget templates from that model's bundle (#193).
+  private leafCells(node: CriterionLeaf, model: string): LeafCells {
     let cells = this.rowCache.get(node.id);
     if (!cells) {
-      cells = { field: "", fieldCell: this.buildFieldCell(), valueCell: this.buildValueCell("") };
+      cells = {
+        field: "",
+        fieldCell: this.buildFieldCell(model),
+        valueCell: this.buildValueCell("", model),
+      };
       this.rowCache.set(node.id, cells);
     }
     if (cells.field !== node.field) {
-      cells.valueCell = this.buildValueCell(node.field);
+      cells.valueCell = this.buildValueCell(node.field, model);
       cells.field = node.field;
-      if (node.field) this.showFieldSelection(cells.fieldCell, node.field);
+      if (node.field) this.showFieldSelection(cells.fieldCell, node.field, model);
     }
     return cells;
   }
 
   // Clone the field-picker combobox into a cell, with a unique id per leaf so
   // multiple pickers on the page never collide.
-  private buildFieldCell(): HTMLElement {
+  private buildFieldCell(model: string): HTMLElement {
     const cell = element("div", FIELD_CELL_CLASS);
     cell.dataset.fieldCell = "";
-    const content = this.fieldPickerTemplate?.content.firstElementChild;
+    const content = this.bundle(model)?.fieldPickerTemplate?.content.firstElementChild;
     if (content) {
       const clone = content.cloneNode(true) as HTMLElement;
       this.uniquify(clone);
@@ -580,15 +750,15 @@ export class FilterGroupElement extends HTMLElement {
 
   // Reflect an already-chosen field in the cloned combobox (import/rebuild). The
   // search-select's setSelected is silent, so it won't re-fire a field-pick.
-  private showFieldSelection(fieldCell: HTMLElement, field: string): void {
+  private showFieldSelection(fieldCell: HTMLElement, field: string, model: string): void {
     const searchSelect = fieldCell.querySelector<SearchSelectLike>("search-select");
-    const label = this.fields.get(field)?.label ?? field;
+    const label = this.bundle(model)?.fields.get(field)?.label ?? field;
     searchSelect?.setSelected(field, label);
   }
 
   // Build a value cell for `field`: a clone of the field's blank widget template,
   // or a placeholder prompt when no field is chosen yet.
-  private buildValueCell(field: string): HTMLElement {
+  private buildValueCell(field: string, model: string): HTMLElement {
     if (!field) {
       const placeholder = element("div", VALUE_PLACEHOLDER_CLASS);
       placeholder.dataset.valueCell = "";
@@ -597,7 +767,7 @@ export class FilterGroupElement extends HTMLElement {
     }
     const cell = element("div", VALUE_CELL_CLASS);
     cell.dataset.valueCell = "";
-    const template = this.widgetTemplates.get(field);
+    const template = this.bundle(model)?.widgetTemplates.get(field);
     const content = template?.content.firstElementChild;
     if (content) {
       const clone = content.cloneNode(true) as HTMLElement;
@@ -615,12 +785,14 @@ export class FilterGroupElement extends HTMLElement {
     path: NodePath,
     index: number,
     siblingCount: number,
+    model: string,
   ): HTMLElement {
-    const cell = this.comparisonCells(node);
+    const cell = this.comparisonCells(node, model);
     const row = element("div", SLOT_ROW_CLASS);
     row.dataset.nodeSlot = "";
     row.dataset.nodeKind = "comparison";
     row.dataset.path = JSON.stringify(path);
+    row.dataset.model = model;
     row.appendChild(this.negateChip(node, path));
     row.appendChild(cell);
     row.appendChild(this.controls(path, false, index, siblingCount));
@@ -631,29 +803,32 @@ export class FilterGroupElement extends HTMLElement {
   // Build or reuse a comparison leaf's row cell (cached by node id). Clones the
   // blank field-comparison row template, drops its ✕ (the group's controls own
   // removal), and wires the left-column change to rebuild its dependent
-  // operator/right-column options via the reused refreshRow.
-  private comparisonCells(node: ComparisonLeaf): HTMLElement {
+  // operator/right-column options via the reused refreshRow. Templates + columns
+  // come from `model`'s bundle (#193).
+  private comparisonCells(node: ComparisonLeaf, model: string): HTMLElement {
     let cell = this.comparisonCache.get(node.id);
     if (!cell) {
-      cell = this.buildComparisonCell();
+      cell = this.buildComparisonCell(model);
       this.comparisonCache.set(node.id, cell);
     }
     return cell;
   }
 
-  private buildComparisonCell(): HTMLElement {
+  private buildComparisonCell(model: string): HTMLElement {
     const cell = element("div", VALUE_CELL_CLASS);
     cell.dataset.valueCell = "";
-    const content = this.comparisonRowTemplate?.content.firstElementChild;
-    if (content) {
+    const bundle = this.bundle(model);
+    const content = bundle?.comparisonRowTemplate?.content.firstElementChild;
+    if (content && bundle) {
+      const columns = bundle.columns;
       const row = content.cloneNode(true) as HTMLElement;
       row.querySelector("[data-fc-remove]")?.remove(); // the group's controls own removal
       this.uniquify(row);
       cell.appendChild(row);
-      refreshRow(row, this.columns); // seed operator/right options from the (blank) left
+      refreshRow(row, columns); // seed operator/right options from the (blank) left
       row
         .querySelector<HTMLSelectElement>("[data-fc-left]")
-        ?.addEventListener("change", () => refreshRow(row, this.columns));
+        ?.addEventListener("change", () => refreshRow(row, columns));
     }
     return cell;
   }
@@ -684,6 +859,12 @@ export class FilterGroupElement extends HTMLElement {
       this.handleFieldPick(fieldPicker, event as CustomEvent<SearchSelectChangeDetail>);
       return;
     }
+    // The relation picker + quantifier are native <select>s (#193); a change on
+    // either rewrites the relation node and re-renders.
+    if (event.type === "change" && target instanceof HTMLSelectElement) {
+      if (target.dataset.relationField !== undefined) return this.handleRelationField(target);
+      if (target.dataset.relationMatch !== undefined) return this.handleRelationMatch(target);
+    }
     if (target.closest("[data-value-cell]")) this.refreshCompleteness(target);
   };
 
@@ -692,10 +873,37 @@ export class FilterGroupElement extends HTMLElement {
     if (!row?.dataset.path) return;
     const meta = parseFieldMeta(event.detail.last?.data?.meta ?? "");
     if (!meta) return;
-    const path = JSON.parse(row.dataset.path) as number[];
+    const path = JSON.parse(row.dataset.path) as NodePath;
     this.tree = setLeafField(this.tree, path, meta);
     this.render();
     this.dispatchChange();
+  }
+
+  // Pick a relation field: setRelationField resets the child group on a model change,
+  // so a full re-render is needed (the child group's field pickers/widgets change).
+  private handleRelationField(select: HTMLSelectElement): void {
+    const path = this.pathForControl(select);
+    if (!path) return;
+    this.tree = setRelationField(this.tree, path, select.value);
+    this.render();
+    this.dispatchChange();
+  }
+
+  // Pick a relation quantifier (ANY/NONE/ALL): only the node's match changes; a
+  // re-render keeps the select + downstream count/summary consistent.
+  private handleRelationMatch(select: HTMLSelectElement): void {
+    const path = this.pathForControl(select);
+    if (!path) return;
+    this.tree = setMatch(this.tree, path, select.value as RelationMatch);
+    this.render();
+    this.dispatchChange();
+  }
+
+  // The node path a relation control belongs to — read off its owning node slot.
+  private pathForControl(control: HTMLElement): NodePath | null {
+    const row = control.closest<HTMLElement>("[data-node-slot]");
+    if (!row?.dataset.path) return null;
+    return JSON.parse(row.dataset.path) as NodePath;
   }
 
   // Toggle the row's incomplete badge/fade in place (no re-render → the widget the
@@ -703,9 +911,10 @@ export class FilterGroupElement extends HTMLElement {
   private refreshCompleteness(target: HTMLElement): void {
     const row = target.closest<HTMLElement>("[data-node-slot]");
     if (row?.dataset.path) {
-      const node = this.nodeAtPath(JSON.parse(row.dataset.path) as number[]);
+      const node = this.nodeAtPath(JSON.parse(row.dataset.path) as NodePath);
+      const model = row.dataset.model ?? this.model;
       if (node?.kind === "criterion") {
-        this.applyIncompleteState(row, !this.leafComplete(node));
+        this.applyIncompleteState(row, !this.leafComplete(node, model));
       } else if (node?.kind === "comparison") {
         this.applyIncompleteState(row, this.comparisonTouched(node) && !this.comparisonComplete(node));
       }
@@ -728,9 +937,14 @@ export class FilterGroupElement extends HTMLElement {
 
   private nodeAtPath(path: NodePath): FilterNode | null {
     let node: FilterNode = this.tree;
-    for (const index of path) {
+    for (const step of path) {
+      if (step === RELATION_CHILD) {
+        if (node.kind !== "relation") return null;
+        node = node.child;
+        continue;
+      }
       if (node.kind !== "group") return null;
-      const child: FilterNode | undefined = node.children[index];
+      const child: FilterNode | undefined = node.children[step];
       if (!child) return null;
       node = child;
     }
@@ -801,7 +1015,7 @@ export class FilterGroupElement extends HTMLElement {
     return bar;
   }
 
-  private footer(path: NodePath): HTMLElement {
+  private footer(path: NodePath, model: string): HTMLElement {
     const footer = element("div", FOOTER_CLASS);
     const capReached = !canAddGroup(this.tree, path);
     footer.appendChild(actionButton("add-condition", "+ condition", path));
@@ -811,15 +1025,19 @@ export class FilterGroupElement extends HTMLElement {
         title: capReached ? "Max nesting reached" : "Add a nested group",
       }),
     );
-    footer.appendChild(
-      actionButton("add-relation", "+ relation", path, {
-        disabled: !canAddRelation(this.tree, path),
-        title: capReached ? "Max nesting reached" : "Add a relation descent",
-      }),
-    );
+    // A relation descends into the current group's model; only offer it when that
+    // model actually has relations (a leaf-only model like Device has none).
+    if ((this.bundle(model)?.relations.length ?? 0) > 0) {
+      footer.appendChild(
+        actionButton("add-relation", "+ relation", path, {
+          disabled: !canAddRelation(this.tree, path),
+          title: capReached ? "Max nesting reached" : "Add a relation descent",
+        }),
+      );
+    }
     // A comparison is a leaf (no nesting), so it is never depth-gated — only shown
     // when the model admits one (a comparison group with ≥2 columns).
-    if (this.hasComparableGroup) {
+    if (this.bundle(model)?.hasComparableGroup) {
       footer.appendChild(
         actionButton("add-comparison", "+ comparison", path, {
           title: "Add a field-to-field comparison",

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -85,8 +85,9 @@ const FOOTER_CLASS = "flex flex-wrap gap-2";
 // chip on a group with nothing to negate or join (issue #236).
 const EMPTY_STATE_CLASS = "px-2 py-1 text-sm text-gray-500 dark:text-gray-400";
 const EMPTY_STATE_TEXT = "No conditions. This will match all items.";
-// Shown for an empty relation child group: an empty child is the presence test
-// (ANY = has ≥1 related row, NONE = has none) rather than an error (#193).
+// Shown for an empty relation child group: an empty child is meaningful — the
+// quantifier alone is the test (ANY = has ≥1 related row, NONE = has none, ALL =
+// vacuously true) rather than an error (#193).
 const RELATION_EMPTY_TEXT = "No conditions — matches on the related row's existence.";
 const SLOT_ROW_CLASS = "flex items-center gap-2 flex-wrap";
 const FIELD_CELL_CLASS = "min-w-[12rem]";
@@ -129,8 +130,8 @@ const BUTTON_CLASS =
   "rounded border border-gray-200 px-2 py-1 text-xs hover:bg-gray-100 disabled:cursor-not-allowed " +
   "disabled:opacity-50 dark:border-gray-700 dark:hover:bg-gray-700";
 // Relation-descent accent block (component 5, #193): a left-accented indigo card set
-// apart from the gray group chrome so the Game→Session model switch reads explicitly
-// (Filter-Forge ↳ INTO). Header carries the `↳ [quantifier] of [relation] where` row.
+// apart from the gray group chrome so the Game→Session model switch reads explicitly.
+// Header carries the `↳ [quantifier] of [relation] where` row.
 const RELATION_CARD_CLASS =
   "flex flex-col gap-2 rounded-lg border border-l-4 border-indigo-200 border-l-indigo-400 " +
   "bg-indigo-50/50 p-2 dark:border-indigo-500/40 dark:border-l-indigo-500/70 dark:bg-indigo-500/10";
@@ -338,16 +339,31 @@ export class FilterGroupElement extends HTMLElement {
   }
 
   // The bundle for a model key, or the root model's as a defensive fallback so a
-  // stale/unknown key never throws mid-render.
+  // stale/unknown key never throws mid-render. An unknown key is a server-metadata
+  // gap (a relation target missing from model_field_registry / a key-casing mismatch),
+  // not an expected path — warn so the otherwise-silent wrong-model render is
+  // debuggable. The server contract (model_field_registry ≡ reachable_models) is
+  // asserted in tests, so this branch should be unreachable in practice.
   private bundle(model: string): ModelBundle | undefined {
-    return this.models.get(model) ?? this.models.get(this.model);
+    const found = this.models.get(model);
+    if (!found) {
+      console.warn(
+        `filter-group: no metadata bundle for model "${model}"; falling back to root "${this.model}"`,
+      );
+    }
+    return found ?? this.models.get(this.model);
   }
 
   // The target model key a relation field descends into, resolved from `model`'s
-  // metadata (RelationTarget.model is a Django model name → lower-cased key).
+  // metadata (RelationTarget.model is a Django model name → lower-cased key). An unset
+  // field ("") is the expected pre-pick state (stay on `model`, silent); a field that
+  // is set but has no relation target is a metadata gap worth warning about.
   private targetModel(model: string, field: string): string {
-    const target = this.bundle(model)?.fields.get(field)?.relations[0]?.model;
-    return target ? target.toLowerCase() : model;
+    const meta = this.bundle(model)?.fields.get(field);
+    if (field && !meta?.relations[0]?.model) {
+      console.warn(`filter-group: relation field "${field}" on model "${model}" has no target`);
+    }
+    return meta?.relations[0]?.model?.toLowerCase() ?? model;
   }
 
   /** The current node tree — for 2d serialize/count. Do not mutate it: every edit

--- a/ts/elements/filter-tree/operations.test.ts
+++ b/ts/elements/filter-tree/operations.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect } from "vitest";
 import { group } from "./serializer.js";
 import { nextNodeId } from "./node-id.js";
 import { ignoreNodeIds } from "./test-support.js";
-import type { ComparisonLeaf, CriterionLeaf, FilterNode, GroupNode } from "./types.js";
+import type { ComparisonLeaf, CriterionLeaf, FilterNode, GroupNode, RelationNode } from "./types.js";
 import type { FilterFieldMeta } from "./types.js";
 
 ignoreNodeIds();
 import {
+  RELATION_CHILD,
   SOFT_DEPTH_CAP,
   canAddGroup,
   canAddRelation,
@@ -33,6 +34,7 @@ import {
   setLeafCriterion,
   setLeafField,
   setMatch,
+  setRelationField,
   toggleConnective,
   toggleNegate,
   unwrapGroup,
@@ -58,7 +60,7 @@ function criterion(field: string): FilterNode {
   return { kind: "criterion", id: nextNodeId(), field, criterion: { value: field, modifier: "INCLUDES" }, negate: false };
 }
 
-function relation(field: string, child: GroupNode): FilterNode {
+function relation(field: string, child: GroupNode): RelationNode {
   return { kind: "relation", id: nextNodeId(), field, match: "ANY", child, negate: false };
 }
 
@@ -611,5 +613,93 @@ describe("pruneIncomplete (#192)", () => {
     };
     const tree = group("AND", [complete, emptyComparison()]);
     expect(pruneIncomplete(tree)).toEqual(group("AND", [complete]));
+  });
+
+  it("drops a relation whose field is unset (#193)", () => {
+    // A field-unset relation would serialize to `{"": …}`; it must be pruned like
+    // an incomplete leaf. A relation with a chosen field + empty child survives (the
+    // ANY presence test).
+    const tree = group("AND", [emptyRelation(), relation("session_filter", group("AND", []))]);
+    expect(pruneIncomplete(tree)).toEqual(
+      group("AND", [relation("session_filter", group("AND", []))]),
+    );
+  });
+});
+
+describe("relation child group navigation (#193)", () => {
+  it("nodeAt descends into a relation's child group via RELATION_CHILD", () => {
+    const tree = group("AND", [relation("session_filter", group("OR", [criterion("device")]))]);
+    expect(nodeAt(tree, [0, RELATION_CHILD])).toEqual(group("OR", [criterion("device")]));
+    expect(nodeAt(tree, [0, RELATION_CHILD, 0])).toEqual(criterion("device"));
+  });
+
+  it("insertChild adds a condition into a relation's child group", () => {
+    const tree = group("AND", [relation("session_filter", group("AND", []))]);
+    const next = insertChild(tree, [0, RELATION_CHILD], criterion("device"));
+    expect(nodeAt(next, [0, RELATION_CHILD])).toEqual(group("AND", [criterion("device")]));
+  });
+
+  it("removeAt removes a node inside a relation's child group", () => {
+    const tree = group("AND", [
+      relation("session_filter", group("AND", [criterion("a"), criterion("b")])),
+    ]);
+    const next = removeAt(tree, [0, RELATION_CHILD, 0]);
+    expect(nodeAt(next, [0, RELATION_CHILD])).toEqual(group("AND", [criterion("b")]));
+  });
+
+  it("removing the last child keeps the (now-empty) relation, not collapses it", () => {
+    // ANY over an empty child group is the presence test — the relation must survive
+    // its child group emptying, unlike a normal nested group (which collapses out).
+    const tree = group("AND", [relation("session_filter", group("AND", [criterion("a")]))]);
+    const next = removeAt(tree, [0, RELATION_CHILD, 0]);
+    expect(next).toEqual(group("AND", [relation("session_filter", group("AND", []))]));
+  });
+
+  it("toggleConnective flips a relation child-group's connective", () => {
+    const tree = group("AND", [relation("session_filter", group("AND", [criterion("a")]))]);
+    const child = nodeAt(toggleConnective(tree, [0, RELATION_CHILD]), [0, RELATION_CHILD]);
+    expect(child.kind).toBe("group");
+    if (child.kind === "group") expect(child.connective).toBe("OR");
+  });
+
+  it("groupDepthAt counts a relation's child group as one group level, not two path steps", () => {
+    const tree = group("AND", [relation("session_filter", group("AND", []))]);
+    expect(groupDepthAt(tree, [0, RELATION_CHILD])).toBe(1);
+    // and one deeper via a nested group inside the child
+    const nested = group("AND", [
+      relation("session_filter", group("AND", [group("OR", [criterion("a")])])),
+    ]);
+    expect(groupDepthAt(nested, [0, RELATION_CHILD, 0])).toBe(2);
+  });
+
+  it("canUnwrap is false for a relation's child group", () => {
+    const tree = group("AND", [relation("session_filter", group("AND", [criterion("a")]))]);
+    expect(canUnwrap(tree, [0, RELATION_CHILD])).toBe(false);
+  });
+});
+
+describe("setRelationField (#193)", () => {
+  it("sets the field and resets the child on change, preserving id/negate/match", () => {
+    const tree = group("AND", [
+      { ...relation("session_filter", group("OR", [criterion("device")])), negate: true, match: "ALL" },
+    ]);
+    const next = setRelationField(tree, [0], "purchase_filter");
+    expect(nodeAt(next, [0])).toEqual({
+      kind: "relation",
+      field: "purchase_filter",
+      match: "ALL",
+      negate: true,
+      child: group("AND", []),
+    });
+  });
+
+  it("keeps the child group when the same field is re-picked", () => {
+    const tree = group("AND", [relation("session_filter", group("OR", [criterion("device")]))]);
+    const next = setRelationField(tree, [0], "session_filter");
+    expect(nodeAt(next, [0])).toEqual(relation("session_filter", group("OR", [criterion("device")])));
+  });
+
+  it("throws on a non-relation node", () => {
+    expect(() => setRelationField(group("AND", [criterion("a")]), [0], "x")).toThrow();
   });
 });

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -62,6 +62,10 @@ export function parseFieldMeta(raw: string): FilterFieldMeta | null {
   try {
     return JSON.parse(raw) as FilterFieldMeta;
   } catch {
+    // A non-empty blob that won't parse is a broken Python↔TS contract (not the
+    // normal empty-option case above) — warn so the silently-dropped field pick is
+    // debuggable, consistent with parseModels in filter-group.ts.
+    console.warn("filter-tree: malformed field-picker data-meta blob");
     return null;
   }
 }

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -7,10 +7,13 @@
  * input, so the custom element can hold `tree`, call an op, reassign, and re-render.
  * DOM lives in `filter-group.ts`; correctness lives here (and is vitest-tested).
  *
- * Addressing: a `NodePath` is the list of `group.children` indices from the root.
- * Paths only ever descend through groups — leaves and relations are terminal (the
- * shell renders a relation's child group as an inert slot, not a navigable subtree),
- * so a group reached at path `P` always sits at group-nesting depth `P.length`.
+ * Addressing: a `NodePath` is a list of steps from the root. A numeric step selects
+ * a `group.children` index; the `RELATION_CHILD` sentinel step descends from a
+ * relation node into its one child group (issue #193). So a relation's child group
+ * *is* a navigable subtree — a numeric step lands on the relation, then a
+ * `RELATION_CHILD` step enters its group. Because a relation node is not itself a
+ * group level, path length no longer equals group-nesting depth; `groupDepthAt`
+ * walks the tree to count group levels.
  */
 import {
   type ComparisonLeaf,
@@ -27,7 +30,13 @@ import { group } from "./serializer.js";
 import { nextNodeId } from "./node-id.js";
 import { isPresenceModifier, isRangeModifier } from "../filter-tokens.js";
 
-export type NodePath = readonly number[];
+// A path step is either a positional index into a group's children, or the
+// `RELATION_CHILD` sentinel meaning "descend into the relation node's child group".
+// The string sentinel survives `JSON.stringify`/`JSON.parse` (paths are stored in the
+// DOM as `data-path` JSON), so no custom (de)serialization is needed.
+export const RELATION_CHILD = "child";
+export type PathStep = number | typeof RELATION_CHILD;
+export type NodePath = readonly PathStep[];
 
 // Soft UI cap on group nesting (design spec): the root group is depth 0; a new
 // group/relation child may be created up to depth 5, deeper is disabled. The
@@ -133,10 +142,15 @@ export function emptyRoot(): GroupNode {
 
 export function nodeAt(root: GroupNode, path: NodePath): FilterNode {
   let node: FilterNode = root;
-  for (const index of path) {
+  for (const step of path) {
+    if (step === RELATION_CHILD) {
+      if (node.kind !== "relation") throw new Error(`RELATION_CHILD step on a non-relation node`);
+      node = node.child;
+      continue;
+    }
     if (node.kind !== "group") throw new Error(`Path descends into a non-group node`);
-    const child: FilterNode | undefined = node.children[index];
-    if (child === undefined) throw new Error(`Path index ${index} out of range`);
+    const child: FilterNode | undefined = node.children[step];
+    if (child === undefined) throw new Error(`Path index ${step} out of range`);
     node = child;
   }
   return node;
@@ -168,12 +182,16 @@ function replaceNode(
   transform: (node: FilterNode) => FilterNode,
 ): FilterNode {
   if (path.length === 0) return transform(node);
+  const [step, ...rest] = path;
+  if (step === RELATION_CHILD) {
+    if (node.kind !== "relation") throw new Error(`RELATION_CHILD step on a non-relation node`);
+    return { ...node, child: replaceNode(node.child, rest, transform) as GroupNode };
+  }
   if (node.kind !== "group") throw new Error(`Path descends into a non-group node`);
-  const [index, ...rest] = path;
-  const child = node.children[index];
-  if (child === undefined) throw new Error(`Path index ${index} out of range`);
+  const child = node.children[step];
+  if (child === undefined) throw new Error(`Path index ${step} out of range`);
   const newChild = replaceNode(child, rest, transform);
-  return { ...node, children: node.children.map((existing, i) => (i === index ? newChild : existing)) };
+  return { ...node, children: node.children.map((existing, i) => (i === step ? newChild : existing)) };
 }
 
 // Transform the `children` array of the group at `groupPath`.
@@ -188,9 +206,15 @@ function updateChildren(
   });
 }
 
+// Split a *positional* node path into its containing group + index. The last step
+// must be a numeric index: only a group's positional children are removed / moved /
+// duplicated / wrapped. A `RELATION_CHILD`-terminated path addresses a relation's
+// child group, which is owned by its relation (never a list slot), so it is rejected.
 function splitPath(path: NodePath): { parentPath: NodePath; index: number } {
   if (path.length === 0) throw new Error(`Path addresses the root, which has no parent`);
-  return { parentPath: path.slice(0, -1), index: path[path.length - 1] };
+  const last = path[path.length - 1];
+  if (typeof last !== "number") throw new Error(`Path does not address a positional child`);
+  return { parentPath: path.slice(0, -1), index: last };
 }
 
 // ── Structural operations ────────────────────────────────────────────────────
@@ -217,7 +241,15 @@ export function removeAt(root: GroupNode, path: NodePath): GroupNode {
   const { parentPath, index } = splitPath(path);
   let next = updateChildren(root, parentPath, (children) => children.filter((_, i) => i !== index));
   let groupPath: NodePath = parentPath;
-  while (groupPath.length > 0 && groupAt(next, groupPath).children.length === 0) {
+  // Cascade the empty-group collapse upward, but only through *positional* group
+  // children (numeric last step). A relation's child group (RELATION_CHILD-terminated)
+  // is a boundary like the root: ANY over an empty child group is the meaningful
+  // "has ≥1 related row" presence test, so it may sit empty and the relation stays.
+  while (
+    groupPath.length > 0 &&
+    typeof groupPath[groupPath.length - 1] === "number" &&
+    groupAt(next, groupPath).children.length === 0
+  ) {
     const { parentPath: grandparentPath, index: groupIndex } = splitPath(groupPath);
     next = updateChildren(next, grandparentPath, (children) =>
       children.filter((_, i) => i !== groupIndex),
@@ -285,6 +317,19 @@ export function setMatch(root: GroupNode, path: NodePath, match: RelationMatch):
   });
 }
 
+// Pick (or change) a relation node's field (issue #193). Changing the field can
+// change the target model, whose fields differ, so the child group is reset to a
+// fresh empty AND group — no silent carry-over of leaves keyed by the old model's
+// fields (mirrors `setLeafField`'s reset). Re-picking the SAME field is a no-op that
+// preserves the in-progress child group. `id`, `negate`, and `match` are preserved.
+export function setRelationField(root: GroupNode, path: NodePath, field: string): GroupNode {
+  return replaceNodeAt(root, path, (node) => {
+    if (node.kind !== "relation") throw new Error(`Node at path is not a relation`);
+    if (node.field === field) return node;
+    return { ...node, field, child: group("AND", []) };
+  });
+}
+
 // ── Leaf payload edits (issue #192) ──────────────────────────────────────────
 
 // Pick (or change) a criterion leaf's field: replace it with a FRESH leaf for the
@@ -343,7 +388,10 @@ function pruneNode(node: FilterNode): FilterNode | null {
     case "comparison":
       return isComparisonComplete(node) ? node : null;
     case "relation":
-      return { ...node, child: pruneGroup(node.child) };
+      // A field-unset relation would serialize to `{"": …}`; drop it like an
+      // incomplete leaf. With a field chosen it survives even when its child group
+      // empties (ANY over empty = the "has ≥1 related row" presence test).
+      return node.field === "" ? null : { ...node, child: pruneGroup(node.child) };
     case "group": {
       const pruned = pruneGroup(node);
       return pruned.children.length === 0 ? null : pruned; // collapse emptied non-root group
@@ -397,10 +445,26 @@ export function deepestGroupDepth(node: GroupNode, groupDepth: number): number {
   return deepest;
 }
 
-// A group reached at `groupPath` sits at depth `groupPath.length` (paths descend
-// through group children only).
-export function groupDepthAt(_root: GroupNode, groupPath: NodePath): number {
-  return groupPath.length;
+// The group-nesting depth of the group reached at `groupPath`. Path length is no
+// longer a proxy: a numeric step onto a relation node is not a group level (only the
+// following RELATION_CHILD step is), so the tree is walked, counting each landing on
+// a group node. `game AND (rel sessions where AND …)`: the child group at
+// `[0, RELATION_CHILD]` is depth 1 (two steps, one group level).
+export function groupDepthAt(root: GroupNode, groupPath: NodePath): number {
+  let node: FilterNode = root;
+  let depth = 0;
+  for (const step of groupPath) {
+    if (step === RELATION_CHILD) {
+      if (node.kind !== "relation") throw new Error(`RELATION_CHILD step on a non-relation node`);
+      node = node.child;
+      depth += 1; // a relation's child group is one level below the relation's group
+      continue;
+    }
+    if (node.kind !== "group") throw new Error(`Path descends into a non-group node`);
+    node = node.children[step];
+    if (node?.kind === "group") depth += 1;
+  }
+  return depth;
 }
 
 // `+ group`/`+ relation` add a child group one level below the current group; allow
@@ -419,12 +483,20 @@ export function canAddRelation(root: GroupNode, groupPath: NodePath): boolean {
 // a group holding the node, and `deepestGroupDepth` accounts for groups/relations.
 export function canWrap(root: GroupNode, path: NodePath): boolean {
   if (path.length === 0) return false; // the root cannot be wrapped
-  const slotDepth = path.length;
+  // The wrapper takes the node's slot, sitting one level below its containing group;
+  // groupDepthAt (not path.length) gives that group's true depth through relations.
+  const slotDepth = groupDepthAt(root, path.slice(0, -1)) + 1;
   const node = nodeAt(root, path);
   return deepestGroupDepth(group("AND", [node]), slotDepth) <= SOFT_DEPTH_CAP;
 }
 
-// Unwrap is meaningful only for a non-root group.
+// Unwrap is meaningful only for a non-root group. A relation's child group
+// (RELATION_CHILD-terminated) is owned by its relation, never a splice-able list
+// slot, so it is not unwrappable.
 export function canUnwrap(root: GroupNode, path: NodePath): boolean {
-  return path.length > 0 && nodeAt(root, path).kind === "group";
+  return (
+    path.length > 0 &&
+    path[path.length - 1] !== RELATION_CHILD &&
+    nodeAt(root, path).kind === "group"
+  );
 }


### PR DESCRIPTION
Closes #193. Component 5 of the nested filter builder (phase 2c of #168): the relation node becomes a **live accent block** — `↳ [ANY/NONE/ALL ▾] of [relation ▾] where …` — over a nested child group built from the **target** model's fields. Replaces the inert slot from the earlier slices (#245, #250).

## Path model (`ts/elements/filter-tree/operations.ts`)
A relation's child group is now **navigable** via a `RELATION_CHILD` sentinel path step (`[…, "child", i]`).
- `nodeAt`/`replaceNode` descend into `relation.child`.
- The empty-group collapse cascade stops at a relation-child boundary — ANY/NONE over an empty child is the "has ≥1 / has 0 related rows" **presence test**, not prunable.
- Path length is no longer a depth proxy (a relation node isn't a group level), so `groupDepthAt` walks the tree; `splitPath` rejects a `"child"`-terminated path; `canUnwrap` excludes the relation child group.
- New `setRelationField` (resets the child group on a target-model change, mirroring `setLeafField`); `pruneNode` drops a **field-unset** relation from the query (advances #225). `setMatch` already existed.

## Server (`custom_elements.py`, `games/filters.py`)
The flat `fields`/`columns` props fold into one normalized **`models`** prop:
- `model_field_registry(root)` emits a `{fields, columns}` bundle **per relation-reachable model** (`reachable_models()` BFS over the relation graph — the closed set of ~6 filter models).
- Per-model field-picker / value-widget / comparison-row `<template>`s are emitted, tagged `data-model` so the client buckets them by the model whose child group they belong to.

## Client (`filter-group.ts`)
- A per-model bundle registry; render + the tree-walk (`fill`/`read`/`incompleteCount`) thread the **active model**, switching to the relation target inside each child group.
- `renderRelationRow` builds the accent block; the child group is rendered by the same recursive shell (minus its own restructuring controls — the relation node owns those) under the target model, so its footer/leaf widgets come from that model's bundle.

## Verification
- Full `direnv exec . make check` green: lint, format-check, mypy, ts-check, **vitest (189, incl. new path-navigation + relation-widget suites)**, **full pytest (1371, incl. e2e)**.
- Browser-mounted `<filter-group model="game">`: picked a relation + quantifier, added a child condition; the descent serializes to `{session_filter:{match:"ALL", AND:[…]}}`. Accent block confirmed (4px indigo left border, tinted card).

## Out of scope (rides with #196, the builder page shell)
- Prefill via `deserialize()` (the multi-model registry this slice builds makes it ready) and the `/…/filter` route + Playwright e2e — no page mounts `<filter-group>` yet.
- The `models`-prop shape is hand-matched to the TS `FilterFieldMeta` until #240 codegen-guards it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)