### PR TITLE
fix(filters): stop shrinking native <select> chevron padding

### DIFF
--- a/games/forms.py
+++ b/games/forms.py
@@ -38,8 +38,15 @@ INPUT_CLASS = (
     "text-sm rounded-base focus:ring-brand focus:border-brand block w-full "
     f"px-3 py-2.5 shadow-xs placeholder:text-body {_DISABLED_CONTROL}"
 )
+# No horizontal padding here: @tailwindcss/forms (base strategy) styles every
+# bare <select> with appearance:none, a chevron pinned to the right edge, AND the
+# right padding (~2.5rem/40px) that clears it. A px-*/pr-* utility can't win over
+# that plugin rule for the right side, and px-* *does* override it symmetrically —
+# pulling the right padding down so option text slides under the chevron (the old
+# px-3 did exactly this on narrow selects, e.g. the field-comparison operator
+# select). So set only vertical padding and let the plugin own the horizontal.
 SELECT_CLASS = (
-    "w-full px-3 py-2.5 bg-neutral-secondary-medium border border-default-medium "
+    "w-full py-2.5 bg-neutral-secondary-medium border border-default-medium "
     "text-heading text-sm rounded-base focus:ring-brand focus:border-brand "
     f"shadow-xs placeholder:text-body {_DISABLED_CONTROL}"
 )

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -145,8 +145,13 @@ const RELATION_CARD_CLASS =
 const RELATION_HEADER_CLASS = "flex items-center gap-2 flex-wrap";
 const RELATION_ARROW_CLASS = "text-indigo-500 dark:text-indigo-300 font-semibold";
 const RELATION_LABEL_CLASS = "text-sm text-gray-600 dark:text-gray-300";
+// No horizontal padding: @tailwindcss/forms styles bare <select> with
+// appearance:none, a right-anchored chevron, and the right padding (~2.5rem) that
+// clears it. A px-*/pr-* utility can't beat the plugin rule for the right side;
+// px-* only overrides it symmetrically, shrinking it so the label ("any") ends up
+// under the chevron (the old px-2 did this). Set only vertical padding here.
 const RELATION_SELECT_CLASS =
-  "rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-800 " +
+  "rounded border border-gray-300 bg-white py-1 text-sm dark:border-gray-600 dark:bg-gray-800 " +
   "disabled:opacity-50 disabled:cursor-not-allowed";
 
 // The closed set of restructuring actions a button can carry; producer


### PR DESCRIPTION
## Problem

On `/filter-group-demo/` (nested filter builder, #193), three native `<select>`s render with the chevron sitting on the label:

- **Quantifier** `↳ [any ▾] of …` — chevron over "any" (reads as a cramped `any✓`)
- **Field-comparison operator** select — squeezed so narrow only the chevron shows; the `—` placeholder is invisible

## Root cause

`@tailwindcss/forms` (base strategy) styles every bare `<select>` with `appearance:none`, a chevron painted as a right-anchored `background-image`, **and** the ~2.5rem (40px) right padding that clears it.

The app's `px-2` / `px-3` overrode that padding **symmetrically**, shrinking the right side to 8/12px so option text slid under the chevron. Verified live: `pr-*` / `pe-*` / even `!pr-*` utilities are **inert** on a `<select>` (the plugin rule wins for the right side); only the `px-*` `padding-inline` shorthand overrides it — which is exactly what caused the regression.

## Fix

Set only vertical padding on these selects and let the plugin own the horizontal padding (12px left / 40px right — enough to clear its own chevron).

- `games/forms.py` — `SELECT_CLASS`: drop `px-3` (fixes the operator select + a latent long-option-text overlap on every form select)
- `ts/elements/filter-group.ts` — `RELATION_SELECT_CLASS`: drop `px-2` (fixes the quantifier + relation pickers)

## Verification

- Live browser, light + dark: `any ▾`, `a relation… ▾`, and `— ▾` all clear the chevron; computed `pl 12 / pr 40`.
- `make check` green — ruff, format, mypy, ts-check, vitest (191), pytest (1373, incl. e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)