### PR TITLE
fix(filters): spell out empty-relation presence test per quantifier (#225)

### DIFF
--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -342,6 +342,19 @@ describe("<filter-group> relation descent (component 5, #193)", () => {
     clickAction(host, "add-condition", [1, "child"]);
     expect(relationChildText(host, [1, "child"])).not.toContain("related items");
   });
+
+  // #225: the empty child the copy describes must actually survive to the query as a
+  // presence test — a field-set relation is never pruned even with no sub-conditions.
+  it("serializes a field-set empty relation child as a presence test (not pruned)", () => {
+    const host = mountRelation();
+    clickAction(host, "add-relation", []);
+    pickRelation(host, [1], "session_filter"); // field set, child left empty
+    // ANY is the default (omitted from the payload): a bare presence test.
+    expect(host.serializeForQuery()).toEqual({ AND: [{ session_filter: {} }] });
+    // The quantifier still rides along on an empty child.
+    setRelationMatch(host, [1], "NONE");
+    expect(host.serializeForQuery()).toEqual({ AND: [{ session_filter: { match: "NONE" } }] });
+  });
 });
 
 describe("<filter-group> connective + negate (component 2, #190)", () => {

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -329,6 +329,9 @@ describe("<filter-group> relation descent (component 5, #193)", () => {
     // ALL empty: matches all.
     setRelationMatch(host, [1], "ALL");
     expect(relationChildText(host, [1, "child"])).toContain("Matches all items");
+    // Back to ANY restores the "1 or more" copy (the switch recomputes each render).
+    setRelationMatch(host, [1], "ANY");
+    expect(relationChildText(host, [1, "child"])).toContain("1 or more related items");
   });
 
   it("drops the empty-child presence-test copy once a real condition is added", () => {

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -205,6 +205,18 @@ function pickRelation(host: HTMLElement, path: Path, field: string): void {
   select.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
+function setRelationMatch(host: HTMLElement, path: Path, value: string): void {
+  const select = relationSelect(host, path, "data-relation-match");
+  select.value = value;
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function relationChildText(host: HTMLElement, path: Path): string {
+  return (
+    host.querySelector(`[data-kind="group"][data-path='${JSON.stringify(path)}']`)?.textContent ?? ""
+  );
+}
+
 describe("<filter-group> relation descent (component 5, #193)", () => {
   it("+ relation adds a live accent block with quantifier + relation pickers", () => {
     const host = mountRelation();
@@ -301,6 +313,31 @@ describe("<filter-group> relation descent (component 5, #193)", () => {
     pickRelation(host, [1], "session_filter");
     // session has no relation fields here → its child group shows no + relation.
     expect(button(host, "add-relation", [1, "child"])).toBeNull();
+  });
+
+  // #225: an empty relation child is an appliable presence test, but its intent must
+  // be spelled out per quantifier so it is never applied silently.
+  it("spells out the empty-child presence test, phrased for the active quantifier", () => {
+    const host = mountRelation();
+    clickAction(host, "add-relation", []);
+    pickRelation(host, [1], "session_filter");
+    // ANY (default): 1 or more.
+    expect(relationChildText(host, [1, "child"])).toContain("1 or more related items");
+    // NONE: 0.
+    setRelationMatch(host, [1], "NONE");
+    expect(relationChildText(host, [1, "child"])).toContain("0 related items");
+    // ALL empty: matches all.
+    setRelationMatch(host, [1], "ALL");
+    expect(relationChildText(host, [1, "child"])).toContain("Matches all items");
+  });
+
+  it("drops the empty-child presence-test copy once a real condition is added", () => {
+    const host = mountRelation();
+    clickAction(host, "add-relation", []);
+    pickRelation(host, [1], "session_filter");
+    expect(relationChildText(host, [1, "child"])).toContain("related items");
+    clickAction(host, "add-condition", [1, "child"]);
+    expect(relationChildText(host, [1, "child"])).not.toContain("related items");
   });
 });
 

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -85,9 +85,6 @@ const FOOTER_CLASS = "flex flex-wrap gap-2";
 // chip on a group with nothing to negate or join (issue #236).
 const EMPTY_STATE_CLASS = "px-2 py-1 text-sm text-gray-500 dark:text-gray-400";
 const EMPTY_STATE_TEXT = "No conditions. This will match all items.";
-// Generic fallback for an empty relation child; `relationEmptyText` supersedes it.
-const RELATION_EMPTY_TEXT = "Matches items with related items.";
-
 // An empty relation child is meaningful, not an error: the quantifier alone is the
 // test. But that intent is invisible until spelled out — an unspelled empty relation
 // silently injects an EXISTS/anti-EXISTS filter the user may not have meant (#225).
@@ -102,6 +99,8 @@ function relationEmptyText(match: RelationMatch): string {
     case "ALL":
       return "Matches all items (add a condition to filter them).";
   }
+  const unreachable: never = match; // exhaustive over RelationMatch; a new member fails tsc here
+  return unreachable;
 }
 const SLOT_ROW_CLASS = "flex items-center gap-2 flex-wrap";
 const FIELD_CELL_CLASS = "min-w-[12rem]";
@@ -602,9 +601,9 @@ export class FilterGroupElement extends HTMLElement {
     // nothing to apply to (issue #236).
     if ((path.length === 0 || isRelationChild) && node.children.length === 0) {
       const emptyState = element("div", EMPTY_STATE_CLASS);
-      emptyState.textContent = isRelationChild
-        ? (relationEmptyLabel ?? RELATION_EMPTY_TEXT)
-        : EMPTY_STATE_TEXT;
+      // Only a relation child supplies a label (its per-quantifier presence-test copy);
+      // the root empty group falls through to the generic "matches all" text.
+      emptyState.textContent = relationEmptyLabel ?? EMPTY_STATE_TEXT;
       card.appendChild(emptyState);
       card.appendChild(this.footer(path, model));
       return card;

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -85,10 +85,24 @@ const FOOTER_CLASS = "flex flex-wrap gap-2";
 // chip on a group with nothing to negate or join (issue #236).
 const EMPTY_STATE_CLASS = "px-2 py-1 text-sm text-gray-500 dark:text-gray-400";
 const EMPTY_STATE_TEXT = "No conditions. This will match all items.";
-// Shown for an empty relation child group: an empty child is meaningful — the
-// quantifier alone is the test (ANY = has ≥1 related row, NONE = has none, ALL =
-// vacuously true) rather than an error (#193).
-const RELATION_EMPTY_TEXT = "No conditions — matches on the related row's existence.";
+// Generic fallback for an empty relation child; `relationEmptyText` supersedes it.
+const RELATION_EMPTY_TEXT = "Matches items with related items.";
+
+// An empty relation child is meaningful, not an error: the quantifier alone is the
+// test. But that intent is invisible until spelled out — an unspelled empty relation
+// silently injects an EXISTS/anti-EXISTS filter the user may not have meant (#225).
+// So state, in plain terms and per quantifier, what an empty child matches. Kept
+// model-agnostic on purpose (no model names).
+function relationEmptyText(match: RelationMatch): string {
+  switch (match) {
+    case "ANY":
+      return "Matches items with 1 or more related items (add a condition to filter them).";
+    case "NONE":
+      return "Matches items with 0 related items (add a condition to filter them).";
+    case "ALL":
+      return "Matches all items (add a condition to filter them).";
+  }
+}
 const SLOT_ROW_CLASS = "flex items-center gap-2 flex-wrap";
 const FIELD_CELL_CLASS = "min-w-[12rem]";
 const VALUE_CELL_CLASS = "flex-1 min-w-[12rem]";
@@ -574,6 +588,7 @@ export class FilterGroupElement extends HTMLElement {
     siblingCount: number,
     model: string,
     depth: number,
+    relationEmptyLabel?: string,
   ): HTMLElement {
     const isRelationChild = path[path.length - 1] === RELATION_CHILD;
     const edgeClass = node.connective === "AND" ? GROUP_AND_EDGE_CLASS : GROUP_OR_EDGE_CLASS;
@@ -587,7 +602,9 @@ export class FilterGroupElement extends HTMLElement {
     // nothing to apply to (issue #236).
     if ((path.length === 0 || isRelationChild) && node.children.length === 0) {
       const emptyState = element("div", EMPTY_STATE_CLASS);
-      emptyState.textContent = isRelationChild ? RELATION_EMPTY_TEXT : EMPTY_STATE_TEXT;
+      emptyState.textContent = isRelationChild
+        ? (relationEmptyLabel ?? RELATION_EMPTY_TEXT)
+        : EMPTY_STATE_TEXT;
       card.appendChild(emptyState);
       card.appendChild(this.footer(path, model));
       return card;
@@ -668,9 +685,19 @@ export class FilterGroupElement extends HTMLElement {
     card.appendChild(header);
 
     // The child group is built from the target model; it descends one depth level.
+    // Spell out what an empty child matches for the active quantifier so a presence
+    // test is never applied silently (#225).
     const childModel = this.targetModel(model, node.field);
     card.appendChild(
-      this.renderGroup(node.child, [...path, RELATION_CHILD], 0, 1, childModel, depth + 1),
+      this.renderGroup(
+        node.child,
+        [...path, RELATION_CHILD],
+        0,
+        1,
+        childModel,
+        depth + 1,
+        relationEmptyText(node.match),
+      ),
     );
     this.applyIncompleteState(card, node.field === "");
     return card;


### PR DESCRIPTION
Closes #225.

## Problem

A relation sub-filter with an **empty child group** is a real presence test (EXISTS / anti-EXISTS), not "no constraint" — the #188 serializer deliberately preserves it (`ANY`+empty = "has ≥1 related row", `NONE`+empty = "has 0 related rows", `ALL`+empty = vacuous match-all). In the nested builder, a user who picked a relation field and hit **Apply** without adding any sub-condition would *silently* inject that filter. Found during the #188 adversarial review.

## Approach

Chosen resolution: **make the intent explicit** (rather than excluding empty relations from Apply, which would kill genuinely-useful presence tests like "games never played"). The empty relation child's placeholder now states, per quantifier, exactly what it matches — and nudges the user to add a condition:

| Quantifier | Placeholder |
|---|---|
| ANY | `Matches items with 1 or more related items (add a condition to filter them).` |
| NONE | `Matches items with 0 related items (add a condition to filter them).` |
| ALL | `Matches all items (add a condition to filter them).` |

Wording is plain and **model-agnostic** (no model names, matching the planned direction of the builder). The text re-renders live when the quantifier picker changes.

The empty relation stays **complete and appliable** — presence tests remain authorable. No serializer / backend / pruning change.

## Changes

- `ts/elements/filter-group.ts` — `relationEmptyText(match)` helper; threaded into `renderGroup`'s empty-relation-child branch via `renderRelationRow`.
- `ts/elements/filter-group.test.ts` — coverage: quantifier-specific copy (ANY/NONE/ALL, updates on switch) + copy clears once a real condition is added.

## Verification

Full `make check` green (lint + format + mypy + ts-check + vitest **193** + pytest incl. `e2e/`, **1373 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)