### PR TITLE
fix(filters): string "is empty"/"is set" match blank strings, not just NULL

### DIFF
--- a/common/criteria.py
+++ b/common/criteria.py
@@ -350,9 +350,17 @@ class StringCriterion(_Criterion):
         if m == Modifier.NOT_MATCHES_REGEX:
             return ~Q(**{f"{field_name}__regex": self.value})
         if m == Modifier.IS_NULL:
-            return Q(**{f"{field_name}__isnull": True})
+            # String fields in this codebase use blank=True, default="" (null=False),
+            # so "empty" means either SQL NULL or an empty string. Both are matched here
+            # so the criterion works correctly regardless of the field's null setting.
+            return Q(**{f"{field_name}__isnull": True}) | Q(
+                **{f"{field_name}__exact": ""}
+            )
         if m == Modifier.NOT_NULL:
-            return Q(**{f"{field_name}__isnull": False})
+            # Logical complement of IS_NULL: neither NULL nor empty string.
+            return ~(
+                Q(**{f"{field_name}__isnull": True}) | Q(**{f"{field_name}__exact": ""})
+            )
         raise FilterError(f"Unsupported modifier {m} for string field")
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -108,11 +108,11 @@ class TestStringCriterion:
 
     def test_is_null(self):
         c = StringCriterion(value="", modifier=Modifier.IS_NULL)
-        assert c.to_q("name") == Q(name__isnull=True)
+        assert c.to_q("name") == Q(name__isnull=True) | Q(name__exact="")
 
     def test_not_null(self):
         c = StringCriterion(value="", modifier=Modifier.NOT_NULL)
-        assert c.to_q("name") == Q(name__isnull=False)
+        assert c.to_q("name") == ~(Q(name__isnull=True) | Q(name__exact=""))
 
     def test_empty_value_survives_to_json(self):
         """An EQUALS "" match (empty string, not unset — "unset" is the criterion
@@ -4309,3 +4309,127 @@ class _BadLookupStub(OperatorFilter):
         from games.models import Game
 
         return Game
+
+
+@pytest.mark.django_db
+class TestStringCriterionIsNullAgainstDB:
+    """Behavioral tests proving IS_NULL/NOT_NULL on string fields matches
+    blank strings (the repo convention: null=False, default="")."""
+
+    def _seed_sessions(self):
+        import datetime
+
+        from games.models import Device, Game, Platform, Session
+
+        platform, _ = Platform.objects.get_or_create(name="Test Platform", icon="test")
+        game, _ = Game.objects.get_or_create(
+            name="Test Game", defaults={"platform": platform, "status": "u"}
+        )
+        device, _ = Device.objects.get_or_create(name="Test Device", type="PC")
+        start = datetime.datetime(2025, 1, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
+        end = datetime.datetime(2025, 1, 1, 11, 0, 0, tzinfo=datetime.timezone.utc)
+
+        empty_note_session_1 = Session.objects.create(
+            game=game, device=device, timestamp_start=start, timestamp_end=end, note=""
+        )
+        empty_note_session_2 = Session.objects.create(
+            game=game,
+            device=device,
+            timestamp_start=start + datetime.timedelta(days=1),
+            timestamp_end=end + datetime.timedelta(days=1),
+            note="",
+        )
+        nonempty_note_session = Session.objects.create(
+            game=game,
+            device=device,
+            timestamp_start=start + datetime.timedelta(days=2),
+            timestamp_end=end + datetime.timedelta(days=2),
+            note="Great session",
+        )
+        return empty_note_session_1, empty_note_session_2, nonempty_note_session
+
+    def test_is_null_matches_blank_string_sessions(self):
+        empty_1, empty_2, nonempty = self._seed_sessions()
+        from games.models import Session
+
+        criterion = StringCriterion(value="", modifier=Modifier.IS_NULL)
+        matching_ids = set(
+            Session.objects.filter(criterion.to_q("note")).values_list("id", flat=True)
+        )
+        assert empty_1.id in matching_ids
+        assert empty_2.id in matching_ids
+        assert nonempty.id not in matching_ids
+
+    def test_not_null_matches_nonempty_string_sessions(self):
+        empty_1, empty_2, nonempty = self._seed_sessions()
+        from games.models import Session
+
+        criterion = StringCriterion(value="", modifier=Modifier.NOT_NULL)
+        matching_ids = set(
+            Session.objects.filter(criterion.to_q("note")).values_list("id", flat=True)
+        )
+        assert nonempty.id in matching_ids
+        assert empty_1.id not in matching_ids
+        assert empty_2.id not in matching_ids
+
+    def test_is_null_and_not_null_partition_sessions(self):
+        """IS_NULL and NOT_NULL together must cover exactly every session created here."""
+        empty_1, empty_2, nonempty = self._seed_sessions()
+        from games.models import Session
+
+        is_null_q = StringCriterion(value="", modifier=Modifier.IS_NULL).to_q("note")
+        not_null_q = StringCriterion(value="", modifier=Modifier.NOT_NULL).to_q("note")
+        seeded_ids = {empty_1.id, empty_2.id, nonempty.id}
+        is_null_ids = (
+            set(Session.objects.filter(is_null_q).values_list("id", flat=True))
+            & seeded_ids
+        )
+        not_null_ids = (
+            set(Session.objects.filter(not_null_q).values_list("id", flat=True))
+            & seeded_ids
+        )
+        assert is_null_ids | not_null_ids == seeded_ids
+        assert is_null_ids & not_null_ids == set()
+
+
+class TestStringFieldNullConvention:
+    """Convention guard: every CharField/TextField in the games app must be
+    null=False. The StringCriterion IS_NULL/NOT_NULL fix relies on this (empty
+    is stored as "", never SQL NULL). If anyone adds a nullable string field this
+    test fails loudly so the filter logic can be revisited.
+
+    Known intentional exceptions (pre-existing nullable string fields not used
+    in any filter, listed as "ModelName.field_name"):
+    - GameStatusChange.old_status: NULL means "no previous status" (first-time set)
+    """
+
+    # Fields that are intentionally null=True for domain reasons and are NOT used
+    # in any filter class. If you add a new nullable string field that IS used in a
+    # filter, update StringCriterion.to_q to handle it, then add it here only if
+    # the null=True IS_NULL/NOT_NULL semantics differ from the "" convention.
+    KNOWN_NULLABLE_EXCEPTIONS: frozenset[str] = frozenset(
+        {"GameStatusChange.old_status"}
+    )
+
+    def test_no_nullable_string_fields_in_games_models(self):
+        from django.apps import apps
+        from django.db.models import CharField, TextField
+
+        games_config = apps.get_app_config("games")
+        unexpected_nullable_fields: list[str] = []
+        for model in games_config.get_models():
+            for field in model._meta.get_fields():
+                if isinstance(field, (CharField, TextField)) and field.null:
+                    field_key = f"{model.__name__}.{field.name}"
+                    if field_key not in self.KNOWN_NULLABLE_EXCEPTIONS:
+                        unexpected_nullable_fields.append(field_key)
+
+        assert unexpected_nullable_fields == [], (
+            "Found unexpected nullable string fields in the games app. "
+            "The repo convention is null=False, default='' for all CharField/TextField fields. "
+            "StringCriterion IS_NULL/NOT_NULL matches both NULL and '' — "
+            "if you intentionally add a nullable string field, either update StringCriterion.to_q "
+            "to handle it correctly and add it to KNOWN_NULLABLE_EXCEPTIONS, or reconsider "
+            "whether null=False with default='' would work instead.\n"
+            f"Unexpected nullable fields found: {', '.join(unexpected_nullable_fields)}"
+        )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -131,6 +131,12 @@ class TestStringCriterion:
         assert restored is not None
         assert restored.name == StringCriterion(value="", modifier=Modifier.EQUALS)
 
+    def test_is_null_round_trips_json(self):
+        original = StringCriterion(value="", modifier=Modifier.IS_NULL)
+        restored = StringCriterion.from_json(original.to_json())
+        assert restored == original
+        assert restored.to_q("note") == Q(note__isnull=True) | Q(note__exact="")
+
 
 class TestIntCriterion:
     def test_between(self):
@@ -4418,7 +4424,7 @@ class TestStringFieldNullConvention:
         games_config = apps.get_app_config("games")
         unexpected_nullable_fields: list[str] = []
         for model in games_config.get_models():
-            for field in model._meta.get_fields():
+            for field in model._meta.get_fields():  # get_fields() also returns reverse relations; the isinstance check below filters them out
                 if isinstance(field, (CharField, TextField)) and field.null:
                     field_key = f"{model.__name__}.{field.name}"
                     if field_key not in self.KNOWN_NULLABLE_EXCEPTIONS:


### PR DESCRIPTION
## Problem

The structured filter's `IS_NULL` ("is empty") / `NOT_NULL` ("is set") modifiers returned wrong results for string fields. This repo stores empty strings as `""` (`blank=True, default="", null=False`) — never SQL NULL — but `StringCriterion.to_q` emitted only `Q(field__isnull=True)`, which matches **0 rows** on a `NOT NULL` column. Confirmed on real data: of 2662 sessions, `note__isnull=True` = 0, but `note=""` = 2295. So "is empty" on `note` returned nothing, misleadingly (the user can't see that empties are `""`).

## Fix (`StringCriterion` only)

- `IS_NULL` → `Q(field__isnull=True) | Q(field__exact="")`
- `NOT_NULL` → `~(Q(field__isnull=True) | Q(field__exact=""))` (exact complement; 3VL-safe — `isnull` is a real boolean)

Covers both empty representations, so it's correct for any string-field config (the `isnull` half is a harmless dead branch on the current `null=False` fields, and stays correct if a nullable string is ever added). Numeric/date/bool/choice/multi criteria are untouched — their `isnull`-only handling is correct (`__exact=""` would error on a non-string column).

## Tests
- Updated `TestStringCriterion.test_is_null`/`test_not_null` to the new Q shapes (failed before, pass after).
- Real-queryset behavioral tests (blank-note vs non-empty rows; a partition test proving the two modifiers cover all rows with empty intersection).
- JSON round-trip test for the `IS_NULL` modifier.
- **Convention-guard test** `TestStringFieldNullConvention` — asserts every `CharField`/`TextField` on games models is `null=False`, so a future nullable string fails CI loudly. Allowlists `GameStatusChange.old_status` (legitimately `null=True`, used by no filter).

`make check` green (1393 passed). Independent of #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)