### PR TITLE
Hydrate leaf value widgets on prefill (#263)

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -22,8 +22,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Compute staging name
+        # "github" → "gh": Fly's abuse filter rejects app names containing
+        # "github" (a phishing target), which every claude/github-issue-* branch
+        # would otherwise hit. Keep this sed program identical in all three jobs.
         run: |
-          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-//; s/-$//' | cut -c1-30 | sed 's/-*$//')
+          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/github/gh/g; s/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-//; s/-$//' | cut -c1-30 | sed 's/-*$//')
           APP="timetracker-staging-${SLUG}"
           echo "SLUG=${SLUG}" >> "$GITHUB_ENV"
           echo "APP=${APP}" >> "$GITHUB_ENV"
@@ -79,7 +82,7 @@ jobs:
     steps:
       - name: Compute staging host
         run: |
-          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-//; s/-$//' | cut -c1-30 | sed 's/-*$//')
+          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/github/gh/g; s/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-//; s/-$//' | cut -c1-30 | sed 's/-*$//')
           echo "HOST=timetracker-staging-${SLUG}.fly.dev" >> "$GITHUB_ENV"
 
       - name: Comment staging URL on PR
@@ -122,6 +125,6 @@ jobs:
 
       - name: Destroy staging app
         run: |
-          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-//; s/-$//' | cut -c1-30 | sed 's/-*$//')
+          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/github/gh/g; s/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-//; s/-$//' | cut -c1-30 | sed 's/-*$//')
           APP="timetracker-staging-${SLUG}"
           flyctl apps destroy "$APP" --yes 2>/dev/null || true

--- a/e2e/test_filter_builder_e2e.py
+++ b/e2e/test_filter_builder_e2e.py
@@ -3,40 +3,22 @@
 Covers the full browser lifecycle of the builder page:
   1. All four custom elements load and initialize (filter-group, filter-summary,
      filter-count, filter-builder).
-  2. A prefilled ?filter= seeds the filter-group tree so the summary reflects
-     the criterion field (even though the DOM widget is blank — the tree structure
-     is seeded, the DOM widget value is read live on Apply).
-  3. Clicking Apply navigates to the game list.
+  2. A prefilled ?filter= seeds the filter-group tree AND hydrates each leaf's
+     value widget (#263), so the summary reflects the criterion field and the
+     count/Apply read the prefilled values from the live widgets.
+  3. Clicking Apply navigates to the game list carrying the ?filter=.
   4. Navigating to the game list with ?filter= narrows results via the Django
      backend (tests the round-trip: JSON → GameFilter.to_q() → queryset).
 
 Prefill behavior note:
   The filter-group element deserializes the ?filter= JSON into its internal tree
   on connectedCallback, so ``filter-group.serialize()`` returns the original
-  filter.  However ``serializeForQuery()`` — which Apply and filter-count both
-  call — reads values from the live DOM widgets.  Because widget templates are
-  cloned blank (no value is back-propagated from the deserialized tree into the
-  DOM), serializeForQuery() returns {} for a prefilled filter whose widgets have
-  not been touched.  The count badge therefore shows all games (empty query) and
-  Apply navigates to the plain game-list URL without ?filter=.
-
-  What IS tested end-to-end:
-    - the JS loads and upgrades all four custom elements
-    - the filter-group dispatches filter-tree-change on connect, triggering the
-      summary to render "Games where Status …" (criterion field is known)
-    - the count badge reaches a settled non-"Counting…" state
-    - the Apply button triggers a navigation to /tracker/game/list
-    - navigating directly to /tracker/game/list?filter=<JSON> narrows results
-      on the Django side (round-trip GameFilter JSON test)
-
-Known limitation — tracked in #263:
-  Prefill seeds the filter-group tree structure but does NOT yet hydrate the
-  leaf value widgets.  Therefore ``serializeForQuery()`` reads blank widgets and
-  Apply navigates to the list WITHOUT ``?filter=`` — the prefilled filter is
-  dropped.  The full prefill→Apply→filtered-list round-trip is tested below as a
-  strict xfail (``test_prefill_apply_roundtrip_carries_filter``); when #263 lands
-  and that test unexpectedly passes, the suite will fail — forcing removal of the
-  marker and confirming the fix.
+  filter.  ``serializeForQuery()`` — which Apply and filter-count both call —
+  reads values from the live DOM widgets; since #263 each cloned widget is
+  hydrated from its leaf's stored criterion (``writeLeafWidget``), so a prefilled
+  filter round-trips: the count badge reflects the narrowed query and Apply
+  carries the ``?filter=`` through to the list
+  (``test_prefill_apply_roundtrip_carries_filter``).
 """
 
 import json
@@ -91,9 +73,8 @@ def test_builder_page_elements_load_and_initialize(
     Game.objects.create(name="DoneGame", platform=platform, status="f")
     Game.objects.create(name="PlayGame", platform=platform, status="p")
 
-    # The filter JSON seeds the filter-group tree: status INCLUDES finished ("f").
-    # filter-group.serialize() will reflect this field, even though the DOM widget
-    # is blank (serializeForQuery() reads from widgets, not the stored tree).
+    # The filter JSON seeds the filter-group tree AND the leaf's value widget
+    # (#263 hydration): status INCLUDES finished ("f").
     filter_json = {"status": {"modifier": "INCLUDES", "value": ["f"]}}
     filter_param = _encode_filter(filter_json)
 
@@ -116,22 +97,19 @@ def test_builder_page_elements_load_and_initialize(
     expect(page.locator("filter-summary")).to_contain_text("Games where")
 
     # The count badge fetches from the API and settles (stops showing "Counting…").
-    # It uses serializeForQuery() which returns {} for a blank-widget tree, so
-    # the count reflects all seeded games (both finished and playing).
+    # It uses serializeForQuery(), which reads the hydrated widget (#263), so the
+    # count reflects the prefilled filter: only DoneGame (status=f) matches.
     count_badge = page.locator("filter-count")
     expect(count_badge).not_to_contain_text("Counting…")
-    # The count must be numeric — just not still loading. We don't assert the exact
-    # number since serializeForQuery() returns {} (all games match).
-    expect(count_badge).to_contain_text("≈")
+    expect(count_badge).to_contain_text("≈ 1 game")
 
 
 def test_apply_navigates_to_game_list(authenticated_page: Page, live_server) -> None:
     """Clicking Apply on the builder page triggers navigation to the game list.
 
-    Because serializeForQuery() reads from blank DOM widgets when the filter is
-    seeded only via ?filter=, it returns {} (empty filter) and Apply navigates
-    to the plain game-list URL without ?filter=. This still validates that the
-    Apply button is present, enabled, and wired up correctly."""
+    Validates only that the Apply button is present, enabled, and wired to a
+    navigation; the ?filter= carried by that navigation is asserted separately
+    by test_prefill_apply_roundtrip_carries_filter."""
     page = authenticated_page
 
     platform = Platform.objects.create(name="PC")
@@ -154,8 +132,8 @@ def test_apply_navigates_to_game_list(authenticated_page: Page, live_server) -> 
     with page.expect_navigation():
         page.locator("filter-builder [data-apply]").click()
 
-    # Apply navigates to the game list (with or without ?filter=, depending on
-    # widget state). The path must contain /tracker/game/list.
+    # Apply navigates to the game list; the path must contain /tracker/game/list
+    # (the carried ?filter= is asserted by the round-trip test below).
     current_url = page.url
     assert "/tracker/game/list" in current_url, (
         f"Expected URL to contain '/tracker/game/list', got: {current_url}"
@@ -192,20 +170,14 @@ def test_game_list_filter_narrows_results(
     expect(page.get_by_text("PlayGame")).not_to_be_visible()
 
 
-@pytest.mark.xfail(
-    reason="prefill value-widget hydration not implemented yet — #263",
-    strict=True,
-)
 def test_prefill_apply_roundtrip_carries_filter(
     authenticated_page: Page, live_server
 ) -> None:
-    """The full prefill → Apply → filtered-list round-trip is NOT yet working.
+    """The full prefill → Apply → filtered-list round-trip (#263).
 
-    When #263 lands (leaf value widgets are hydrated from the deserialized tree),
-    serializeForQuery() will read the hydrated values and Apply will carry the
-    ?filter= through to the game list, narrowing results.  Until then this test
-    is expected to fail (strict xfail): if it unexpectedly passes the suite
-    reports XPASS and fails, forcing removal of the marker."""
+    The leaf value widgets are hydrated from the deserialized tree
+    (writeLeafWidget), so serializeForQuery() reads the prefilled values and
+    Apply carries the ?filter= through to the game list, narrowing results."""
     page = authenticated_page
 
     platform = Platform.objects.create(name="PC")
@@ -255,10 +227,8 @@ def test_load_set_field_preset_reflects_field_without_crash(
     ``reflectFieldSelections()``, called after ``replaceChildren()`` so every
     ``<search-select>`` is live.  This test guards that fix at the browser level.
 
-    Asserted boundary: the field picker shows "Game" selected (a pill with the
-    label "Game" appears in the field-picker's pills area) after the preset
-    loads.  Value/modifier hydration is deferred to issue #263 and is NOT
-    asserted here.
+    Asserted boundary: the field picker shows "Game" selected after the preset
+    loads, and the value widget carries the hydrated include pill (#263).
     """
     page = authenticated_page
 
@@ -343,3 +313,12 @@ def test_load_set_field_preset_reflects_field_without_crash(
         "[data-field-picker] [data-search-select-search]"
     )
     expect(field_search_input).to_have_value("Game", timeout=5_000)
+
+    # -- Assertion 4: the value widget is hydrated (#263) --
+    # writeLeafWidget clones an include pill for the preset's {id, label} value
+    # into the FilterSelect's pills area, so the game's name shows as a pill.
+    value_pill = criterion_row.locator(
+        "[data-value-cell] [data-search-select-pills] [data-pill]"
+    )
+    expect(value_pill).to_be_visible(timeout=5_000)
+    expect(value_pill).to_contain_text("SpyGame")

--- a/ts/elements/date-range-picker.ts
+++ b/ts/elements/date-range-picker.ts
@@ -258,22 +258,32 @@ function syncHiddenFromSegments(picker: HTMLElement, side: string): boolean {
   return changed;
 }
 
-/** Push an ISO value (or "") into a side's segments and hidden input. */
-function setSideValue(picker: HTMLElement, side: string, isoString: string): void {
+/** Push an ISO value (or "") into a side's segments and hidden input WITHOUT
+ * dispatching date-range:change — the write half shared with prefill hydration
+ * (#263), which runs on a detached, not-yet-connected clone and must stay
+ * silent. Returns whether the hidden value changed. Null-guarded so partial
+ * markup (synthetic fixtures, malformed ISO) degrades to a no-op, not a throw. */
+export function writeSideValue(picker: HTMLElement, side: string, isoString: string): boolean {
   const hidden = picker.querySelector<HTMLInputElement>(
     `input[data-date-range-hidden="${side}"]`
-  )!;
+  );
+  if (!hidden) return false;
   const previousValue = hidden.value;
   hidden.value = isoString;
   let partValues: Record<string, string> = { year: "", month: "", day: "" };
   if (isoString) {
     const pieces = isoString.split("-");
-    partValues = { year: pieces[0], month: pieces[1], day: pieces[2] };
+    partValues = { year: pieces[0] ?? "", month: pieces[1] ?? "", day: pieces[2] ?? "" };
   }
   segmentsForSide(picker, side).forEach((segment) => {
-    setSegmentBuffer(segment, partValues[segment.dataset.datePart ?? ""]);
+    setSegmentBuffer(segment, partValues[segment.dataset.datePart ?? ""] ?? "");
   });
-  if (hidden.value !== previousValue) dispatchDateRangeChange(picker);
+  return hidden.value !== previousValue;
+}
+
+/** Push an ISO value (or "") into a side's segments and hidden input. */
+function setSideValue(picker: HTMLElement, side: string, isoString: string): void {
+  if (writeSideValue(picker, side, isoString)) dispatchDateRangeChange(picker);
 }
 
 function initField(picker: HTMLElement, calendarState: CalendarState): void {

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -917,3 +917,318 @@ describe("loadFilter with a set field — regression for #196 crash", () => {
     expect(() => document.body.appendChild(group)).not.toThrow();
   });
 });
+
+// ── Prefill hydration of leaf value widgets (#263) ──
+// Loading a filter (preset / ?filter= import) must write each leaf's stored
+// criterion INTO its cloned value widget, because serializeForQuery() reads the
+// live widgets — before #263 a prefilled filter round-tripped as {} (match all).
+// One model with a field of every widget kind, each widget template mirroring the
+// data hooks of its Python builder (StringFilter / NumberFilter / DateRangeField /
+// _bool_control / FilterSelect), plus comparison columns for the comparison leaf.
+const HYDRATION_FIELDS = [
+  {
+    name: "name", label: "Name", kind: "string", nullable: true, choices: [],
+    modifiers: ["EQUALS", "INCLUDES", "IS_NULL"], relations: [], search_url: "", is_m2m: false,
+  },
+  {
+    name: "year", label: "Year", kind: "number", nullable: true, choices: [],
+    modifiers: ["EQUALS", "GREATER_THAN", "BETWEEN", "IS_NULL"], relations: [], search_url: "", is_m2m: false,
+  },
+  {
+    name: "released", label: "Released", kind: "date", nullable: false, choices: [],
+    modifiers: [], relations: [], search_url: "", is_m2m: false,
+  },
+  {
+    name: "mastered", label: "Mastered", kind: "bool", nullable: false, choices: [],
+    modifiers: ["EQUALS"], relations: [], search_url: "", is_m2m: false,
+  },
+  {
+    name: "status", label: "Status", kind: "set", nullable: true,
+    choices: [{ value: "f", label: "Finished" }, { value: "u", label: "Unplayed" }],
+    modifiers: ["INCLUDES", "EXCLUDES"], relations: [], search_url: "", is_m2m: false,
+  },
+];
+const HYDRATION_COLUMNS = [
+  { value: "year_released", label: "Year", group: "number", operators: ["EQUALS", "LESS_THAN"] },
+  { value: "original_year_released", label: "Orig", group: "number", operators: ["EQUALS", "LESS_THAN"] },
+  { value: "created_at", label: "Created", group: "datetime", operators: ["EQUALS", "LESS_THAN"] },
+  { value: "updated_at", label: "Updated", group: "datetime", operators: ["EQUALS", "LESS_THAN"] },
+];
+const HYDRATION_MODELS = JSON.stringify({
+  game: { fields: HYDRATION_FIELDS, columns: HYDRATION_COLUMNS },
+});
+// The per-kind widget templates. Segment inputs carry the dual hidden-input
+// attributes (data-date-range-hidden + data-range-min/max) exactly like
+// DateRangeField; the set widget carries the pill/option/modifier-row markup and
+// the pill <template>s FilterSelect always ships.
+const HYDRATION_TEMPLATES = `
+  <template data-model="game" data-field-picker-template>
+    <div data-field-picker><search-select name="field-picker"><input data-search-select-search /></search-select></div>
+  </template>
+  <template data-model="game" data-field="name">
+    <div class="flex-col">
+      <select data-string-modifier-select>
+        <option value="EQUALS" selected>is</option>
+        <option value="INCLUDES">includes</option>
+        <option value="IS_NULL">is empty</option>
+      </select>
+      <input type="text" />
+    </div>
+  </template>
+  <template data-model="game" data-field="year">
+    <div class="flex-col">
+      <select data-number-modifier-select>
+        <option value="EQUALS" selected>=</option>
+        <option value="GREATER_THAN">&gt;</option>
+        <option value="BETWEEN">between</option>
+        <option value="IS_NULL">is empty</option>
+      </select>
+      <div>
+        <input type="number" />
+        <input type="number" data-number-value2 class="hidden" />
+      </div>
+    </div>
+  </template>
+  <template data-model="game" data-field="released">
+    <div>
+      <input type="hidden" data-date-range-hidden="min" data-range-min />
+      <input type="hidden" data-date-range-hidden="max" data-range-max />
+      <input data-date-side="min" data-date-part="day" maxlength="2" placeholder="dd" />
+      <input data-date-side="min" data-date-part="month" maxlength="2" placeholder="mm" />
+      <input data-date-side="min" data-date-part="year" maxlength="4" placeholder="yyyy" />
+      <input data-date-side="max" data-date-part="day" maxlength="2" placeholder="dd" />
+      <input data-date-side="max" data-date-part="month" maxlength="2" placeholder="mm" />
+      <input data-date-side="max" data-date-part="year" maxlength="4" placeholder="yyyy" />
+    </div>
+  </template>
+  <template data-model="game" data-field="mastered">
+    <div>
+      <label><input type="radio" name="mastered" value="true" />True</label>
+      <label><input type="radio" name="mastered" value="false" />False</label>
+    </div>
+  </template>
+  <template data-model="game" data-field="status">
+    <search-select filter-mode="true">
+      <div data-search-select-pills></div>
+      <input data-search-select-search />
+      <div>
+        <div data-search-select-modifier-option="NOT_NULL" data-label="(Any)">(Any)</div>
+        <div data-search-select-modifier-option="IS_NULL" data-label="(None)">(None)</div>
+        <div data-search-select-option data-value="f" data-label="Finished"><span data-search-select-label>Finished</span></div>
+        <div data-search-select-option data-value="u" data-label="Unplayed"><span data-search-select-label>Unplayed</span></div>
+      </div>
+      <template data-search-select-template="pill-include"><span data-pill data-value="" data-label="" data-search-select-type="include">✓ <span data-search-select-label></span><button data-pill-remove>×</button></span></template>
+      <template data-search-select-template="pill-exclude"><span data-pill data-value="" data-label="" data-search-select-type="exclude">✗ <span data-search-select-label></span><button data-pill-remove>×</button></span></template>
+      <template data-search-select-template="pill-modifier"><span data-pill data-search-select-modifier=""><span data-search-select-label></span><button data-pill-remove>×</button></span></template>
+    </search-select>
+  </template>
+  <template data-model="game" data-fc-row-template>
+    <div data-fc-row>
+      <select data-fc-left>
+        <option value="">column…</option>
+        <option value="year_released">Year</option>
+        <option value="original_year_released">Orig</option>
+        <option value="created_at">Created</option>
+        <option value="updated_at">Updated</option>
+      </select>
+      <select data-fc-op data-selected></select>
+      <select data-fc-right data-selected></select>
+      <label data-fc-granularity-wrap hidden><input type="checkbox" data-fc-granularity /></label>
+      <button data-fc-remove>✕</button>
+    </div>
+  </template>`;
+
+function mountHydration(filter = ""): FilterGroupElement {
+  document.body.innerHTML = "";
+  const host = document.createElement("filter-group") as FilterGroupElement;
+  host.setAttribute("model", "game");
+  host.setAttribute("models", HYDRATION_MODELS);
+  if (filter) host.setAttribute("filter", filter);
+  host.innerHTML = HYDRATION_TEMPLATES;
+  document.body.appendChild(host);
+  return host;
+}
+
+// Mount + loadFilter (the preset path) in one step. The ?filter=-prop path is
+// covered separately — both funnel into deserialize() + render().
+function loadHydration(filter: Record<string, unknown>): FilterGroupElement {
+  const host = mountHydration();
+  host.loadFilter(filter);
+  return host;
+}
+
+function valueCell(host: HTMLElement, path: Path): HTMLElement {
+  return row(host, path).querySelector<HTMLElement>("[data-value-cell]")!;
+}
+
+describe("<filter-group> prefill hydrates leaf value widgets (#263)", () => {
+  it("string: writes modifier + value and round-trips serializeForQuery", () => {
+    const filter = { AND: [{ name: { value: "Hades", modifier: "INCLUDES" } }] };
+    const host = loadHydration(filter);
+    const cell = valueCell(host, [0]);
+    expect(cell.querySelector<HTMLSelectElement>("[data-string-modifier-select]")!.value).toBe("INCLUDES");
+    expect(cell.querySelector<HTMLInputElement>('input[type="text"]')!.value).toBe("Hades");
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("string presence (IS_NULL): disables the text input and round-trips {modifier} only", () => {
+    const filter = { AND: [{ name: { modifier: "IS_NULL" } }] };
+    const host = loadHydration(filter);
+    const input = valueCell(host, [0]).querySelector<HTMLInputElement>('input[type="text"]')!;
+    expect(input.disabled).toBe(true);
+    expect(input.value).toBe("");
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("number GREATER_THAN: writes the value and round-trips", () => {
+    const filter = { AND: [{ year: { value: 1990, modifier: "GREATER_THAN" } }] };
+    const host = loadHydration(filter);
+    const cell = valueCell(host, [0]);
+    expect(cell.querySelector<HTMLInputElement>('input[type="number"]:not([data-number-value2])')!.value).toBe("1990");
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("number BETWEEN: reveals value2, writes both bounds, and round-trips", () => {
+    const filter = { AND: [{ year: { value: 2000, value2: 2010, modifier: "BETWEEN" } }] };
+    const host = loadHydration(filter);
+    const cell = valueCell(host, [0]);
+    const value2 = cell.querySelector<HTMLInputElement>("[data-number-value2]")!;
+    expect(value2.classList.contains("hidden")).toBe(false); // BETWEEN reveals value2
+    expect(value2.value).toBe("2010");
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("date BETWEEN: writes hidden bounds + visible segments and round-trips", () => {
+    const filter = { AND: [{ released: { value: "2020-01-05", value2: "2021-12-31", modifier: "BETWEEN" } }] };
+    const host = loadHydration(filter);
+    const cell = valueCell(host, [0]);
+    expect(cell.querySelector<HTMLInputElement>("[data-range-min]")!.value).toBe("2020-01-05");
+    expect(cell.querySelector<HTMLInputElement>("[data-range-max]")!.value).toBe("2021-12-31");
+    // Segments display the split ISO pieces (what initField adopts at connect).
+    expect(cell.querySelector<HTMLInputElement>('[data-date-side="min"][data-date-part="year"]')!.value).toBe("2020");
+    expect(cell.querySelector<HTMLInputElement>('[data-date-side="min"][data-date-part="day"]')!.value).toBe("05");
+    expect(cell.querySelector<HTMLInputElement>('[data-date-side="max"][data-date-part="month"]')!.value).toBe("12");
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("date LESS_THAN: the single bound fills the max side (min stays empty) and round-trips", () => {
+    const filter = { AND: [{ released: { value: "2021-06-30", modifier: "LESS_THAN" } }] };
+    const host = loadHydration(filter);
+    const cell = valueCell(host, [0]);
+    expect(cell.querySelector<HTMLInputElement>("[data-range-min]")!.value).toBe("");
+    expect(cell.querySelector<HTMLInputElement>("[data-range-max]")!.value).toBe("2021-06-30");
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("bool: checks the matching radio and round-trips", () => {
+    const filter = { AND: [{ mastered: { value: true, modifier: "EQUALS" } }] };
+    const host = loadHydration(filter);
+    const cell = valueCell(host, [0]);
+    expect(cell.querySelector<HTMLInputElement>('input[type="radio"][value="true"]')!.checked).toBe(true);
+    expect(cell.querySelector<HTMLInputElement>('input[type="radio"][value="false"]')!.checked).toBe(false);
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("set: renders include + exclude pills and round-trips", () => {
+    const host = loadHydration({
+      AND: [{
+        status: {
+          value: [{ id: "f", label: "Finished" }],
+          excludes: [{ id: "u", label: "Unplayed" }],
+          modifier: "INCLUDES",
+        },
+      }],
+    });
+    const pills = valueCell(host, [0]).querySelectorAll<HTMLElement>("[data-pill]");
+    expect([...pills].map((pill) => pill.getAttribute("data-search-select-type"))).toEqual([
+      "include",
+      "exclude",
+    ]);
+    expect(pills[0].getAttribute("data-value")).toBe("f");
+    expect(pills[0].textContent).toContain("Finished");
+    expect(host.serializeForQuery()).toEqual({
+      AND: [{
+        status: {
+          value: [{ id: "f", label: "Finished" }],
+          excludes: [{ id: "u", label: "Unplayed" }],
+          modifier: "INCLUDES",
+        },
+      }],
+    });
+  });
+
+  it("set presence modifier: renders the sticky modifier pill and round-trips {modifier} only", () => {
+    const filter = { AND: [{ status: { modifier: "NOT_NULL" } }] };
+    const host = loadHydration(filter);
+    const pill = valueCell(host, [0]).querySelector<HTMLElement>("[data-pill][data-search-select-modifier]")!;
+    expect(pill.getAttribute("data-search-select-modifier")).toBe("NOT_NULL");
+    expect(pill.textContent).toContain("(Any)");
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("set with bare string ids (URL-authored JSON) enriches labels from the option rows", () => {
+    // The e2e prefill fixture shape: {"status": {"modifier": "INCLUDES", "value": ["f"]}}
+    const host = loadHydration({ AND: [{ status: { modifier: "INCLUDES", value: ["f"] } }] });
+    const pill = valueCell(host, [0]).querySelector<HTMLElement>("[data-pill]")!;
+    expect(pill.getAttribute("data-label")).toBe("Finished");
+    expect(host.serializeForQuery()).toEqual({
+      AND: [{
+        status: { value: [{ id: "f", label: "Finished" }], excludes: [], modifier: "INCLUDES" },
+      }],
+    });
+  });
+
+  it("comparison: restores left/operator/right and round-trips", () => {
+    const filter = {
+      AND: [{
+        field_comparisons: [
+          { left: "year_released", right: "original_year_released", modifier: "LESS_THAN" },
+        ],
+      }],
+    };
+    const host = loadHydration(filter);
+    const cell = valueCell(host, [0]);
+    expect(cell.querySelector<HTMLSelectElement>("[data-fc-left]")!.value).toBe("year_released");
+    expect(cell.querySelector<HTMLSelectElement>("[data-fc-op]")!.value).toBe("LESS_THAN");
+    expect(cell.querySelector<HTMLSelectElement>("[data-fc-right]")!.value).toBe("original_year_released");
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("comparison with granularity: restores the by-day toggle and round-trips", () => {
+    const filter = {
+      AND: [{
+        field_comparisons: [
+          { left: "created_at", right: "updated_at", modifier: "LESS_THAN", granularity: "date" },
+        ],
+      }],
+    };
+    const host = loadHydration(filter);
+    const byDay = valueCell(host, [0]).querySelector<HTMLInputElement>("[data-fc-granularity]")!;
+    expect(byDay.checked).toBe(true);
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("hydrates via the ?filter= prop on connect too (the builder-page path)", () => {
+    const filter = { AND: [{ name: { value: "Hades", modifier: "EQUALS" } }] };
+    const host = mountHydration(JSON.stringify(filter));
+    expect(valueCell(host, [0]).querySelector<HTMLInputElement>('input[type="text"]')!.value).toBe("Hades");
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("a user edit after hydration wins and survives a structural re-render", () => {
+    const host = loadHydration({ AND: [{ name: { value: "Hades", modifier: "EQUALS" } }] });
+    typeValue(host, [0], "Celeste");
+    clickAction(host, "add-condition", []); // structural re-render reuses the cached cell
+    expect(row(host, [0]).querySelector<HTMLInputElement>('[data-value-cell] input[type="text"]')!.value).toBe("Celeste");
+    // The new empty leaf is pruned; the edited value — not the hydrated one — serializes.
+    expect(host.serializeForQuery()).toEqual({ AND: [{ name: { value: "Celeste", modifier: "EQUALS" } }] });
+  });
+
+  it("re-picking a different field yields a blank widget (no stale hydration)", () => {
+    const host = loadHydration({ AND: [{ name: { value: "Hades", modifier: "EQUALS" } }] });
+    pickField(host, [0], HYDRATION_FIELDS[1]); // name → year
+    const numberInput = valueCell(host, [0]).querySelector<HTMLInputElement>('input[type="number"]:not([data-number-value2])')!;
+    expect(numberInput.value).toBe("");
+    expect(host.serializeForQuery()).toEqual({}); // incomplete leaf → pruned
+  });
+});

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -948,14 +948,8 @@ const HYDRATION_FIELDS = [
     modifiers: ["INCLUDES", "EXCLUDES"], relations: [], search_url: "", is_m2m: false,
   },
 ];
-const HYDRATION_COLUMNS = [
-  { value: "year_released", label: "Year", group: "number", operators: ["EQUALS", "LESS_THAN"] },
-  { value: "original_year_released", label: "Orig", group: "number", operators: ["EQUALS", "LESS_THAN"] },
-  { value: "created_at", label: "Created", group: "datetime", operators: ["EQUALS", "LESS_THAN"] },
-  { value: "updated_at", label: "Updated", group: "datetime", operators: ["EQUALS", "LESS_THAN"] },
-];
 const HYDRATION_MODELS = JSON.stringify({
-  game: { fields: HYDRATION_FIELDS, columns: HYDRATION_COLUMNS },
+  game: { fields: HYDRATION_FIELDS, columns: COLUMNS },
 });
 // The per-kind widget templates. Segment inputs carry the dual hidden-input
 // attributes (data-date-range-hidden + data-range-min/max) exactly like
@@ -1120,6 +1114,32 @@ describe("<filter-group> prefill hydrates leaf value widgets (#263)", () => {
     expect(host.serializeForQuery()).toEqual(filter);
   });
 
+  it("date EQUALS: hydrates as the exactly-equivalent same-day range", () => {
+    // DateCriterion EQUALS(d) and BETWEEN(d, d) compile to the same rows
+    // (criteria.py — every datetime field filters via a __date lookup), so the
+    // min/max widget represents EQUALS as d..d and serializes BETWEEN.
+    const host = loadHydration({ AND: [{ released: { value: "2020-01-05", modifier: "EQUALS" } }] });
+    const cell = valueCell(host, [0]);
+    expect(cell.querySelector<HTMLInputElement>("[data-range-min]")!.value).toBe("2020-01-05");
+    expect(cell.querySelector<HTMLInputElement>("[data-range-max]")!.value).toBe("2020-01-05");
+    expect(host.serializeForQuery()).toEqual({
+      AND: [{ released: { value: "2020-01-05", value2: "2020-01-05", modifier: "BETWEEN" } }],
+    });
+  });
+
+  it("date NOT_BETWEEN: hydrates blank (pruned) instead of rewriting to the complement range", () => {
+    // NOT_BETWEEN is two open rays — no faithful min/max form. Writing the
+    // bounds would read back as BETWEEN (the exact complement), so the widget
+    // stays blank and the leaf prunes, like before hydration existed.
+    const host = loadHydration({
+      AND: [{ released: { value: "2020-01-01", value2: "2020-12-31", modifier: "NOT_BETWEEN" } }],
+    });
+    const cell = valueCell(host, [0]);
+    expect(cell.querySelector<HTMLInputElement>("[data-range-min]")!.value).toBe("");
+    expect(cell.querySelector<HTMLInputElement>("[data-range-max]")!.value).toBe("");
+    expect(host.serializeForQuery()).toEqual({});
+  });
+
   it("bool: checks the matching radio and round-trips", () => {
     const filter = { AND: [{ mastered: { value: true, modifier: "EQUALS" } }] };
     const host = loadHydration(filter);
@@ -1130,7 +1150,7 @@ describe("<filter-group> prefill hydrates leaf value widgets (#263)", () => {
   });
 
   it("set: renders include + exclude pills and round-trips", () => {
-    const host = loadHydration({
+    const filter = {
       AND: [{
         status: {
           value: [{ id: "f", label: "Finished" }],
@@ -1138,7 +1158,8 @@ describe("<filter-group> prefill hydrates leaf value widgets (#263)", () => {
           modifier: "INCLUDES",
         },
       }],
-    });
+    };
+    const host = loadHydration(filter);
     const pills = valueCell(host, [0]).querySelectorAll<HTMLElement>("[data-pill]");
     expect([...pills].map((pill) => pill.getAttribute("data-search-select-type"))).toEqual([
       "include",
@@ -1146,13 +1167,33 @@ describe("<filter-group> prefill hydrates leaf value widgets (#263)", () => {
     ]);
     expect(pills[0].getAttribute("data-value")).toBe("f");
     expect(pills[0].textContent).toContain("Finished");
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("set EXCLUDES: values hydrate as exclude pills, never inverted into includes", () => {
+    // {modifier: EXCLUDES, value: [X]} compiles to exactly ~Q(field__in=[X]) —
+    // identical to INCLUDES + excludes (criteria.py _value_q/to_q) — so the
+    // widget's exclude channel is the faithful representation.
+    const host = loadHydration({ AND: [{ status: { modifier: "EXCLUDES", value: ["f"] } }] });
+    const pill = valueCell(host, [0]).querySelector<HTMLElement>("[data-pill]")!;
+    expect(pill.getAttribute("data-search-select-type")).toBe("exclude");
+    expect(pill.getAttribute("data-label")).toBe("Finished");
     expect(host.serializeForQuery()).toEqual({
       AND: [{
-        status: {
-          value: [{ id: "f", label: "Finished" }],
-          excludes: [{ id: "u", label: "Unplayed" }],
-          modifier: "INCLUDES",
-        },
+        status: { value: [], excludes: [{ id: "f", label: "Finished" }], modifier: "INCLUDES" },
+      }],
+    });
+  });
+
+  it("set: a control character in a URL-authored id neither throws nor aborts the render", () => {
+    // A raw newline in a CSS string is a parse error; the option-row label
+    // lookup must escape it (CSS.escape), not crash the whole builder page.
+    const host = loadHydration({ AND: [{ status: { modifier: "INCLUDES", value: ["f\nx"] } }] });
+    const pill = valueCell(host, [0]).querySelector<HTMLElement>("[data-pill]")!;
+    expect(pill.getAttribute("data-value")).toBe("f\nx");
+    expect(host.serializeForQuery()).toEqual({
+      AND: [{
+        status: { value: [{ id: "f\nx", label: "f\nx" }], excludes: [], modifier: "INCLUDES" },
       }],
     });
   });
@@ -1230,5 +1271,32 @@ describe("<filter-group> prefill hydrates leaf value widgets (#263)", () => {
     const numberInput = valueCell(host, [0]).querySelector<HTMLInputElement>('input[type="number"]:not([data-number-value2])')!;
     expect(numberInput.value).toBe("");
     expect(host.serializeForQuery()).toEqual({}); // incomplete leaf → pruned
+  });
+
+  it("string: an untrimmed stored value hydrates trimmed, matching the read side", () => {
+    const host = loadHydration({ AND: [{ name: { value: " Hades ", modifier: "EQUALS" } }] });
+    expect(valueCell(host, [0]).querySelector<HTMLInputElement>('input[type="text"]')!.value).toBe("Hades");
+    expect(host.serializeForQuery()).toEqual({ AND: [{ name: { value: "Hades", modifier: "EQUALS" } }] });
+  });
+
+  it("duplicate copies the leaf's CURRENT value, not the stale prefill snapshot", () => {
+    const host = loadHydration({ AND: [{ name: { value: "Hades", modifier: "EQUALS" } }] });
+    typeValue(host, [0], "Celeste"); // live edit — the stored tree still says "Hades"
+    clickAction(host, "duplicate", [0]);
+    expect(host.serializeForQuery()).toEqual({
+      AND: [
+        { name: { value: "Celeste", modifier: "EQUALS" } },
+        { name: { value: "Celeste", modifier: "EQUALS" } },
+      ],
+    });
+  });
+
+  it("duplicate after clearing a prefilled value stays blank (deleted values never resurrect)", () => {
+    const host = loadHydration({ AND: [{ name: { value: "Hades", modifier: "EQUALS" } }] });
+    typeValue(host, [0], ""); // the user deletes the prefilled value
+    clickAction(host, "duplicate", [0]);
+    const inputs = [...host.querySelectorAll<HTMLInputElement>('[data-value-cell] input[type="text"]')];
+    expect(inputs.map((input) => input.value)).toEqual(["", ""]);
+    expect(host.serializeForQuery()).toEqual({}); // both leaves incomplete → pruned
   });
 });

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -493,7 +493,7 @@ export class FilterGroupElement extends HTMLElement {
   private readLeaf(node: CriterionLeaf, model: string): Record<string, unknown> | null {
     const meta = this.bundle(model)?.fields.get(node.field);
     const cells = this.rowCache.get(node.id);
-    if (!meta || !cells) return null;
+    if (!meta || meta.kind === "relation" || !cells) return null;
     return readLeafWidget(cells.valueCell, meta.kind);
   }
 
@@ -562,7 +562,11 @@ export class FilterGroupElement extends HTMLElement {
         this.tree = removeAt(this.tree, path);
         break;
       case "duplicate":
-        this.tree = duplicateAt(this.tree, path);
+        // Duplicate what the user SEES: fill every leaf's stored payload from
+        // its live widget first, so the copy hydrates from current values
+        // rather than the deserialize-time snapshot (which would resurrect
+        // prefilled values the user has since edited or removed, #263 review).
+        this.tree = duplicateAt(this.fillCriteria(this.tree, this.model), path);
         break;
       case "wrap":
         if (canWrap(this.tree, path)) this.tree = wrapInGroup(this.tree, path);
@@ -929,7 +933,15 @@ export class FilterGroupElement extends HTMLElement {
       this.uniquify(clone);
       cell.appendChild(clone);
       const kind = this.bundle(model)?.fields.get(field)?.kind;
-      if (kind) writeLeafWidget(cell, kind, criterion);
+      if (kind && kind !== "relation") {
+        try {
+          writeLeafWidget(cell, kind, criterion);
+        } catch (error) {
+          // Fail open: a hydration bug on one leaf degrades to a blank widget
+          // (the pre-hydration behavior), never an aborted page render.
+          console.warn("filter-group: leaf hydration failed", error);
+        }
+      }
     }
     return cell;
   }

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -66,7 +66,7 @@ import {
   readComparisonRow,
   refreshRow,
 } from "./field-comparison-set.js";
-import { readLeafWidget, setupModifierToggles } from "./filter-widgets.js";
+import { readLeafWidget, setupModifierToggles, writeLeafWidget } from "./filter-widgets.js";
 import type { SearchSelectChangeDetail } from "./search-select.js";
 
 // Full, static class strings only — Tailwind detects complete strings, so the
@@ -871,7 +871,12 @@ export class FilterGroupElement extends HTMLElement {
       this.rowCache.set(node.id, cells);
     }
     if (cells.field !== node.field) {
-      cells.valueCell = this.buildValueCell(node.field, model);
+      // First build for this field: hydrate the fresh clone from the node's
+      // stored payload (#263) — non-empty only on a preset load / ?filter=
+      // import (a user field-pick resets the criterion to just its default
+      // modifier). Later renders reuse the cell, so a hydrated value is never
+      // re-written over live user edits.
+      cells.valueCell = this.buildValueCell(node.field, model, node.criterion);
       cells.field = node.field;
     }
     return cells;
@@ -899,9 +904,16 @@ export class FilterGroupElement extends HTMLElement {
     searchSelect?.setSelected(field, label);
   }
 
-  // Build a value cell for `field`: a clone of the field's blank widget template,
-  // or a placeholder prompt when no field is chosen yet.
-  private buildValueCell(field: string, model: string): HTMLElement {
+  // Build a value cell for `field`: a clone of the field's blank widget template
+  // hydrated from `criterion` (the write-mirror of the serialize-time read, #263),
+  // or a placeholder prompt when no field is chosen yet. Hydration is plain DOM
+  // writing that works on this detached clone — no custom-element upgrade needed
+  // (unlike the field-picker's setSelected, deferred to reflectFieldSelections).
+  private buildValueCell(
+    field: string,
+    model: string,
+    criterion: Record<string, unknown> = {},
+  ): HTMLElement {
     if (!field) {
       const placeholder = element("div", VALUE_PLACEHOLDER_CLASS);
       placeholder.dataset.valueCell = "";
@@ -916,6 +928,8 @@ export class FilterGroupElement extends HTMLElement {
       const clone = content.cloneNode(true) as HTMLElement;
       this.uniquify(clone);
       cell.appendChild(clone);
+      const kind = this.bundle(model)?.fields.get(field)?.kind;
+      if (kind) writeLeafWidget(cell, kind, criterion);
     }
     return cell;
   }
@@ -951,13 +965,13 @@ export class FilterGroupElement extends HTMLElement {
   private comparisonCells(node: ComparisonLeaf, model: string): HTMLElement {
     let cell = this.comparisonCache.get(node.id);
     if (!cell) {
-      cell = this.buildComparisonCell(model);
+      cell = this.buildComparisonCell(model, node.comparison);
       this.comparisonCache.set(node.id, cell);
     }
     return cell;
   }
 
-  private buildComparisonCell(model: string): HTMLElement {
+  private buildComparisonCell(model: string, comparison: ComparisonPayload): HTMLElement {
     const cell = element("div", VALUE_CELL_CLASS);
     cell.dataset.valueCell = "";
     const bundle = this.bundle(model);
@@ -968,12 +982,34 @@ export class FilterGroupElement extends HTMLElement {
       row.querySelector("[data-fc-remove]")?.remove(); // the group's controls own removal
       this.uniquify(row);
       cell.appendChild(row);
-      refreshRow(row, columns); // seed operator/right options from the (blank) left
+      this.seedComparisonRow(row, comparison); // hydrate a prefilled payload (#263)
+      refreshRow(row, columns); // seed operator/right options from the left column
       row
         .querySelector<HTMLSelectElement>("[data-fc-left]")
         ?.addEventListener("change", () => refreshRow(row, columns));
     }
     return cell;
+  }
+
+  // Seed a freshly-cloned comparison row from a stored payload (preset load /
+  // ?filter= import) via the row's server-prefill contract: the left column is a
+  // plain select value (the template ships the full option set), while operator +
+  // right column go through `data-selected`, which the refreshRow call right
+  // after this adopts on first paint (it rebuilds their options from the left
+  // column). Granularity pre-checks the by-day toggle; refreshRow unchecks it
+  // when the left column turns out non-datetime.
+  private seedComparisonRow(row: HTMLElement, comparison: ComparisonPayload): void {
+    const { left, right, modifier, granularity } = comparison;
+    if (left) {
+      const leftSelect = row.querySelector<HTMLSelectElement>("[data-fc-left]");
+      if (leftSelect) leftSelect.value = left;
+    }
+    if (modifier) row.querySelector("[data-fc-op]")?.setAttribute("data-selected", modifier);
+    if (right) row.querySelector("[data-fc-right]")?.setAttribute("data-selected", right);
+    if (granularity === "date") {
+      const byDay = row.querySelector<HTMLInputElement>("[data-fc-granularity]");
+      if (byDay) byDay.checked = true;
+    }
   }
 
   // Suffix every id/for/name in a cloned subtree so repeated clones stay valid HTML

--- a/ts/elements/filter-tree/operations.test.ts
+++ b/ts/elements/filter-tree/operations.test.ts
@@ -508,6 +508,18 @@ describe("add-criterion field picker contract (#191)", () => {
       ).toBe(false);
     });
 
+    it("treats an excludes-only set as complete (a meaningful NOT-IN filter)", () => {
+      expect(
+        isCriterionComplete({
+          kind: "criterion",
+          id: "c",
+          field:"platform",
+          criterion: { modifier: "INCLUDES", value: [], excludes: [{ id: "2", label: "Switch" }] },
+          negate: false,
+        }),
+      ).toBe(true);
+    });
+
     it("requires both bounds for a range modifier (#192)", () => {
       const halfBetween: CriterionLeaf = {
         kind: "criterion",

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -90,17 +90,22 @@ function isValuePresent(value: unknown): boolean {
 
 // Whether a leaf is complete enough to query/apply: it needs a field, a modifier,
 // and a non-empty value — UNLESS the modifier is a presence test (IS_NULL /
-// NOT_NULL), which is value-less by design. A range modifier (BETWEEN / NOT_BETWEEN)
-// additionally needs the second bound `value2`: a half-filled BETWEEN serializes to a
-// payload the backend rejects *wholesale* (`IntCriterion.to_q` raises FilterError when
-// value2 is None, and `filter_from_json` validates eagerly — so one bad leaf drops the
-// entire filter). Excluding it here keeps it out of both the count query and Apply.
+// NOT_NULL), which is value-less by design, or the payload carries a non-empty
+// set `excludes` list (an excludes-only set is a meaningful ~Q(field__in=…) with
+// no include half — same phrasing exception summary.ts makes). A range modifier
+// (BETWEEN / NOT_BETWEEN) additionally needs the second bound `value2`: a
+// half-filled BETWEEN serializes to a payload the backend rejects *wholesale*
+// (`IntCriterion.to_q` raises FilterError when value2 is None, and
+// `filter_from_json` validates eagerly — so one bad leaf drops the entire
+// filter). Excluding it here keeps it out of both the count query and Apply.
 export function isCriterionComplete(leaf: CriterionLeaf): boolean {
   if (!leaf.field) return false;
   const modifier = leaf.criterion["modifier"];
   if (typeof modifier !== "string" || modifier === "") return false;
   if (isPresenceModifier(modifier)) return true;
-  if (!isValuePresent(leaf.criterion["value"])) return false;
+  if (!isValuePresent(leaf.criterion["value"])) {
+    return !isRangeModifier(modifier) && isValuePresent(leaf.criterion["excludes"]);
+  }
   if (isRangeModifier(modifier) && !isValuePresent(leaf.criterion["value2"])) return false;
   return true;
 }

--- a/ts/elements/filter-tree/summary.ts
+++ b/ts/elements/filter-tree/summary.ts
@@ -193,8 +193,8 @@ function renderCriterion(leaf: CriterionLeaf, model: SummaryModel | undefined): 
   const meta = model?.fields.get(leaf.field);
   const label = meta?.label ?? leaf.field;
   const modifier = String(leaf.criterion["modifier"] ?? "");
-  // Sets gate on include-OR-exclude presence, not isCriterionComplete (which only
-  // inspects `value` and would call an excludes-only set incomplete).
+  // Sets gate on include-OR-exclude presence, not isCriterionComplete (sets
+  // phrase includes and excludes separately, so the gate stays set-shaped).
   if (meta?.kind === "set") {
     if (!setHasSelection(leaf.criterion, modifier)) return `${label} ${PLACEHOLDER}`;
     if (isPresenceModifier(modifier)) return `${label} ${MODIFIER_PHRASES[modifier] ?? modifier}`;
@@ -218,8 +218,7 @@ function renderCriterion(leaf: CriterionLeaf, model: SummaryModel | undefined): 
 // A set is worth rendering once it has a modifier and any selection (included,
 // excluded, or a presence test). Like buildSetCriterion's "included OR excluded"
 // non-null condition, but stricter: summary also requires a modifier (there is
-// nothing to phrase without one). Distinct from isCriterionComplete's value-only
-// check, which would reject an excludes-only set.
+// nothing to phrase without one).
 function setHasSelection(criterion: CriterionLeaf["criterion"], modifier: string): boolean {
   if (!modifier) return false;
   if (isPresenceModifier(modifier)) return true;

--- a/ts/elements/filter-widgets.ts
+++ b/ts/elements/filter-widgets.ts
@@ -6,7 +6,7 @@
  * widget contract the bars produce via the Python `field_widget` builder (#242).
  */
 import { isPresenceModifier, isRangeModifier } from "./filter-tokens.js";
-import { readFilterSelect } from "./search-select.js";
+import { cssEscape, readFilterSelect } from "./search-select.js";
 
 export interface Criterion {
   value: unknown;
@@ -218,4 +218,235 @@ export function setupModifierToggles(root: HTMLElement): void {
       toggleNumberFilterInput(target as HTMLSelectElement);
     }
   });
+}
+
+// ── Per-kind writers: the write-mirror of the readers above (issue #263) ──
+// Hydrate a freshly-cloned blank widget from a leaf's stored criterion payload
+// (preset load / ?filter= import), so serializeForQuery() — which reads the LIVE
+// widgets — round-trips the prefilled values instead of dropping them. Each
+// writer mirrors its server-side `_*_from_field` decode (common/components/
+// filters.py). All writes are silent (no input/change events): hydration runs on
+// a detached clone mid-render, and an event would reach the filter-group's
+// delegated onValueEvent once attached — so the modifier toggle helpers are
+// called directly instead of relying on the delegated change listener.
+
+// Select `modifier` in a modifier <select> — only when a matching <option>
+// exists, so a malformed stored modifier can't clobber the default selection.
+function selectModifier(select: HTMLSelectElement | null, modifier: unknown): void {
+  if (!select || typeof modifier !== "string" || modifier === "") return;
+  const match = [...select.options].some((option) => option.value === modifier);
+  if (match) select.value = modifier;
+}
+
+function scalarToInputValue(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  return String(value);
+}
+
+export function writeStringWidget(element: HTMLElement, criterion: Record<string, unknown>): void {
+  const select = element.querySelector<HTMLSelectElement>("select[data-string-modifier-select]");
+  selectModifier(select, criterion["modifier"]);
+  if (select) toggleStringFilterInput(select);
+  const modifier = select?.value ?? "EQUALS";
+  if (isPresenceModifier(modifier)) return; // presence carries no value; input stays disabled+empty
+  const textInput = element.querySelector<HTMLInputElement>('input[type="text"]');
+  const value = scalarToInputValue(criterion["value"]);
+  if (textInput && value !== "") textInput.value = value;
+}
+
+export function writeNumberWidget(element: HTMLElement, criterion: Record<string, unknown>): void {
+  const select = element.querySelector<HTMLSelectElement>("select[data-number-modifier-select]");
+  selectModifier(select, criterion["modifier"]);
+  if (select) toggleNumberFilterInput(select); // reveals value2 for BETWEEN, disables for presence
+  const modifier = select?.value ?? "EQUALS";
+  if (isPresenceModifier(modifier)) return;
+  const valueInput = element.querySelector<HTMLInputElement>(
+    'input[type="number"]:not([data-number-value2])',
+  );
+  const value = scalarToInputValue(criterion["value"]);
+  if (valueInput && value !== "") valueInput.value = value;
+  if (!isRangeModifier(modifier)) return;
+  const value2Marker = element.querySelector("[data-number-value2]");
+  const value2Input =
+    value2Marker instanceof HTMLInputElement
+      ? value2Marker
+      : (value2Marker?.querySelector<HTMLInputElement>("input") ?? null);
+  const value2 = scalarToInputValue(criterion["value2"]);
+  if (value2Input && value2 !== "") value2Input.value = value2;
+}
+
+// Write one side's hidden input + visible segments. The segments get the split
+// ISO pieces exactly as the server pre-renders them; the date-range element's
+// initField (which runs at connect — always AFTER this detached write) adopts
+// the segment values into its typed-digit buffers, so display and editing state
+// match a server-side prefill.
+function writeDateSide(element: HTMLElement, side: "min" | "max", isoString: string): void {
+  const hidden = element.querySelector<HTMLInputElement>(
+    side === "min" ? "[data-range-min]" : "[data-range-max]",
+  );
+  if (hidden) hidden.value = isoString;
+  if (!isoString) return;
+  const [year = "", month = "", day = ""] = isoString.split("-");
+  const partValues: Record<string, string> = { year, month, day };
+  element
+    .querySelectorAll<HTMLInputElement>(`input[data-date-side="${side}"][data-date-part]`)
+    .forEach((segment) => {
+      segment.value = partValues[segment.dataset.datePart ?? ""] ?? "";
+    });
+}
+
+// Mirrors _range_from_field: a one-sided range stores its single bound in
+// `value` regardless of side, so the modifier decides which slot it fills
+// (LESS_THAN → max, GREATER_THAN → min); only BETWEEN carries value + value2.
+export function writeDateWidget(element: HTMLElement, criterion: Record<string, unknown>): void {
+  const value = scalarToInputValue(criterion["value"]);
+  const value2 = scalarToInputValue(criterion["value2"]);
+  const isLessThan = criterion["modifier"] === "LESS_THAN";
+  writeDateSide(element, "min", isLessThan ? "" : value);
+  writeDateSide(element, "max", isLessThan ? value : value2);
+}
+
+// Mirrors _bool_from_field's coercion (string "true"/"1"/"yes" and friends).
+export function writeBoolWidget(element: HTMLElement, criterion: Record<string, unknown>): void {
+  const raw = criterion["value"];
+  if (raw === undefined || raw === null) return;
+  let value: boolean;
+  if (typeof raw === "string") {
+    const lowered = raw.toLowerCase();
+    if (["true", "1", "yes"].includes(lowered)) value = true;
+    else if (["false", "0", "no"].includes(lowered)) value = false;
+    else value = Boolean(raw);
+  } else {
+    value = Boolean(raw);
+  }
+  const radio = element.querySelector<HTMLInputElement>(
+    `input[type="radio"][value="${value ? "true" : "false"}"]`,
+  );
+  if (radio) radio.checked = true;
+}
+
+// Clone one of the <search-select>'s own pill <template> prototypes (the same
+// ones its click handlers clone), so hydrated pills are byte-identical to
+// user-added ones — readFilterSelect and the delegated ×-remove listener treat
+// them exactly the same, and no element upgrade is needed.
+function cloneSetPillTemplate(searchSelect: HTMLElement, templateName: string): HTMLElement | null {
+  const template = searchSelect.querySelector<HTMLTemplateElement>(
+    `template[data-search-select-template="${templateName}"]`,
+  );
+  const clone = template?.content.firstElementChild?.cloneNode(true);
+  return clone instanceof HTMLElement ? clone : null;
+}
+
+function setPillLabel(pill: HTMLElement, label: string): void {
+  const slot = pill.querySelector("[data-search-select-label]");
+  if (slot) slot.textContent = label;
+}
+
+// The label a value id shows on its pill: the stored label when the payload
+// carries {id, label} entries, else the pre-rendered option row's label, else
+// the id itself (mirrors _extract_labeled's bare-value fallback).
+function normalizePillEntries(raw: unknown, searchSelect: HTMLElement): PillEntry[] {
+  if (!Array.isArray(raw)) return [];
+  const entries: PillEntry[] = [];
+  for (const item of raw) {
+    let id: string;
+    let label = "";
+    if (item !== null && typeof item === "object") {
+      const record = item as { id?: unknown; label?: unknown };
+      if (record.id === undefined || record.id === null) continue;
+      id = String(record.id);
+      if (typeof record.label === "string") label = record.label;
+    } else if (typeof item === "string" || typeof item === "number") {
+      id = String(item);
+    } else {
+      continue;
+    }
+    if (!label) {
+      const optionRow = searchSelect.querySelector<HTMLElement>(
+        `[data-search-select-option][data-value="${cssEscape(id)}"]`,
+      );
+      label = optionRow?.getAttribute("data-label") || id;
+    }
+    entries.push({ id, label });
+  }
+  return entries;
+}
+
+function appendValuePill(
+  searchSelect: HTMLElement,
+  pills: HTMLElement,
+  entry: PillEntry,
+  kind: "include" | "exclude",
+): void {
+  const pill = cloneSetPillTemplate(searchSelect, kind === "include" ? "pill-include" : "pill-exclude");
+  if (!pill) return;
+  pill.setAttribute("data-value", entry.id);
+  pill.setAttribute("data-label", entry.label);
+  setPillLabel(pill, entry.label);
+  pills.appendChild(pill);
+}
+
+// Tree set writer — the mirror of readTreeSetWidget/_choice_from_raw: `value`
+// entries become include pills, `excludes` exclude pills, and a modifier that
+// matches one of the widget's pinned modifier rows becomes the sticky modifier
+// pill (INCLUDES/EXCLUDES have no pinned row and no pill — the read side
+// defaults to INCLUDES). A presence modifier excludes value pills entirely.
+export function writeTreeSetWidget(valueCell: HTMLElement, criterion: Record<string, unknown>): void {
+  const searchSelect = valueCell.querySelector<HTMLElement>("search-select");
+  const pills = searchSelect?.querySelector<HTMLElement>("[data-search-select-pills]");
+  if (!searchSelect || !pills) return;
+  const modifier = typeof criterion["modifier"] === "string" ? criterion["modifier"] : "";
+  const modifierRow = modifier
+    ? searchSelect.querySelector<HTMLElement>(
+        `[data-search-select-modifier-option="${cssEscape(modifier)}"]`,
+      )
+    : null;
+  if (modifierRow) {
+    const pill = cloneSetPillTemplate(searchSelect, "pill-modifier");
+    if (pill) {
+      pill.setAttribute("data-search-select-modifier", modifier);
+      setPillLabel(pill, modifierRow.getAttribute("data-label") ?? modifier);
+      pills.insertBefore(pill, pills.firstChild);
+      searchSelect.setAttribute("data-modifier", modifier);
+    }
+  }
+  if (isPresenceModifier(modifier)) return; // presence is mutually exclusive with value pills
+  for (const entry of normalizePillEntries(criterion["value"], searchSelect)) {
+    appendValuePill(searchSelect, pills, entry, "include");
+  }
+  for (const entry of normalizePillEntries(criterion["excludes"], searchSelect)) {
+    appendValuePill(searchSelect, pills, entry, "exclude");
+  }
+}
+
+// Write one leaf value cell from a criterion payload by kind — the write-mirror
+// of readLeafWidget, called by the nested builder when it clones a value widget
+// for a leaf that already carries a payload (preset load / ?filter= import).
+// A fresh user field-pick carries only {modifier: firstModifier}, on which every
+// writer is an idempotent no-op beyond selecting the already-default modifier.
+export function writeLeafWidget(
+  valueCell: HTMLElement,
+  kind: string,
+  criterion: Record<string, unknown>,
+): void {
+  if (Object.keys(criterion).length === 0) return;
+  switch (kind) {
+    case "string":
+      writeStringWidget(valueCell, criterion);
+      break;
+    case "number":
+      writeNumberWidget(valueCell, criterion);
+      break;
+    case "date":
+      writeDateWidget(valueCell, criterion);
+      break;
+    case "bool":
+      writeBoolWidget(valueCell, criterion);
+      break;
+    case "set":
+      writeTreeSetWidget(valueCell, criterion);
+      break;
+    default:
+      break;
+  }
 }

--- a/ts/elements/filter-widgets.ts
+++ b/ts/elements/filter-widgets.ts
@@ -5,8 +5,10 @@
  * #192). Extracted verbatim from filter-bar.ts so the tree reuses the exact same
  * widget contract the bars produce via the Python `field_widget` builder (#242).
  */
+import type { LeafWidgetKind } from "../generated/filter-metadata.js";
+import { writeSideValue } from "./date-range-picker.js";
 import { isPresenceModifier, isRangeModifier } from "./filter-tokens.js";
-import { cssEscape, readFilterSelect } from "./search-select.js";
+import { readFilterSelect, writeFilterSelect } from "./search-select.js";
 
 export interface Criterion {
   value: unknown;
@@ -31,6 +33,14 @@ export function parseNumberInputValue(element: HTMLInputElement | null): number 
   if (!element || element.value === "") return "";
   const value = parseFloat(element.value);
   return isNaN(value) ? "" : value;
+}
+
+// The value2 slot's [data-number-value2] marker may be the input itself or a
+// wrapper around one — the single lookup shared by the reader and the writer.
+function resolveValue2Input(element: HTMLElement): HTMLInputElement | null {
+  const marker = element.querySelector("[data-number-value2]");
+  if (marker instanceof HTMLInputElement) return marker;
+  return marker?.querySelector<HTMLInputElement>("input") ?? null;
 }
 
 export function buildRangeCriterion(
@@ -82,12 +92,7 @@ export function readNumberWidget(element: HTMLElement): Criterion | Record<strin
     element.querySelector<HTMLInputElement>('input[type="number"]:not([data-number-value2])'),
   );
   if (isRangeModifier(modifier)) {
-    const value2Marker = element.querySelector('[data-number-value2]');
-    const value2Input =
-      value2Marker instanceof HTMLInputElement
-        ? value2Marker
-        : (value2Marker?.querySelector<HTMLInputElement>("input") ?? null);
-    const value2 = parseNumberInputValue(value2Input);
+    const value2 = parseNumberInputValue(resolveValue2Input(element));
     if (value !== "") return criterion(value, value2, modifier);
     return null;
   }
@@ -150,7 +155,10 @@ export function readTreeSetWidget(valueCell: HTMLElement): Record<string, unknow
 // Read one leaf value cell into a criterion payload by kind — the nested builder's
 // entry point. For `set` it self-serializes; for the scalar kinds it reuses the
 // shared readers. Returns null when the widget carries no usable value (incomplete).
-export function readLeafWidget(valueCell: HTMLElement, kind: string): Record<string, unknown> | null {
+export function readLeafWidget(
+  valueCell: HTMLElement,
+  kind: LeafWidgetKind,
+): Record<string, unknown> | null {
   switch (kind) {
     case "string":
       return readStringWidget(valueCell);
@@ -162,8 +170,14 @@ export function readLeafWidget(valueCell: HTMLElement, kind: string): Record<str
       return readBoolWidget(valueCell) as Record<string, unknown> | null;
     case "set":
       return readTreeSetWidget(valueCell);
-    default:
-      return null;
+    case "field-comparison":
+      return null; // comparison leaves are read by readComparisonRow, not here
+    default: {
+      // Exhaustive over LeafWidgetKind: a new widget kind fails tsc here until
+      // it gets BOTH a reader case and a writeLeafWidget case (see below).
+      const unhandled: never = kind;
+      return unhandled;
+    }
   }
 }
 
@@ -250,7 +264,8 @@ export function writeStringWidget(element: HTMLElement, criterion: Record<string
   const modifier = select?.value ?? "EQUALS";
   if (isPresenceModifier(modifier)) return; // presence carries no value; input stays disabled+empty
   const textInput = element.querySelector<HTMLInputElement>('input[type="text"]');
-  const value = scalarToInputValue(criterion["value"]);
+  // Trimmed like the read side (readStringWidget), so hydrate → serialize is stable.
+  const value = scalarToInputValue(criterion["value"]).trim();
   if (textInput && value !== "") textInput.value = value;
 }
 
@@ -266,44 +281,45 @@ export function writeNumberWidget(element: HTMLElement, criterion: Record<string
   const value = scalarToInputValue(criterion["value"]);
   if (valueInput && value !== "") valueInput.value = value;
   if (!isRangeModifier(modifier)) return;
-  const value2Marker = element.querySelector("[data-number-value2]");
-  const value2Input =
-    value2Marker instanceof HTMLInputElement
-      ? value2Marker
-      : (value2Marker?.querySelector<HTMLInputElement>("input") ?? null);
+  const value2Input = resolveValue2Input(element);
   const value2 = scalarToInputValue(criterion["value2"]);
   if (value2Input && value2 !== "") value2Input.value = value2;
 }
 
-// Write one side's hidden input + visible segments. The segments get the split
-// ISO pieces exactly as the server pre-renders them; the date-range element's
-// initField (which runs at connect — always AFTER this detached write) adopts
-// the segment values into its typed-digit buffers, so display and editing state
-// match a server-side prefill.
-function writeDateSide(element: HTMLElement, side: "min" | "max", isoString: string): void {
-  const hidden = element.querySelector<HTMLInputElement>(
-    side === "min" ? "[data-range-min]" : "[data-range-max]",
-  );
-  if (hidden) hidden.value = isoString;
-  if (!isoString) return;
-  const [year = "", month = "", day = ""] = isoString.split("-");
-  const partValues: Record<string, string> = { year, month, day };
-  element
-    .querySelectorAll<HTMLInputElement>(`input[data-date-side="${side}"][data-date-part]`)
-    .forEach((segment) => {
-      segment.value = partValues[segment.dataset.datePart ?? ""] ?? "";
-    });
-}
-
-// Mirrors _range_from_field: a one-sided range stores its single bound in
-// `value` regardless of side, so the modifier decides which slot it fills
-// (LESS_THAN → max, GREATER_THAN → min); only BETWEEN carries value + value2.
+// Hydrate the date range widget ONLY for modifiers the min/max pair can
+// represent faithfully — the read side (readDateWidget → buildRangeCriterion)
+// re-derives the modifier purely from which bounds are set, so writing an
+// unrepresentable modifier's bounds would silently rewrite the query on
+// Apply/count. A one-sided range stores its single bound in `value` regardless
+// of side (the modifier decides the slot, mirroring _range_from_field);
+// EQUALS(d) is written as the exactly-equivalent day range d..d (DateCriterion
+// compiles both to the same rows — every datetime field filters via a __date
+// lookup). NOT_EQUALS (a hole), NOT_BETWEEN (two rays), and presence modifiers
+// have no faithful min/max form: leave the widget blank (the leaf prunes, the
+// pre-hydration behavior) rather than apply a different query.
 export function writeDateWidget(element: HTMLElement, criterion: Record<string, unknown>): void {
   const value = scalarToInputValue(criterion["value"]);
   const value2 = scalarToInputValue(criterion["value2"]);
-  const isLessThan = criterion["modifier"] === "LESS_THAN";
-  writeDateSide(element, "min", isLessThan ? "" : value);
-  writeDateSide(element, "max", isLessThan ? value : value2);
+  let bounds: { min: string; max: string } | null;
+  switch (criterion["modifier"]) {
+    case "LESS_THAN":
+      bounds = { min: "", max: value };
+      break;
+    case "GREATER_THAN":
+      bounds = { min: value, max: "" };
+      break;
+    case "BETWEEN":
+      bounds = { min: value, max: value2 };
+      break;
+    case "EQUALS":
+      bounds = { min: value, max: value };
+      break;
+    default:
+      bounds = null;
+  }
+  if (!bounds) return;
+  writeSideValue(element, "min", bounds.min);
+  writeSideValue(element, "max", bounds.max);
 }
 
 // Mirrors _bool_from_field's coercion (string "true"/"1"/"yes" and friends).
@@ -325,26 +341,24 @@ export function writeBoolWidget(element: HTMLElement, criterion: Record<string, 
   if (radio) radio.checked = true;
 }
 
-// Clone one of the <search-select>'s own pill <template> prototypes (the same
-// ones its click handlers clone), so hydrated pills are byte-identical to
-// user-added ones — readFilterSelect and the delegated ×-remove listener treat
-// them exactly the same, and no element upgrade is needed.
-function cloneSetPillTemplate(searchSelect: HTMLElement, templateName: string): HTMLElement | null {
-  const template = searchSelect.querySelector<HTMLTemplateElement>(
-    `template[data-search-select-template="${templateName}"]`,
+// Escape a user-authored value for use inside a quoted attribute selector.
+// Control characters are CSS parse errors inside quoted strings, so they get
+// hex-escaped (the native CSS.escape treatment); quotes and backslashes are
+// backslash-escaped. Implemented locally rather than via CSS.escape so the
+// behavior is identical in browsers and in jsdom (which lacks the CSS global).
+function escapeSelectorValue(value: string): string {
+  return value.replace(/[\u0000-\u001f\u007f"\\]/g, (character) =>
+    character === '"' || character === "\\"
+      ? `\\${character}`
+      : `\\${character.charCodeAt(0).toString(16)} `,
   );
-  const clone = template?.content.firstElementChild?.cloneNode(true);
-  return clone instanceof HTMLElement ? clone : null;
-}
-
-function setPillLabel(pill: HTMLElement, label: string): void {
-  const slot = pill.querySelector("[data-search-select-label]");
-  if (slot) slot.textContent = label;
 }
 
 // The label a value id shows on its pill: the stored label when the payload
 // carries {id, label} entries, else the pre-rendered option row's label, else
-// the id itself (mirrors _extract_labeled's bare-value fallback).
+// the id itself (mirrors _extract_labeled's bare-value fallback). Ids come from
+// user-authored ?filter= JSON, so the selector escape must cover control
+// characters, not just quotes.
 function normalizePillEntries(raw: unknown, searchSelect: HTMLElement): PillEntry[] {
   if (!Array.isArray(raw)) return [];
   const entries: PillEntry[] = [];
@@ -363,7 +377,7 @@ function normalizePillEntries(raw: unknown, searchSelect: HTMLElement): PillEntr
     }
     if (!label) {
       const optionRow = searchSelect.querySelector<HTMLElement>(
-        `[data-search-select-option][data-value="${cssEscape(id)}"]`,
+        `[data-search-select-option][data-value="${escapeSelectorValue(id)}"]`,
       );
       label = optionRow?.getAttribute("data-label") || id;
     }
@@ -372,51 +386,36 @@ function normalizePillEntries(raw: unknown, searchSelect: HTMLElement): PillEntr
   return entries;
 }
 
-function appendValuePill(
-  searchSelect: HTMLElement,
-  pills: HTMLElement,
-  entry: PillEntry,
-  kind: "include" | "exclude",
-): void {
-  const pill = cloneSetPillTemplate(searchSelect, kind === "include" ? "pill-include" : "pill-exclude");
-  if (!pill) return;
-  pill.setAttribute("data-value", entry.id);
-  pill.setAttribute("data-label", entry.label);
-  setPillLabel(pill, entry.label);
-  pills.appendChild(pill);
-}
-
-// Tree set writer — the mirror of readTreeSetWidget/_choice_from_raw: `value`
-// entries become include pills, `excludes` exclude pills, and a modifier that
-// matches one of the widget's pinned modifier rows becomes the sticky modifier
-// pill (INCLUDES/EXCLUDES have no pinned row and no pill — the read side
-// defaults to INCLUDES). A presence modifier excludes value pills entirely.
+// Tree set writer — the mirror of readTreeSetWidget/_choice_from_raw, rendered
+// through the <search-select>'s own writeFilterSelect so hydrated pills are
+// identical to click-added ones. A modifier that matches one of the widget's
+// pinned modifier rows becomes the sticky modifier pill (INCLUDES/EXCLUDES have
+// no pinned row and no pill — the read side defaults to INCLUDES). EXCLUDES and
+// NOT_EQUALS store their values in `value` but mean exclusion — the backend
+// compiles them to exactly ~Q(field__in=…), the same Q the widget's exclude
+// channel produces (criteria.py _value_q/to_q) — so they hydrate as ✗ exclude
+// pills rather than silently inverting into includes.
 export function writeTreeSetWidget(valueCell: HTMLElement, criterion: Record<string, unknown>): void {
   const searchSelect = valueCell.querySelector<HTMLElement>("search-select");
-  const pills = searchSelect?.querySelector<HTMLElement>("[data-search-select-pills]");
-  if (!searchSelect || !pills) return;
+  if (!searchSelect) return;
   const modifier = typeof criterion["modifier"] === "string" ? criterion["modifier"] : "";
   const modifierRow = modifier
     ? searchSelect.querySelector<HTMLElement>(
-        `[data-search-select-modifier-option="${cssEscape(modifier)}"]`,
+        `[data-search-select-modifier-option="${escapeSelectorValue(modifier)}"]`,
       )
     : null;
-  if (modifierRow) {
-    const pill = cloneSetPillTemplate(searchSelect, "pill-modifier");
-    if (pill) {
-      pill.setAttribute("data-search-select-modifier", modifier);
-      setPillLabel(pill, modifierRow.getAttribute("data-label") ?? modifier);
-      pills.insertBefore(pill, pills.firstChild);
-      searchSelect.setAttribute("data-modifier", modifier);
-    }
-  }
-  if (isPresenceModifier(modifier)) return; // presence is mutually exclusive with value pills
-  for (const entry of normalizePillEntries(criterion["value"], searchSelect)) {
-    appendValuePill(searchSelect, pills, entry, "include");
-  }
-  for (const entry of normalizePillEntries(criterion["excludes"], searchSelect)) {
-    appendValuePill(searchSelect, pills, entry, "exclude");
-  }
+  const valueEntries = normalizePillEntries(criterion["value"], searchSelect);
+  const excludeEntries = normalizePillEntries(criterion["excludes"], searchSelect);
+  const isExclusion = modifier === "EXCLUDES" || modifier === "NOT_EQUALS";
+  writeFilterSelect(
+    searchSelect,
+    {
+      included: isExclusion ? [] : valueEntries,
+      excluded: isExclusion ? [...valueEntries, ...excludeEntries] : excludeEntries,
+      modifier: modifierRow ? modifier : "",
+    },
+    modifierRow?.getAttribute("data-label") ?? "",
+  );
 }
 
 // Write one leaf value cell from a criterion payload by kind — the write-mirror
@@ -426,7 +425,7 @@ export function writeTreeSetWidget(valueCell: HTMLElement, criterion: Record<str
 // writer is an idempotent no-op beyond selecting the already-default modifier.
 export function writeLeafWidget(
   valueCell: HTMLElement,
-  kind: string,
+  kind: LeafWidgetKind,
   criterion: Record<string, unknown>,
 ): void {
   if (Object.keys(criterion).length === 0) return;
@@ -446,7 +445,13 @@ export function writeLeafWidget(
     case "set":
       writeTreeSetWidget(valueCell, criterion);
       break;
-    default:
-      break;
+    case "field-comparison":
+      break; // comparison leaves hydrate via seedComparisonRow, not here
+    default: {
+      // Exhaustive over LeafWidgetKind: a new widget kind fails tsc here until
+      // it gets BOTH this writer case and a readLeafWidget case (see above).
+      const unhandled: never = kind;
+      return unhandled;
+    }
   }
 }

--- a/ts/elements/search-select.ts
+++ b/ts/elements/search-select.ts
@@ -715,7 +715,7 @@ const initWidget = (containerElement: Element) => {
 };
 
 /** Minimal escape for use inside an attribute-value selector. */
-const cssEscape = (value: string | null): string => String(value).replace(/["\\]/g, "\\$&");
+export const cssEscape = (value: string | null): string => String(value).replace(/["\\]/g, "\\$&");
 
 // The current include/exclude/modifier state of one filter-mode <search-select>,
 // read straight from its pills. Self-contained per element (no flat form) so the

--- a/ts/elements/search-select.ts
+++ b/ts/elements/search-select.ts
@@ -205,18 +205,10 @@ const initWidget = (containerElement: Element) => {
 
   // ── Clone a server-rendered <template> prototype by name. The server emits
   //    the mode-appropriate prototypes, so the JS never names a class. ──
-  const cloneTemplate = (templateName: string): HTMLElement | null => {
-    const template = container.querySelector<HTMLTemplateElement>(
-      `template[data-search-select-template="${templateName}"]`
-    );
-    const clone = template?.content.firstElementChild?.cloneNode(true);
-    return (clone as HTMLElement) ?? null;
-  };
+  const cloneTemplate = (templateName: string): HTMLElement | null =>
+    cloneTemplateFrom(container, templateName);
 
-  const setLabel = (node: Element, label: string) => {
-    const slot = node.querySelector("[data-search-select-label]");
-    if (slot) slot.textContent = label;
-  };
+  const setLabel = setLabelSlot;
 
   const applyData = (node: Element, data: Record<string, string> = {}) => {
     Object.keys(data).forEach(key => {
@@ -715,7 +707,24 @@ const initWidget = (containerElement: Element) => {
 };
 
 /** Minimal escape for use inside an attribute-value selector. */
-export const cssEscape = (value: string | null): string => String(value).replace(/["\\]/g, "\\$&");
+const cssEscape = (value: string | null): string => String(value).replace(/["\\]/g, "\\$&");
+
+// ── Detached-safe pill construction (shared by the click handlers above and the
+//    silent writer below). Parametrized on the container so they work on a
+//    template clone that is not yet connected/upgraded. ──
+
+function cloneTemplateFrom(container: HTMLElement, templateName: string): HTMLElement | null {
+  const template = container.querySelector<HTMLTemplateElement>(
+    `template[data-search-select-template="${templateName}"]`
+  );
+  const clone = template?.content.firstElementChild?.cloneNode(true);
+  return (clone as HTMLElement) ?? null;
+}
+
+function setLabelSlot(node: Element, label: string): void {
+  const slot = node.querySelector("[data-search-select-label]");
+  if (slot) slot.textContent = label;
+}
 
 // The current include/exclude/modifier state of one filter-mode <search-select>,
 // read straight from its pills. Self-contained per element (no flat form) so the
@@ -749,6 +758,45 @@ export function readFilterSelect(container: HTMLElement): FilterSelectValue {
     });
   }
   return { included, excluded, modifier };
+}
+
+/** Silent write mirror of readFilterSelect (#263 prefill hydration): render an
+ * include/exclude/modifier state into a filter-mode widget's pills by cloning
+ * the widget's own pill templates, so hydrated pills are identical to
+ * click-added ones (readFilterSelect and the delegated ×-remove treat them the
+ * same). Works on a detached, not-yet-upgraded clone and dispatches no events.
+ * `modifierLabel` is the pinned modifier row's display label; the modifier pill
+ * is only rendered when it is non-empty (INCLUDES/EXCLUDES have no pill).
+ * Presence modifiers are mutually exclusive with value pills, mirroring
+ * setModifier/addFilterPill above. */
+export function writeFilterSelect(
+  container: HTMLElement,
+  value: FilterSelectValue,
+  modifierLabel = "",
+): void {
+  const pills = container.querySelector<HTMLElement>("[data-search-select-pills]");
+  if (!pills) return;
+  const { included, excluded, modifier } = value;
+  if (modifier && modifierLabel) {
+    const pill = cloneTemplateFrom(container, "pill-modifier");
+    if (pill) {
+      pill.setAttribute("data-search-select-modifier", modifier);
+      setLabelSlot(pill, modifierLabel);
+      pills.insertBefore(pill, pills.firstChild);
+      container.setAttribute("data-modifier", modifier);
+    }
+  }
+  if (modifier && isPresenceModifier(modifier)) return;
+  const appendValuePill = (entry: FilterPillEntry, templateName: string): void => {
+    const pill = cloneTemplateFrom(container, templateName);
+    if (!pill) return;
+    pill.setAttribute("data-value", entry.id);
+    pill.setAttribute("data-label", entry.label);
+    setLabelSlot(pill, entry.label);
+    pills.appendChild(pill);
+  };
+  for (const entry of included) appendValuePill(entry, "pill-include");
+  for (const entry of excluded) appendValuePill(entry, "pill-exclude");
 }
 
 // Serialise each widget's current state onto data-* attributes for the caller.


### PR DESCRIPTION
## Summary

Implements prefill hydration for leaf value widgets in the filter builder. When a filter is loaded via preset or `?filter=` import, each leaf's stored criterion is now written into its cloned value widget, ensuring `serializeForQuery()` reads the prefilled values from live DOM elements instead of blank widgets.

## Key Changes

- **`filter-widgets.ts`**: Added per-kind writer functions (`writeStringWidget`, `writeNumberWidget`, `writeDateWidget`, `writeBoolWidget`, `writeTreeSetWidget`) that mirror the server-side decode logic and populate DOM elements from criterion payloads. These are called during widget cloning, before the element is attached to the DOM, so no input events fire.

- **`filter-group.ts`**: Modified `buildValueCell()` to accept a `criterion` parameter and call `writeLeafWidget()` to hydrate the cloned widget. Comparison cells are similarly hydrated via `seedComparisonRow()`. Hydration only occurs on first build for a field; subsequent renders reuse the cached cell, preserving user edits.

- **`search-select.ts`**: Exported `cssEscape()` utility for safe attribute-value selector construction in the set widget writer.

- **Test coverage** (`filter-group.test.ts`): Added comprehensive test suite covering hydration of all widget kinds (string, number, date, bool, set) with various modifiers, presence checks, range handling, and round-trip serialization. Tests verify that prefilled values survive structural re-renders and that field re-picking clears stale hydration.

- **E2E tests** (`test_filter_builder_e2e.py`): Removed `xfail` marker from `test_prefill_apply_roundtrip_carries_filter` and updated test expectations. The count badge now correctly reflects the prefilled filter (hydrated widgets), and Apply carries the `?filter=` parameter through to the game list.

## Implementation Details

- Hydration is **silent DOM writing** on a detached clone—no custom-element upgrade or event dispatch needed, avoiding side effects during render.
- Date widgets write both hidden ISO-string inputs (for the date-range element's `initField`) and visible segment inputs (day/month/year), matching server-side prefill behavior.
- Set widgets clone pill templates from the `<search-select>` element itself, ensuring hydrated pills are byte-identical to user-added ones and work with existing delegated listeners.
- Bare string IDs in set payloads (from URL-authored JSON) are enriched with labels from pre-rendered option rows, falling back to the ID itself.
- Comparison rows are hydrated with left/operator/right selections and optional granularity toggle before `refreshRow()` seeds dependent dropdowns.

https://claude.ai/code/session_01FnApNVSMTgoBoyi1UQk6x6