### PR TITLE
fix(filters): filter builder swallows nested relation filters on prefill

### DIFF
--- a/e2e/test_filter_builder_e2e.py
+++ b/e2e/test_filter_builder_e2e.py
@@ -23,12 +23,13 @@ Prefill behavior note:
 
 import json
 import urllib.parse
+from datetime import datetime, timezone
 
 import pytest
 from django.urls import reverse
 from playwright.sync_api import Page, expect
 
-from games.models import FilterPreset, Game, Platform
+from games.models import FilterPreset, Game, Platform, PlayEvent, Purchase
 
 
 # ── auth helpers (no shared authenticated_page fixture exists in conftest.py) ──
@@ -322,3 +323,76 @@ def test_load_set_field_preset_reflects_field_without_crash(
     )
     expect(value_pill).to_be_visible(timeout=5_000)
     expect(value_pill).to_contain_text("SpyGame")
+
+
+def test_nested_relation_prefill_renders_full_tree(
+    authenticated_page: Page, live_server
+) -> None:
+    """The stats "View all" → Advanced filter URL shape: a purchase filter whose
+    only key is a nested relation chain (game_filter → playevent_filter → ended
+    BETWEEN) must deserialize into two relation rows with the inner date widget
+    hydrated — not one "Incomplete" criterion row whose pruned query matches all
+    purchases.  Regression: buildRegistry() leaked relation-kind field names into
+    the registry's criterion-field set, and deserialize resolves criterion-first,
+    so the relation swallowed its whole subtree as an opaque criterion payload."""
+    page = authenticated_page
+
+    platform = Platform.objects.create(name="PC")
+    done_game = Game.objects.create(name="DoneGame", platform=platform, status="f")
+    other_game = Game.objects.create(name="OtherGame", platform=platform, status="p")
+    PlayEvent.objects.create(
+        game=done_game, ended=datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+    )
+    matching_purchase = Purchase.objects.create(
+        date_purchased=datetime(2026, 1, 5, 12, 0, tzinfo=timezone.utc),
+        type=Purchase.GAME,
+    )
+    matching_purchase.games.set([done_game])
+    non_matching_purchase = Purchase.objects.create(
+        date_purchased=datetime(2026, 2, 5, 12, 0, tzinfo=timezone.utc),
+        type=Purchase.GAME,
+    )
+    non_matching_purchase.games.set([other_game])
+
+    filter_json = {
+        "game_filter": {
+            "playevent_filter": {
+                "ended": {
+                    "value": "2026-01-01",
+                    "modifier": "BETWEEN",
+                    "value2": "2026-12-31",
+                }
+            }
+        }
+    }
+    page.goto(
+        f"{live_server.url}{reverse('games:filter_builder', args=['purchase'])}"
+        f"?filter={_encode_filter(filter_json)}"
+    )
+
+    group = page.locator("filter-group")
+    expect(group).to_be_attached()
+
+    # Two relation rows (outer game_filter, inner playevent_filter), each with its
+    # field reflected in the relation picker.  The rows nest, so "first" is the
+    # outer card and its own picker is the first select inside it.
+    relation_rows = group.locator('[data-node-slot][data-node-kind="relation"]')
+    expect(relation_rows).to_have_count(2)
+    expect(relation_rows.nth(0).locator("[data-relation-field]").first).to_have_value(
+        "game_filter"
+    )
+    expect(relation_rows.nth(1).locator("[data-relation-field]").first).to_have_value(
+        "playevent_filter"
+    )
+
+    # Nothing is incomplete: the inner date criterion hydrated both bounds.
+    expect(group.locator("[data-incomplete-badge]")).to_have_count(0)
+    expect(group.locator("[data-range-min]").first).to_have_value("2026-01-01")
+    expect(group.locator("[data-range-max]").first).to_have_value("2026-12-31")
+
+    # The count reads the live widgets via serializeForQuery(): only the purchase
+    # of the game with a 2026 PlayEvent matches — not all purchases (the bug
+    # pruned the whole filter and counted everything).
+    count_badge = page.locator("filter-count")
+    expect(count_badge).not_to_contain_text("Counting…")
+    expect(count_badge).to_contain_text("≈ 1 purchase")

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -948,8 +948,32 @@ const HYDRATION_FIELDS = [
     modifiers: ["INCLUDES", "EXCLUDES"], relations: [], search_url: "", is_m2m: false,
   },
 ];
+// Relation chain for prefill: game → session → playevent, so a nested-relation
+// filter (the stats "View all" URL shape — purchase → game → playevent in
+// production, transposed onto the harness models) is expressible here.
+const PLAYEVENT_RELATION = {
+  name: "playevent_filter",
+  label: "PlayEvents",
+  kind: "relation",
+  nullable: false,
+  choices: [],
+  modifiers: [],
+  relations: [{ field: "playevent_filter", filter: "PlayEventFilter", model: "PlayEvent" }],
+  search_url: "",
+  is_m2m: false,
+};
+const ENDED_META = {
+  name: "ended", label: "Ended", kind: "date", nullable: false, choices: [],
+  modifiers: [], relations: [], search_url: "", is_m2m: false,
+};
+const SESSION_NAME_META = {
+  name: "name", label: "Name", kind: "string", nullable: false, choices: [],
+  modifiers: ["EQUALS", "INCLUDES"], relations: [], search_url: "", is_m2m: false,
+};
 const HYDRATION_MODELS = JSON.stringify({
-  game: { fields: HYDRATION_FIELDS, columns: COLUMNS },
+  game: { fields: [...HYDRATION_FIELDS, SESSION_RELATION], columns: COLUMNS },
+  session: { fields: [SESSION_NAME_META, PLAYEVENT_RELATION], columns: [] },
+  playevent: { fields: [ENDED_META], columns: [] },
 });
 // The per-kind widget templates. Segment inputs carry the dual hidden-input
 // attributes (data-date-range-hidden + data-range-min/max) exactly like
@@ -1029,6 +1053,33 @@ const HYDRATION_TEMPLATES = `
       <select data-fc-right data-selected></select>
       <label data-fc-granularity-wrap hidden><input type="checkbox" data-fc-granularity /></label>
       <button data-fc-remove>✕</button>
+    </div>
+  </template>
+  <template data-model="session" data-field-picker-template>
+    <div data-field-picker><search-select name="field-picker"><input data-search-select-search /></search-select></div>
+  </template>
+  <template data-model="session" data-field="name">
+    <div class="flex-col">
+      <select data-string-modifier-select>
+        <option value="EQUALS" selected>is</option>
+        <option value="INCLUDES">includes</option>
+      </select>
+      <input type="text" />
+    </div>
+  </template>
+  <template data-model="playevent" data-field-picker-template>
+    <div data-field-picker><search-select name="field-picker"><input data-search-select-search /></search-select></div>
+  </template>
+  <template data-model="playevent" data-field="ended">
+    <div>
+      <input type="hidden" data-date-range-hidden="min" data-range-min />
+      <input type="hidden" data-date-range-hidden="max" data-range-max />
+      <input data-date-side="min" data-date-part="day" maxlength="2" placeholder="dd" />
+      <input data-date-side="min" data-date-part="month" maxlength="2" placeholder="mm" />
+      <input data-date-side="min" data-date-part="year" maxlength="4" placeholder="yyyy" />
+      <input data-date-side="max" data-date-part="day" maxlength="2" placeholder="dd" />
+      <input data-date-side="max" data-date-part="month" maxlength="2" placeholder="mm" />
+      <input data-date-side="max" data-date-part="year" maxlength="4" placeholder="yyyy" />
     </div>
   </template>`;
 
@@ -1298,5 +1349,95 @@ describe("<filter-group> prefill hydrates leaf value widgets (#263)", () => {
     const inputs = [...host.querySelectorAll<HTMLInputElement>('[data-value-cell] input[type="text"]')];
     expect(inputs.map((input) => input.value)).toEqual(["", ""]);
     expect(host.serializeForQuery()).toEqual({}); // both leaves incomplete → pruned
+  });
+});
+
+// ── Prefill of relation subtrees ──
+// A prefilled filter whose top-level key is a relation (the stats "View all" →
+// Advanced filter URL shape) must deserialize into a RelationNode with its nested
+// child group intact — not a criterion leaf that swallows the subtree and renders
+// one "Incomplete" row. Regression: buildRegistry() used to put relation-kind
+// fields in the registry's `fields` set, and deserialize resolves criterion-first.
+describe("<filter-group> prefill hydrates relation subtrees", () => {
+  it("single relation: renders the relation row + hydrated child criterion", () => {
+    const filter = {
+      AND: [{ session_filter: { AND: [{ name: { value: "Hades", modifier: "EQUALS" } }] } }],
+    };
+    const host = loadHydration(filter);
+    const card = row(host, [0]);
+    expect(card.dataset.nodeKind).toBe("relation");
+    expect(relationSelect(host, [0], "data-relation-field").value).toBe("session_filter");
+    expect(card.querySelector("[data-incomplete-badge]")).toBeNull();
+    const input = valueCell(host, [0, "child", 0]).querySelector<HTMLInputElement>('input[type="text"]')!;
+    expect(input.value).toBe("Hades");
+    expect(host.getIncompleteCount()).toBe(0);
+    expect(host.serializeForQuery()).toEqual(filter);
+  });
+
+  it("nested relation (stats View-all URL shape): full subtree hydrates and round-trips", () => {
+    // Mirrors ?filter={"game_filter":{"playevent_filter":{"ended":{…BETWEEN…}}}}
+    // from the bug report, expressed in the harness's game→session→playevent chain.
+    const host = loadHydration({
+      session_filter: {
+        playevent_filter: {
+          ended: { value: "2026-01-01", modifier: "BETWEEN", value2: "2026-12-31" },
+        },
+      },
+    });
+    const outer = row(host, [0]);
+    expect(outer.dataset.nodeKind).toBe("relation");
+    expect(relationSelect(host, [0], "data-relation-field").value).toBe("session_filter");
+    expect(outer.querySelector("[data-incomplete-badge]")).toBeNull();
+    const inner = row(host, [0, "child", 0]);
+    expect(inner.dataset.nodeKind).toBe("relation");
+    expect(relationSelect(host, [0, "child", 0], "data-relation-field").value).toBe("playevent_filter");
+    const dateCell = valueCell(host, [0, "child", 0, "child", 0]);
+    expect(dateCell.querySelector<HTMLInputElement>("[data-range-min]")!.value).toBe("2026-01-01");
+    expect(dateCell.querySelector<HTMLInputElement>("[data-range-max]")!.value).toBe("2026-12-31");
+    expect(host.getIncompleteCount()).toBe(0);
+    // The canonical form: groups keep their connective wrapper, default ANY match omitted.
+    expect(host.serializeForQuery()).toEqual({
+      AND: [{
+        session_filter: {
+          AND: [{
+            playevent_filter: {
+              AND: [{ ended: { value: "2026-01-01", modifier: "BETWEEN", value2: "2026-12-31" } }],
+            },
+          }],
+        },
+      }],
+    });
+  });
+
+  it("a relation field with no target stays a fail-visible criterion, never a relations entry", () => {
+    // Malformed metadata (server-side unreachable: field_metadata hard-fails on
+    // a target-less relation). Pins buildRegistry's else-branch: the name lands
+    // in the criterion set → an Incomplete row that prunes, NOT a bogus
+    // relations entry whose undefined target would throw UNKNOWN_MODEL and
+    // fail the whole prefill open to an empty match-all builder.
+    document.body.innerHTML = "";
+    const host = document.createElement("filter-group") as FilterGroupElement;
+    host.setAttribute("model", "game");
+    host.setAttribute(
+      "models",
+      JSON.stringify({
+        game: {
+          fields: [{
+            name: "broken_filter", label: "Broken", kind: "relation", nullable: false,
+            choices: [], modifiers: [], relations: [], search_url: "", is_m2m: false,
+          }],
+          columns: [],
+        },
+      }),
+    );
+    host.setAttribute(
+      "filter",
+      JSON.stringify({ broken_filter: { name: { value: "x", modifier: "EQUALS" } } }),
+    );
+    document.body.appendChild(host);
+    const card = row(host, [0]);
+    expect(card.dataset.nodeKind).toBe("criterion");
+    expect(card.querySelector("[data-incomplete-badge]")).not.toBeNull();
+    expect(host.serializeForQuery()).toEqual({}); // incomplete → pruned
   });
 });

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -459,15 +459,24 @@ export class FilterGroupElement extends HTMLElement {
 
   // A name-set MetadataRegistry (what deserialize wants) projected from the richer
   // per-model ModelBundle map this element already parsed from the `models` prop.
+  // The registry contract requires `fields` and `relations` to be DISJOINT:
+  // deserialize resolves criterion-first, so a relation name left in `fields`
+  // shadows the relation and swallows its whole subtree as an opaque criterion
+  // payload (the "Incomplete Game Filter" prefill bug). A relation missing its
+  // target (server-side unreachable — field_metadata hard-fails on it) falls
+  // into `fields`, surfacing as an Incomplete criterion row instead of being
+  // silently dropped.
   private buildRegistry(): MetadataRegistry {
     const registry: Record<string, ModelMeta> = {};
     for (const [key, bundle] of this.models) {
+      const fields = new Set<string>();
       const relations: Record<string, string> = {};
       for (const [name, meta] of bundle.fields) {
         const target = meta.relations[0]?.model;
         if (meta.kind === "relation" && target) relations[name] = target.toLowerCase();
+        else fields.add(name);
       }
-      registry[key] = { fields: new Set(bundle.fields.keys()), relations };
+      registry[key] = { fields, relations };
     }
     return registry;
   }

--- a/ts/elements/filter-tree/fixtures.json
+++ b/ts/elements/filter-tree/fixtures.json
@@ -100,6 +100,15 @@
       "description": "negated relation (NOT EXISTS)",
       "model": "game",
       "filter": { "NOT": [ { "session_filter": { "device": { "value": [1], "modifier": "INCLUDES" } } } ] }
+    },
+    {
+      "description": "nested relation: game -> session -> game criterion",
+      "model": "game",
+      "filter": {
+        "session_filter": {
+          "game_filter": { "name": { "value": "zelda", "modifier": "INCLUDES" } }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Problem

Stats page "View all" (Finished) links to the purchase list with
`?filter={"game_filter": {"playevent_filter": {"ended": {…BETWEEN…}}}}`. Opening the
Advanced filter builder with that filter rendered a single "Incomplete" row labeled
"Game Filter" instead of the nested tree, and the live count showed all purchases
(the pruned query matched everything).

## Root cause

`FilterGroupElement.buildRegistry()` projected the `models` prop into the serializer's
`MetadataRegistry` with `fields: new Set(bundle.fields.keys())` — which includes
`kind === "relation"` fields. `deserializeNode()` resolves criterion-first, mirroring
Python `from_json`, under the documented contract that `fields`/`relations` are
**disjoint**. Every other registry producer honors that contract; `buildRegistry()`
was the one that violated it, so `game_filter` matched the criterion branch first and
deserialized as a criterion leaf with the whole nested subtree as an opaque payload:

- the row's field picker displayed the "Game Filter" label (via `setSelected`) while
  relation-kind widgets skip hydration → permanent "Incomplete" badge
- the nested `playevent_filter`/`ended` never became tree nodes
- `serializeForQuery()` pruned the incomplete leaf → count/Apply matched all purchases

## Fix

Relation-kind fields now go only into the registry's `relations` map, keeping
`fields`/`relations` disjoint (one method: `buildRegistry()`).

## Tests

- **vitest** (`ts/elements/filter-group.test.ts`): hydration harness extended to a
  game → session → playevent chain; new single-relation and nested-relation prefill
  tests — red before the fix (`expected 'criterion' to be 'relation'`), asserting
  relation rows, hydrated date bounds, zero incomplete count, canonical round-trip.
- **Cross-language contract** (`fixtures.json`): nested-relation case; pytest verifies
  the TS canonical form is `to_q()`-equivalent on the real Python filters.
- **e2e** (`test_filter_builder_e2e.py`): the exact bug URL shape on the purchase
  builder in real Chromium — two relation rows with fields reflected, both date bounds
  hydrated, no Incomplete badge, count badge narrows to ≈ 1 purchase.

Full `make check` green (1411 pytest incl. e2e + contract, 290 vitest, lint/mypy/ts-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)