### PR TITLE
refactor(filters): extract shared preset load/save/delete into presets.ts (#264)

### DIFF
--- a/ts/elements/filter-bar.ts
+++ b/ts/elements/filter-bar.ts
@@ -7,6 +7,11 @@
  */
 import { readFilterBarProps } from "../generated/props.js";
 import { readFieldComparisonSet } from "./field-comparison-set.js";
+import {
+  PresetDropdown,
+  savePreset as requestSavePreset,
+  setupPresetDropdown,
+} from "./presets.js";
 import { readSearchSelect } from "./search-select.js";
 import {
   parseJSONAttr,
@@ -34,15 +39,6 @@ function presetMode(): string {
   if (path.indexOf("platform") !== -1) return "platforms";
   if (path.indexOf("playevent") !== -1) return "playevents";
   return "games";
-}
-
-function getCsrfToken(): string {
-  const cookie = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith("csrftoken="));
-  if (cookie) return cookie.split("=")[1];
-  const element = document.querySelector<HTMLInputElement>('input[name="csrfmiddlewaretoken"]');
-  return element ? element.value : "";
 }
 
 // Deep-merge a single leaf criterion into `target` by its JSON path. Branch
@@ -243,70 +239,6 @@ function setupDeselectableRadios(root: HTMLElement): void {
   });
 }
 
-function setupPresetDeleteHandlers(container: HTMLElement): void {
-  const deleteLinks = container.querySelectorAll<HTMLAnchorElement>("[data-delete-preset]");
-  deleteLinks.forEach((link) => {
-    link.addEventListener("click", (event) => {
-      event.preventDefault();
-      const deleteUrl = link.getAttribute("href");
-      if (!deleteUrl) return;
-      if (!confirm("Delete this preset?")) return;
-      // fetchWithHtmxTriggers so the server's delete success/error toast surfaces;
-      // only remove the row when the server actually deleted it (response.ok),
-      // otherwise a 404/405/500 would desync the UI from the DB.
-      window
-        .fetchWithHtmxTriggers(deleteUrl, {
-          method: "DELETE",
-          credentials: "same-origin",
-          headers: { "X-CSRFToken": getCsrfToken() },
-        })
-        .then((response) => {
-          if (!response.ok) return; // server rejected; its toast already fired
-          const listItem = link.closest("li");
-          if (listItem) listItem.remove();
-          const list = container.querySelector("ul");
-          if (list && list.querySelectorAll("li").length === 0) {
-            list.innerHTML =
-              '<li class="px-4 py-2 text-sm text-body italic">No saved presets</li>';
-          }
-        })
-        .catch((error) => {
-          // Transport failure only (no Response, no HX-Trigger) — surface a toast.
-          console.error("Delete failed:", error);
-          window.toast("Failed to delete preset.", "error");
-        });
-    });
-  });
-}
-
-function loadPresets(root: HTMLElement, presetListUrl: string): void {
-  const dropdown = root.querySelector<HTMLElement>("#preset-dropdown");
-  if (!dropdown) return;
-
-  const mode = presetMode();
-  let query = "";
-  if (presetListUrl.indexOf("mode=") === -1) {
-    query = (presetListUrl.indexOf("?") !== -1 ? "&" : "?") + "mode=" + mode;
-  }
-
-  fetch(presetListUrl + query, { credentials: "same-origin" })
-    .then((response) => {
-      if (!response.ok) throw new Error("Failed to load presets");
-      return response.text();
-    })
-    .then((html) => {
-      dropdown.innerHTML = html;
-      setupPresetDeleteHandlers(dropdown);
-      // Names just (re)arrived; re-check collision in case the input is open.
-      updateOverwriteWarning(root);
-    })
-    .catch((error) => {
-      dropdown.innerHTML =
-        '<span class="text-sm text-body italic">Presets unavailable</span>';
-      console.error(error);
-    });
-}
-
 function showPresetNameInput(root: HTMLElement): void {
   const input = root.querySelector<HTMLElement>("[data-filter-bar-preset-name]");
   const saveButton = root.querySelector<HTMLElement>("[data-filter-bar-save]");
@@ -346,8 +278,8 @@ function updateOverwriteWarning(root: HTMLElement): void {
 function savePreset(
   form: HTMLElement,
   presetSaveUrl: string,
-  presetListUrl: string,
   root: HTMLElement,
+  presets: PresetDropdown,
 ): void {
   const input = root.querySelector<HTMLInputElement>("[data-filter-bar-preset-name]");
   const name = input ? input.value.trim() : "";
@@ -356,52 +288,31 @@ function savePreset(
     return;
   }
 
-  const filterObject = buildFilterJSON(form);
-  const body = new URLSearchParams();
-  body.append("name", name);
-  body.append("mode", presetMode());
-  body.append("filter", JSON.stringify(filterObject));
-
-  // fetchWithHtmxTriggers (not plain fetch) so the server's messages — the error
-  // toast on a rejected filter/mode, and the success toast — surface via the
-  // HX-Trigger header the toast middleware sets, for any response that carries a
-  // Django message.
-  window
-    .fetchWithHtmxTriggers(presetSaveUrl, {
-      method: "POST",
-      credentials: "same-origin",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "X-CSRFToken": getCsrfToken(),
-      },
-      body: body.toString(),
-    })
-    .then((response) => {
-      // A non-ok response already fired its error toast via the wrapper; leave
-      // the confirm-save UI in place so the user can correct and retry.
-      if (!response.ok) return;
-      if (input) {
-        input.value = "";
-        input.classList.add("hidden");
-        input.classList.remove("border-red-500");
-      }
-      const saveButton = root.querySelector<HTMLElement>("[data-filter-bar-save]");
-      const confirmButton = root.querySelector<HTMLElement>("[data-filter-bar-confirm-save]");
-      if (saveButton) saveButton.classList.remove("hidden");
-      if (confirmButton) {
-        confirmButton.classList.add("hidden");
-        confirmButton.textContent = "Save";
-      }
-      const warning = root.querySelector<HTMLElement>("[data-filter-bar-overwrite-warning]");
-      if (warning) warning.classList.add("hidden");
-      loadPresets(root, presetListUrl);
-    })
-    .catch((error) => {
-      // Reached only on a transport failure (no Response, so no HX-Trigger and no
-      // toast fired). Surface one here so the failure is never invisible.
-      console.error("Failed to save preset:", error);
-      window.toast("Failed to save preset.", "error");
-    });
+  requestSavePreset(presetSaveUrl, {
+    name,
+    mode: presetMode(),
+    filter: buildFilterJSON(form),
+  }).then((response) => {
+    // A non-ok response already fired its error toast via HX-Trigger (and a
+    // transport failure toasted inside the helper); leave the confirm-save UI
+    // in place so the user can correct and retry.
+    if (!response?.ok) return;
+    if (input) {
+      input.value = "";
+      input.classList.add("hidden");
+      input.classList.remove("border-red-500");
+    }
+    const saveButton = root.querySelector<HTMLElement>("[data-filter-bar-save]");
+    const confirmButton = root.querySelector<HTMLElement>("[data-filter-bar-confirm-save]");
+    if (saveButton) saveButton.classList.remove("hidden");
+    if (confirmButton) {
+      confirmButton.classList.add("hidden");
+      confirmButton.textContent = "Save";
+    }
+    const warning = root.querySelector<HTMLElement>("[data-filter-bar-overwrite-warning]");
+    if (warning) warning.classList.add("hidden");
+    void presets.refresh();
+  });
 }
 
 class FilterBarElement extends HTMLElement {
@@ -409,6 +320,16 @@ class FilterBarElement extends HTMLElement {
     const { presetListUrl, presetSaveUrl } = readFilterBarProps(this);
     const form = this.querySelector<HTMLFormElement>("form");
     if (!form) return;
+
+    // No onPick: a preset anchor keeps its native navigation to the list view.
+    const presets = setupPresetDropdown({
+      root: this,
+      dropdownSelector: "#preset-dropdown",
+      listUrl: presetListUrl,
+      mode: presetMode(),
+      // Names just (re)arrived; re-check collision in case the input is open.
+      onListRendered: () => updateOverwriteWarning(this),
+    });
 
     // Delegated on the persistent custom element so the toggle keeps working
     // after the inner #filter-bar body is htmx-swapped — connectedCallback does
@@ -441,7 +362,7 @@ class FilterBarElement extends HTMLElement {
     });
 
     this.querySelector("[data-filter-bar-confirm-save]")?.addEventListener("click", () => {
-      savePreset(form, presetSaveUrl, presetListUrl, this);
+      savePreset(form, presetSaveUrl, this, presets);
     });
 
     this.querySelector("[data-filter-bar-preset-name]")?.addEventListener("input", () => {
@@ -450,7 +371,7 @@ class FilterBarElement extends HTMLElement {
 
     setupDeselectableRadios(this);
     setupModifierToggles(this);
-    if (presetListUrl) loadPresets(this, presetListUrl);
+    if (presetListUrl) void presets.refresh();
   }
 }
 

--- a/ts/elements/filter-builder.ts
+++ b/ts/elements/filter-builder.ts
@@ -1,26 +1,14 @@
 import { readFilterBuilderProps } from "../generated/props.js";
 import { FILTER_TREE_CHANGE_EVENT, FilterGroupElement } from "./filter-group.js";
+import { PresetDropdown, savePreset, setupPresetDropdown } from "./presets.js";
 
 // <filter-builder> — the builder-page toolbar (#196). Owns Load/Save preset,
 // Apply, Clear; drives the sibling <filter-group>. Preset load/save/delete is
-// duplicated from filter-bar.ts for now (follow-up: extract to presets.ts).
+// shared with filter-bar.ts via presets.ts (#264).
 
 export function applyUrl(listUrl: string, filter: Record<string, unknown>): string {
   if (Object.keys(filter).length === 0) return listUrl;
   return listUrl + "?filter=" + encodeURIComponent(JSON.stringify(filter));
-}
-
-// fetchWithHtmxTriggers does NOT add CSRF — it only parses HX-Trigger response
-// headers. Django's CSRF middleware rejects unsafe methods (POST/DELETE) without
-// the token, so mirror filter-bar.ts (getCsrfToken + X-CSRFToken header) or the
-// save/delete requests 403.
-function getCsrfToken(): string {
-  const match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
-  if (match) return decodeURIComponent(match[1]);
-  const element = document.querySelector<HTMLInputElement>('input[name="csrfmiddlewaretoken"]');
-  if (element) return element.value;
-  console.warn("filter-builder: CSRF token not found — preset save/delete will 403");
-  return "";
 }
 
 function isFilterGroup(element: Element | null): element is FilterGroupElement {
@@ -34,10 +22,10 @@ function isFilterGroup(element: Element | null): element is FilterGroupElement {
 export class FilterBuilderElement extends HTMLElement {
   private mode = "";
   private applyTarget = "";
-  private presetListUrl = "";
   private presetSaveUrl = "";
   private incompleteCount = 0;
   private changeListener: ((event: Event) => void) | null = null;
+  private presets: PresetDropdown | null = null;
 
   // Build the toolbar buttons into this element. Called when the element is
   // test-created (no server-rendered children) so tests can querySelector for
@@ -63,11 +51,22 @@ export class FilterBuilderElement extends HTMLElement {
     const props = readFilterBuilderProps(this);
     this.mode = props.mode;
     this.applyTarget = props.applyUrl;
-    this.presetListUrl = props.presetListUrl;
     this.presetSaveUrl = props.presetSaveUrl;
 
     this.ensureToolbar();
     this.addEventListener("click", this.onClick);
+    this.presets = setupPresetDropdown({
+      root: this,
+      dropdownSelector: "[data-preset-dropdown]",
+      listUrl: props.presetListUrl,
+      mode: props.mode,
+      onPick: (filter) => {
+        // A loadFilter throw (valid JSON, bad filter shape) propagates back
+        // into the controller's catch → "not a valid filter" toast.
+        this.group()?.loadFilter(filter);
+        this.querySelector("[data-preset-dropdown]")?.classList.add("hidden");
+      },
+    });
     this.changeListener = (event: Event): void => {
       const detail = (event as CustomEvent<{ incompleteCount: number }>).detail;
       if (detail) {
@@ -89,6 +88,8 @@ export class FilterBuilderElement extends HTMLElement {
       document.removeEventListener(FILTER_TREE_CHANGE_EVENT, this.changeListener);
       this.changeListener = null;
     }
+    this.presets?.dispose();
+    this.presets = null;
   }
 
   // Overridable so tests can assert the target without a real navigation.
@@ -114,21 +115,11 @@ export class FilterBuilderElement extends HTMLElement {
     apply.disabled = this.incompleteCount > 0 && !filterIsEmpty;
   }
 
+  // Preset delete/pick clicks are handled by the presets.ts controller's own
+  // delegated listener; this branch set is disjoint from it (the dropdown is a
+  // sibling of the toolbar buttons, so closest() never crosses between them).
   private onClick = (event: Event): void => {
     const target = event.target as HTMLElement;
-    // Delete FIRST: list_presets renders the delete control as a <span
-    // data-delete-preset> nested INSIDE the preset <a href>, so the anchor branch
-    // would otherwise swallow a delete click and load the preset instead.
-    const deleteButton = target.closest<HTMLElement>("[data-delete-preset]");
-    if (deleteButton) {
-      event.preventDefault();
-      return this.onDeletePreset(deleteButton);
-    }
-    const presetLink = target.closest<HTMLAnchorElement>("[data-preset-dropdown] a[href]");
-    if (presetLink) {
-      event.preventDefault();
-      return this.onPresetPicked(presetLink);
-    }
     if (target.closest("[data-apply]")) return this.onApply();
     if (target.closest("[data-clear]")) return this.group()?.clear();
     if (target.closest("[data-load-presets]")) return this.onLoadPresets();
@@ -146,46 +137,7 @@ export class FilterBuilderElement extends HTMLElement {
     if (!dropdown) return;
     dropdown.classList.toggle("hidden");
     if (dropdown.classList.contains("hidden")) return;
-    const separator = this.presetListUrl.indexOf("?") === -1 ? "?" : "&";
-    fetch(this.presetListUrl + separator + "mode=" + encodeURIComponent(this.mode), {
-      credentials: "same-origin",
-    })
-      .then((response) => {
-        if (!response.ok) throw new Error("preset list failed");
-        return response.text();
-      })
-      .then((html) => {
-        dropdown.innerHTML = html;
-      })
-      .catch((error: unknown) => { console.error("filter-builder: load presets failed", error); window.toast("Failed to load presets.", "error"); });
-  }
-
-  // The list fragment's anchors carry ?filter=<json> in their href (see
-  // list_presets). Read it out and feed the group instead of navigating.
-  private onPresetPicked(anchor: HTMLAnchorElement): void {
-    const raw = new URL(anchor.href, window.location.origin).searchParams.get("filter") ?? "";
-    const group = this.group();
-    if (!group) return;
-    try {
-      group.loadFilter(raw ? (JSON.parse(raw) as Record<string, unknown>) : {});
-      this.querySelector("[data-preset-dropdown]")?.classList.add("hidden");
-    } catch (error) {
-      console.error("filter-builder: preset load failed", error);
-      window.toast("Preset is not a valid filter.", "error");
-    }
-  }
-
-  private onDeletePreset(button: HTMLElement): void {
-    const deleteUrl = button.getAttribute("href");
-    if (!deleteUrl || !confirm("Delete this preset?")) return;
-    window
-      .fetchWithHtmxTriggers(deleteUrl, {
-        method: "DELETE",
-        credentials: "same-origin",
-        headers: { "X-CSRFToken": getCsrfToken() },
-      })
-      .then(() => this.onLoadPresets())
-      .catch((error: unknown) => { console.error("filter-builder: delete preset failed", error); window.toast("Failed to delete preset.", "error"); });
+    void this.presets?.refresh();
   }
 
   private onSavePreset(): void {
@@ -197,21 +149,15 @@ export class FilterBuilderElement extends HTMLElement {
       window.toast("Preset name is required.", "error");
       return;
     }
-    const body = new FormData();
-    body.append("name", name);
-    body.append("mode", this.mode);
-    body.append("filter", JSON.stringify(group.serialize()));
-    window
-      .fetchWithHtmxTriggers(this.presetSaveUrl, {
-        method: "POST",
-        body,
-        credentials: "same-origin",
-        headers: { "X-CSRFToken": getCsrfToken() },
-      })
-      .then(() => {
-        input.value = "";
-      })
-      .catch((error: unknown) => { console.error("filter-builder: save preset failed", error); window.toast("Failed to save preset.", "error"); });
+    void savePreset(this.presetSaveUrl, {
+      name,
+      mode: this.mode,
+      filter: group.serialize(),
+    }).then((response) => {
+      // Keep the typed name around when the server rejected the save (its
+      // error toast already fired) so the user can correct and retry.
+      if (response?.ok) input.value = "";
+    });
   }
 }
 

--- a/ts/elements/presets.test.ts
+++ b/ts/elements/presets.test.ts
@@ -1,0 +1,295 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getCsrfToken, savePreset, setupPresetDropdown } from "./presets.js";
+
+const LIST_URL = "/tracker/filter/presets/list";
+
+function clearCsrfCookie(): void {
+  document.cookie = "csrftoken=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+interface MountOptions {
+  listUrl?: string;
+  onPick?: (filter: Record<string, unknown>) => void;
+  onListRendered?: () => void;
+}
+
+function mount(options: MountOptions = {}) {
+  document.body.innerHTML = "";
+  const root = document.createElement("div");
+  const dropdown = document.createElement("div");
+  dropdown.setAttribute("data-preset-dropdown", "");
+  root.appendChild(dropdown);
+  document.body.appendChild(root);
+  const controller = setupPresetDropdown({
+    root,
+    dropdownSelector: "[data-preset-dropdown]",
+    listUrl: options.listUrl ?? LIST_URL,
+    mode: "games",
+    onPick: options.onPick,
+    onListRendered: options.onListRendered,
+  });
+  return { root, dropdown, controller };
+}
+
+// A preset row shaped like the list_presets fragment: the delete <span> is
+// nested INSIDE the preset <a href>.
+function injectPresetRow(dropdown: HTMLElement, filter: Record<string, unknown>): void {
+  dropdown.innerHTML = `
+    <ul>
+      <li>
+        <a href="/tracker/game/list?filter=${encodeURIComponent(JSON.stringify(filter))}">
+          My preset
+          <span data-delete-preset="" href="/tracker/filter/presets/delete/42">x</span>
+        </a>
+      </li>
+    </ul>`;
+}
+
+function stubListFetch(html = "<ul><li>fresh</li></ul>"): ReturnType<typeof vi.fn> {
+  const fetchStub = vi.fn(() => Promise.resolve(new Response(html)));
+  vi.stubGlobal("fetch", fetchStub);
+  return fetchStub;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  clearCsrfCookie();
+});
+
+describe("getCsrfToken", () => {
+  it("reads and URL-decodes the csrftoken cookie", () => {
+    document.cookie = "csrftoken=abc%3D123";
+    expect(getCsrfToken()).toBe("abc=123");
+  });
+
+  it("falls back to the hidden csrfmiddlewaretoken input", () => {
+    clearCsrfCookie();
+    document.body.innerHTML = '<input name="csrfmiddlewaretoken" value="hidden-token">';
+    expect(getCsrfToken()).toBe("hidden-token");
+  });
+});
+
+describe("refresh", () => {
+  it("appends mode only when the list URL does not already carry one", async () => {
+    const fetchStub = stubListFetch();
+    const { controller } = mount();
+    await controller.refresh();
+    const requested = new URL(fetchStub.mock.calls[0][0] as string);
+    expect(requested.pathname).toBe(LIST_URL);
+    expect(requested.searchParams.get("mode")).toBe("games");
+
+    fetchStub.mockClear();
+    const { controller: second } = mount({ listUrl: `${LIST_URL}?mode=devices` });
+    await second.refresh();
+    const kept = new URL(fetchStub.mock.calls[0][0] as string);
+    expect(kept.searchParams.get("mode")).toBe("devices");
+  });
+
+  it("renders the fragment and calls onListRendered", async () => {
+    stubListFetch("<ul><li>row</li></ul>");
+    const onListRendered = vi.fn();
+    const { dropdown, controller } = mount({ onListRendered });
+    await controller.refresh();
+    expect(dropdown.innerHTML).toBe("<ul><li>row</li></ul>");
+    expect(onListRendered).toHaveBeenCalledOnce();
+  });
+
+  it("no-ops on an empty list URL", async () => {
+    const fetchStub = stubListFetch();
+    const { controller } = mount({ listUrl: "" });
+    await controller.refresh();
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  it("renders a placeholder on failure without rejecting", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("network down"))));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { dropdown, controller } = mount();
+    await expect(controller.refresh()).resolves.toBeUndefined();
+    expect(dropdown.innerHTML).toContain("Presets unavailable");
+  });
+});
+
+describe("delete", () => {
+  function stubDeleteEnvironment(deleteResponse: unknown = new Response(null, { status: 200 })) {
+    document.cookie = "csrftoken=testtoken";
+    const deleteStub = vi.fn(() => Promise.resolve(deleteResponse));
+    (window as unknown as Record<string, unknown>).fetchWithHtmxTriggers = deleteStub;
+    const toastStub = vi.fn();
+    (window as unknown as Record<string, unknown>).toast = toastStub;
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    const listStub = stubListFetch();
+    return { deleteStub, toastStub, listStub };
+  }
+
+  it("sends DELETE with X-CSRFToken and refetches the list", async () => {
+    const { deleteStub, toastStub, listStub } = stubDeleteEnvironment();
+    const { dropdown } = mount();
+    injectPresetRow(dropdown, {});
+
+    (dropdown.querySelector("[data-delete-preset]") as HTMLElement).click();
+    await flushPromises();
+
+    expect(deleteStub).toHaveBeenCalledOnce();
+    const [url, options] = deleteStub.mock.calls[0] as unknown as [
+      string,
+      RequestInit & { headers: Record<string, string> },
+    ];
+    expect(url).toBe("/tracker/filter/presets/delete/42");
+    expect(options.method).toBe("DELETE");
+    expect(options.headers["X-CSRFToken"]).toBe("testtoken");
+    expect(listStub).toHaveBeenCalledOnce();
+    expect(toastStub).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when the confirm is declined", () => {
+    const { deleteStub } = stubDeleteEnvironment();
+    vi.stubGlobal("confirm", vi.fn(() => false));
+    const { dropdown } = mount();
+    injectPresetRow(dropdown, {});
+
+    (dropdown.querySelector("[data-delete-preset]") as HTMLElement).click();
+
+    expect(deleteStub).not.toHaveBeenCalled();
+  });
+
+  it("toasts on a server rejection (no Django message fires for those)", async () => {
+    const { toastStub, listStub } = stubDeleteEnvironment(new Response(null, { status: 404 }));
+    const { dropdown } = mount();
+    injectPresetRow(dropdown, {});
+
+    (dropdown.querySelector("[data-delete-preset]") as HTMLElement).click();
+    await flushPromises();
+
+    expect(toastStub).toHaveBeenCalledWith("Failed to delete preset.", "error");
+    expect(listStub).toHaveBeenCalledOnce(); // still refetched — self-correcting
+  });
+
+  it("wins over the pick branch for a delete span nested inside the anchor", async () => {
+    const { deleteStub } = stubDeleteEnvironment();
+    const onPick = vi.fn();
+    const { dropdown } = mount({ onPick });
+    injectPresetRow(dropdown, {});
+
+    (dropdown.querySelector("[data-delete-preset]") as HTMLElement).click();
+    await flushPromises();
+
+    expect(deleteStub).toHaveBeenCalledOnce();
+    expect(onPick).not.toHaveBeenCalled();
+  });
+
+  it("does not stack listeners when setup runs twice on the same root", () => {
+    const { deleteStub } = stubDeleteEnvironment();
+    const confirmStub = vi.fn(() => true);
+    vi.stubGlobal("confirm", confirmStub);
+    const { root, dropdown } = mount();
+    setupPresetDropdown({
+      root,
+      dropdownSelector: "[data-preset-dropdown]",
+      listUrl: LIST_URL,
+      mode: "games",
+    });
+    injectPresetRow(dropdown, {});
+
+    (dropdown.querySelector("[data-delete-preset]") as HTMLElement).click();
+
+    expect(confirmStub).toHaveBeenCalledOnce();
+    expect(deleteStub).toHaveBeenCalledOnce();
+  });
+});
+
+describe("pick", () => {
+  it("parses the anchor's ?filter= JSON into onPick and prevents navigation", () => {
+    const onPick = vi.fn();
+    const { dropdown } = mount({ onPick });
+    const filter = { AND: [{ status: { modifier: "EQUALS", value: "f" } }] };
+    injectPresetRow(dropdown, filter);
+
+    const anchor = dropdown.querySelector("a[href]") as HTMLAnchorElement;
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    anchor.dispatchEvent(event);
+
+    expect(onPick).toHaveBeenCalledWith(filter);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("leaves anchors alone when no onPick is given (native navigation)", () => {
+    const { dropdown } = mount();
+    injectPresetRow(dropdown, {});
+
+    const anchor = dropdown.querySelector("a[href]") as HTMLAnchorElement;
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    anchor.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("toasts and logs 'preset load failed' when onPick throws", () => {
+    const toastStub = vi.fn();
+    (window as unknown as Record<string, unknown>).toast = toastStub;
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const onPick = vi.fn(() => {
+      throw new Error("bad filter shape");
+    });
+    const { dropdown } = mount({ onPick });
+    injectPresetRow(dropdown, {});
+
+    (dropdown.querySelector("a[href]") as HTMLElement).click();
+
+    expect(toastStub).toHaveBeenCalledWith("Preset is not a valid filter.", "error");
+    // The builder e2e greps the console for this substring as its crash guard.
+    expect(String(consoleError.mock.calls[0][0])).toContain("preset load failed");
+  });
+});
+
+describe("savePreset", () => {
+  it("POSTs an urlencoded body with Content-Type and X-CSRFToken", async () => {
+    document.cookie = "csrftoken=testtoken";
+    const fetchStub = vi.fn(() => Promise.resolve(new Response(null, { status: 201 })));
+    (window as unknown as Record<string, unknown>).fetchWithHtmxTriggers = fetchStub;
+
+    const filter = { search: { value: "mario", modifier: "INCLUDES" } };
+    const response = await savePreset("/tracker/filter/presets/save", {
+      name: "My preset",
+      mode: "games",
+      filter,
+    });
+
+    expect(response?.ok).toBe(true);
+    const [url, options] = fetchStub.mock.calls[0] as unknown as [
+      string,
+      RequestInit & { headers: Record<string, string>; body: string },
+    ];
+    expect(url).toBe("/tracker/filter/presets/save");
+    expect(options.method).toBe("POST");
+    expect(options.headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+    expect(options.headers["X-CSRFToken"]).toBe("testtoken");
+    const body = new URLSearchParams(options.body);
+    expect(body.get("name")).toBe("My preset");
+    expect(body.get("mode")).toBe("games");
+    expect(body.get("filter")).toBe(JSON.stringify(filter));
+  });
+
+  it("resolves null and toasts on a transport failure", async () => {
+    const fetchStub = vi.fn(() => Promise.reject(new Error("network down")));
+    (window as unknown as Record<string, unknown>).fetchWithHtmxTriggers = fetchStub;
+    const toastStub = vi.fn();
+    (window as unknown as Record<string, unknown>).toast = toastStub;
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await savePreset("/tracker/filter/presets/save", {
+      name: "My preset",
+      mode: "games",
+      filter: {},
+    });
+
+    expect(response).toBeNull();
+    expect(toastStub).toHaveBeenCalledWith("Failed to save preset.", "error");
+  });
+});

--- a/ts/elements/presets.ts
+++ b/ts/elements/presets.ts
@@ -1,0 +1,187 @@
+/**
+ * Shared filter-preset plumbing for <filter-bar> and <filter-builder> (#264).
+ *
+ * Owns the preset dropdown lifecycle — fetching the list_presets fragment,
+ * delete handling (confirm → DELETE → refetch), and optional pick
+ * interception — plus the save_preset POST and the CSRF token read. The two
+ * callers differ only in what a preset click does: the bar lets the anchor
+ * navigate natively (no `onPick`), the builder feeds `group.loadFilter()`.
+ */
+
+export function getCsrfToken(): string {
+  const match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
+  if (match) return decodeURIComponent(match[1]);
+  const element = document.querySelector<HTMLInputElement>('input[name="csrfmiddlewaretoken"]');
+  if (element) return element.value;
+  console.warn("presets: CSRF token not found — preset save/delete will 403");
+  return "";
+}
+
+export interface PresetDropdownOptions {
+  /** Persistent element carrying the delegated click listener. */
+  root: HTMLElement;
+  /**
+   * Resolved against `root` on every use, never captured — the dropdown's
+   * contents (and potentially the node itself) are replaced after load/delete.
+   */
+  dropdownSelector: string;
+  listUrl: string;
+  mode: string;
+  /**
+   * When set, clicks on preset anchors are intercepted: the anchor's
+   * ?filter= JSON is parsed and passed here. When unset, anchors keep their
+   * native navigation. A throw from the callback (valid JSON, bad filter
+   * shape) is caught and surfaced as the "not a valid filter" toast.
+   */
+  onPick?: (filter: Record<string, unknown>) => void;
+  /** Runs after each successful list render (e.g. re-check name collisions). */
+  onListRendered?: () => void;
+}
+
+export interface PresetDropdown {
+  /** Refetch and re-render the preset list. Never rejects. */
+  refresh(): Promise<void>;
+  /** Remove the delegated click listener. */
+  dispose(): void;
+}
+
+const UNAVAILABLE_HTML = '<span class="text-sm text-body italic">Presets unavailable</span>';
+
+// connectedCallback re-runs when an element is moved or re-appended; without
+// this, each re-setup would stack another delegated listener on the same root
+// (one click → two confirm()s → two DELETEs).
+const controllers = new WeakMap<HTMLElement, PresetDropdown>();
+
+export function setupPresetDropdown(options: PresetDropdownOptions): PresetDropdown {
+  const { root, dropdownSelector, listUrl, mode, onPick, onListRendered } = options;
+
+  controllers.get(root)?.dispose();
+  const abortController = new AbortController();
+
+  function dropdown(): HTMLElement | null {
+    return root.querySelector<HTMLElement>(dropdownSelector);
+  }
+
+  async function refresh(): Promise<void> {
+    const container = dropdown();
+    if (!container || !listUrl) return;
+    try {
+      const url = new URL(listUrl, window.location.origin);
+      if (!url.searchParams.has("mode")) url.searchParams.set("mode", mode);
+      const response = await fetch(url.toString(), { credentials: "same-origin" });
+      if (!response.ok) throw new Error(`preset list failed (${response.status})`);
+      container.innerHTML = await response.text();
+      onListRendered?.();
+    } catch (error) {
+      container.innerHTML = UNAVAILABLE_HTML;
+      console.error("presets: failed to load preset list", error);
+    }
+  }
+
+  function deletePreset(deleteButton: HTMLElement): void {
+    const deleteUrl = deleteButton.getAttribute("href");
+    if (!deleteUrl || !confirm("Delete this preset?")) return;
+    window
+      .fetchWithHtmxTriggers(deleteUrl, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: { "X-CSRFToken": getCsrfToken() },
+      })
+      .then((response) => {
+        // delete_preset attaches no Django message on 404/405/500, so no
+        // HX-Trigger toast fires for a rejection — surface one here.
+        if (response && !response.ok) window.toast("Failed to delete preset.", "error");
+        // Refetch regardless of the outcome: self-correcting either way (a
+        // stale-row 404 makes the row vanish instead of lingering).
+        return refresh();
+      })
+      .catch((error: unknown) => {
+        console.error("presets: delete preset failed", error);
+        window.toast("Failed to delete preset.", "error");
+      });
+  }
+
+  function pickPreset(anchor: HTMLAnchorElement): void {
+    if (!onPick) return;
+    try {
+      const raw = new URL(anchor.href, window.location.origin).searchParams.get("filter") ?? "";
+      onPick(raw ? (JSON.parse(raw) as Record<string, unknown>) : {});
+    } catch (error) {
+      // Message must keep the "preset load failed" substring — the builder e2e
+      // greps the console for it as its crash guard.
+      console.error("presets: preset load failed", error);
+      window.toast("Preset is not a valid filter.", "error");
+    }
+  }
+
+  root.addEventListener(
+    "click",
+    (event) => {
+      const target = event.target as HTMLElement | null;
+      const container = target ? dropdown() : null;
+      if (!target || !container) return;
+      // Delete FIRST: list_presets nests the delete <span data-delete-preset>
+      // INSIDE the preset <a href>, so the anchor branch would swallow it.
+      const deleteButton = target.closest<HTMLElement>("[data-delete-preset]");
+      if (deleteButton && container.contains(deleteButton)) {
+        event.preventDefault();
+        deletePreset(deleteButton);
+        return;
+      }
+      if (!onPick) return; // no interception — preset anchors navigate natively
+      const anchor = target.closest<HTMLAnchorElement>("a[href]");
+      if (anchor && container.contains(anchor)) {
+        event.preventDefault();
+        pickPreset(anchor);
+      }
+    },
+    { signal: abortController.signal },
+  );
+
+  const controller: PresetDropdown = {
+    refresh,
+    dispose(): void {
+      abortController.abort();
+      if (controllers.get(root) === controller) controllers.delete(root);
+    },
+  };
+  controllers.set(root, controller);
+  return controller;
+}
+
+export interface SavePresetRequest {
+  name: string;
+  mode: string;
+  filter: Record<string, unknown>;
+}
+
+/**
+ * POST the filter to save_preset. Resolves to the Response, or null on a
+ * transport failure (already toasted here — with no Response there is no
+ * HX-Trigger, so no server toast fired). Server-side rejections carry their
+ * own Django-message toast via fetchWithHtmxTriggers; callers only need to
+ * branch on `response?.ok` for their success UI.
+ */
+export function savePreset(saveUrl: string, request: SavePresetRequest): Promise<Response | null> {
+  const body = new URLSearchParams();
+  body.append("name", request.name);
+  body.append("mode", request.mode);
+  body.append("filter", JSON.stringify(request.filter));
+  return window
+    .fetchWithHtmxTriggers(saveUrl, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        // Mandatory with a string body: without it the request goes out as
+        // text/plain and request.POST parses empty (a misleading 400).
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-CSRFToken": getCsrfToken(),
+      },
+      body: body.toString(),
+    })
+    .catch((error: unknown) => {
+      console.error("presets: failed to save preset", error);
+      window.toast("Failed to save preset.", "error");
+      return null;
+    });
+}


### PR DESCRIPTION
Closes #264. Part of #168.

## What

`ts/elements/filter-bar.ts` and `ts/elements/filter-builder.ts` carried near-identical preset **load / save / delete** flows (deliberately duplicated in #196 to keep that PR to new files). This extracts them into a new `ts/elements/presets.ts`:

- `setupPresetDropdown({root, dropdownSelector, listUrl, mode, onPick?, onListRendered?})` — owns the dropdown lifecycle: fetches the `list_presets` fragment (appending `mode` only when the URL doesn't already carry one, via `URL.searchParams`), and handles delete + pick through **one delegated click listener on the persistent custom element** (survives innerHTML swaps; delete checked first since the delete `<span>` nests inside the preset `<a>`).
- The **on-pick behavior is the parameter**: the bar passes no `onPick`, so preset anchors keep native navigation; the builder's `onPick` feeds `group.loadFilter()` and hides the dropdown. A callback throw (valid JSON, bad filter shape) is caught and keeps both the `"Preset is not a valid filter."` toast and the `"preset load failed"` console substring the builder e2e greps as its crash guard.
- `savePreset(saveUrl, {name, mode, filter})` — urlencoded POST via `fetchWithHtmxTriggers` + `X-CSRFToken`; toasts and resolves `null` on transport failure so callers branch only on `response?.ok`.
- One `getCsrfToken()` (the builder's regex + `decodeURIComponent` + hidden-input fallback wins).
- Reconnect-safe: per-root WeakMap disposes the previous delegated listener on re-setup (`connectedCallback` re-runs on DOM moves — a fresh closure per call would stack listeners → double `confirm()`/double DELETE); `dispose()` is AbortController-backed and wired into the builder's `disconnectedCallback`. `refresh()` never rejects — all failures render the "Presets unavailable" placeholder.

## Behavior changes (all improvements, none asserted by existing tests)

1. **After-delete unified to a list refetch** for both callers. The bar's in-place `<li>` removal + hand-written "No saved presets" placeholder die (the server fragment renders an identical placeholder itself). The builder's dropdown now **stays open with the refreshed list** — previously `.then(() => this.onLoadPresets())` *toggled* it hidden and early-returned, so it closed without ever refetching.
2. **Bar post-delete re-checks the overwrite warning** — deleting a preset whose name is typed in the save input no longer leaves a stale "Overwrite" label.
3. **Delete server rejection now toasts.** `delete_preset` attaches no Django message on 404/405/500, so no HX-Trigger toast ever fired for those (the old "its toast already fired" comment was wrong). The unconditional refetch is also self-correcting for a stale-row 404.
4. **Builder save clears the name input only on `response.ok`** (previously cleared even when the server rejected).
5. **Builder list-load failure** surfaces as the in-dropdown placeholder instead of a toast (the bar's existing pattern).

## Tests

- New `ts/elements/presets.test.ts` (17 cases): CSRF read/decode/fallback, mode-append logic, empty-listUrl no-op, never-reject failure placeholder, delete flow (confirm decline, CSRF header, refetch, rejection toast, delete-inside-anchor ordering, no listener stacking on re-setup), pick with/without `onPick` incl. the throw→toast path, savePreset body/headers + transport-failure null.
- `ts/elements/filter-builder.test.ts`: all 9 cases pass unchanged.
- Full `make check` green (lint, format, mypy, ts-check, vitest, pytest incl. `e2e/` — 1411 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)