### PR TITLE
refactor(components): fold dropdown toggle styles into ControlButton variants

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -3,6 +3,9 @@ name: Django CI/CD
 on:
   push:
     paths-ignore: [ 'README.md' ]
+  # allow manual reruns from the Actions tab (an empty retrigger commit
+  # matches no paths, so the push trigger skips it)
+  workflow_dispatch:
 
 jobs:
   test:

--- a/common/components/custom_elements.py
+++ b/common/components/custom_elements.py
@@ -479,25 +479,10 @@ _Dropdown = custom_element_builder("drop-down")
 # `outline`: a border on the toggle AND panel for button-like (non-menu)
 # dropdowns (the value selectors, the played-row split button); menu-like
 # dropdowns (the navbar) stay borderless (shadow only). Behavior is shared via
-# attachMenu; these constants are the single source of truth for the look and
-# are reused by the selectors (domain.py) and the played row (game.py).
-
-# Outlined (button-like) toggle: bordered button, no base rounding — Dropdown
-# adds rounded-lg / rounded-e-lg by shape; standalone consumers add their own.
-DROPDOWN_TOGGLE_OUTLINE = (
-    "px-2 py-1 lg:px-4 lg:py-2 text-xs font-medium bg-white border border-gray-200 "
-    "hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:text-white "
-    "dark:hover:bg-gray-700 hover:cursor-pointer whitespace-nowrap"
-)
-
-# Plain (menu-like) toggle: the borderless navbar nav-link look.
-_DROPDOWN_TOGGLE_PLAIN = (
-    "flex items-center justify-between w-full py-2 px-3 text-gray-900 rounded-sm "
-    "hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 "
-    "md:p-0 md:w-auto dark:text-white md:dark:hover:text-blue-500 "
-    "dark:focus:text-white dark:border-gray-700 dark:hover:bg-gray-700 "
-    "md:dark:hover:bg-transparent hover:cursor-pointer"
-)
+# attachMenu. Toggle looks live on ControlButton (issue #272):
+# variant="outline" is the bordered toggle (no base rounding — Dropdown adds
+# rounded-lg / rounded-e-lg by shape; standalone consumers add their own),
+# variant="plain" the borderless navbar trigger.
 
 # Panel: white (light) / frosted (dark). Keeps the #46 overflow-hidden. Outline
 # adds a border; otherwise a shadow.
@@ -775,9 +760,9 @@ def MenuDropdown(
 ) -> Node:
     """A borderless, navbar-style menu dropdown (the old non-outline look)."""
     trigger = _as_menu_trigger(
-        Button(type="button", class_=_DROPDOWN_TOGGLE_PLAIN)[
+        ControlButton(variant="plain")[
             Span(class_="flex items-center gap-1")[label, Icon("arrowdown")]
-        ]
+        ].as_element()
     )
     return Dropdown(
         trigger_element=trigger,
@@ -824,9 +809,9 @@ def SplitButtonDropdown(
     that opens the menu. The Dropdown attaches to the caret only — ``primary`` is
     a plain sibling, so the core never needs to know it exists."""
     caret = _as_menu_trigger(
-        Button(type="button", class_=DROPDOWN_TOGGLE_OUTLINE + " rounded-e-lg")[
+        ControlButton([("class", "rounded-e-lg")], variant="outline")[
             Icon("arrowdown")
-        ]
+        ].as_element()
     )
     dropdown = Dropdown(
         trigger_element=caret,
@@ -922,17 +907,15 @@ def SelectDropdown(
     """A value-selector dropdown: a current-value trigger + a listbox whose picks
     PATCH the server (via the client `select` behavior). The per-entity specifics
     (endpoint, body key, numeric) are the caller's; this owns the shared shape."""
-    trigger = Button(
-        type="button",
-        class_=(
-            DROPDOWN_TOGGLE_OUTLINE + " rounded-lg" + (f" {class_}" if class_ else "")
-        ),
+    trigger = ControlButton(
+        [("class", "rounded-lg" + (f" {class_}" if class_ else ""))],
+        variant="outline",
         aria_haspopup="listbox",
     )[
         Span(class_="flex flex-row gap-4 justify-between items-center")[
             Span(data_label="")[current_label], Icon("arrowdown")
         ]
-    ]
+    ].as_element()
     config: dict[str, str] = {
         "data_patch_url": patch_url,
         "data_body_key": body_key,

--- a/common/components/primitives.py
+++ b/common/components/primitives.py
@@ -337,19 +337,23 @@ _CONTROL_BASE_CLASS = (
     f"{DISABLED_CONTROL_CLASS}"
 )
 
-# Container-query sizing: compact by default (a container-query variant never
-# matches without an `@container` ancestor, so "no wrapper" = compact by
-# construction); form-shaped containers ≥ 28rem (`@md`) upsize to the old
-# default look. There is deliberately no size parameter — the container decides.
+# Container-query sizing, shared by EVERY button-shaped variant: compact by
+# default (a container-query variant never matches without an `@container`
+# ancestor, so "no wrapper" = compact by construction); form-shaped containers
+# ≥ 28rem (`@md`) upsize to the old default look. There is deliberately no
+# size parameter — the container decides. Note this means segmented groups and
+# outline toggles in tables are compact at every viewport width: a
+# shrink-to-fit inline-flex group cannot be its own inline-size container
+# (containment would collapse it to zero width) and table cells can't be
+# containers either — but every button on such a page is compact together.
+_CONTROL_SIZE_CLASS = "px-3 py-2 text-xs @md:px-5 @md:py-2.5 @md:text-sm"
+
 _FILLED_VARIANT_CLASS = (
     "gap-2 text-center leading-5 focus:outline-hidden focus:ring-4 rounded-base "
-    "px-3 py-2 text-xs @md:px-5 @md:py-2.5 @md:text-sm"
+    f"{_CONTROL_SIZE_CLASS}"
 )
 
-# Segmented members keep viewport-based sizing: a shrink-to-fit inline-flex
-# group cannot be its own inline-size container (containment would collapse it
-# to zero width), and its ancestors (table cells) can't be containers either.
-_SEGMENTED_VARIANT_CLASS = "focus:z-10 px-2 py-1 text-xs lg:px-4 lg:py-2 lg:text-sm"
+_SEGMENTED_VARIANT_CLASS = f"focus:z-10 {_CONTROL_SIZE_CLASS}"
 
 _FILLED_COLOR_CLASSES: dict[ButtonColor, str] = {
     "blue": "text-white bg-brand box-border border border-transparent hover:bg-brand-strong focus:ring-brand-medium",
@@ -397,14 +401,15 @@ _SEGMENTED_COLOR_CLASSES: dict[ButtonColor, str] = {
 }
 
 
-# Dropdown-toggle variants (issue #272): single-look, no color axis. Their
-# layout contradicts _CONTROL_BASE_CLASS (plain is a nav-link — flex
-# justify-between, no centering; neither wants the container-query sizing), so
-# each carries its complete look and skips the base + color stack.
+# Dropdown-toggle variants (issue #272): single-look, no color axis. Outline
+# is a regular button-shaped control — base + shared sizing + its bordered
+# look. Plain is the navbar nav-link: its layout (flex justify-between,
+# md:p-0) contradicts the base and the sizing scale, so it alone carries its
+# complete look and skips both.
 _OUTLINE_VARIANT_CLASS = (
-    "px-2 py-1 lg:px-4 lg:py-2 text-xs font-medium bg-white border border-gray-200 "
+    f"{_CONTROL_SIZE_CLASS} bg-white border border-gray-200 "
     "hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:text-white "
-    "dark:hover:bg-gray-700 hover:cursor-pointer whitespace-nowrap"
+    "dark:hover:bg-gray-700 whitespace-nowrap"
 )
 
 _PLAIN_VARIANT_CLASS = (
@@ -432,13 +437,15 @@ class ControlButton(BaseComponent):
 
     Sizing contract: compact by default; upsizes inside an ``@container``
     ancestor at least 28rem wide (``@md``). There is no size parameter — the
-    container decides. ``variant="segmented"`` is the ButtonGroup-member look
-    (white background, hover hue, viewport-based sizing).
+    container decides, and every button-shaped variant follows the same scale.
+    ``variant="segmented"`` is the ButtonGroup-member look (white background,
+    hover hue).
 
     The dropdown-toggle variants are single-look and ignore ``color``:
     ``variant="outline"`` is the bordered toggle (split-button carets, value
     selectors — callers add rounding by shape, e.g. ``rounded-e-lg``);
-    ``variant="plain"`` is the borderless navbar nav-link trigger.
+    ``variant="plain"`` is the borderless navbar nav-link trigger, the one
+    variant outside the sizing contract (its navbar layout is its own).
 
     Children go via the htpy ``[]`` slot — ``ControlButton(color="red")[label]``
     — which routes into the inner button in post mode. Extra attributes take the
@@ -461,7 +468,10 @@ class ControlButton(BaseComponent):
         **kwargs: object,
     ) -> None:
         if variant == "outline":
-            class_attrs: list[HTMLAttribute] = [("class", _OUTLINE_VARIANT_CLASS)]
+            class_attrs: list[HTMLAttribute] = [
+                ("class", _CONTROL_BASE_CLASS),
+                ("class", _OUTLINE_VARIANT_CLASS),
+            ]
         elif variant == "plain":
             class_attrs = [("class", _PLAIN_VARIANT_CLASS)]
         else:

--- a/common/components/primitives.py
+++ b/common/components/primitives.py
@@ -39,7 +39,12 @@ from common.sorting import SortString, SortTerm, collapse_sort, cycle_sort
 from common.utils import truncate
 
 type ButtonColor = Literal["blue", "red", "gray", "green"]  # e.g. "red" (destructive)
-type ButtonVariant = Literal["filled", "segmented"]  # standalone vs ButtonGroup member
+type ButtonVariant = Literal[
+    "filled",  # standalone default
+    "segmented",  # ButtonGroup member
+    "outline",  # bordered dropdown-toggle look (colorless)
+    "plain",  # borderless navbar nav-link look (colorless)
+]
 
 # Shared disabled appearance for every form control, so all form elements look
 # the same when disabled. Put on the control itself (DISABLED_CONTROL_CLASS) or,
@@ -392,6 +397,25 @@ _SEGMENTED_COLOR_CLASSES: dict[ButtonColor, str] = {
 }
 
 
+# Dropdown-toggle variants (issue #272): single-look, no color axis. Their
+# layout contradicts _CONTROL_BASE_CLASS (plain is a nav-link — flex
+# justify-between, no centering; neither wants the container-query sizing), so
+# each carries its complete look and skips the base + color stack.
+_OUTLINE_VARIANT_CLASS = (
+    "px-2 py-1 lg:px-4 lg:py-2 text-xs font-medium bg-white border border-gray-200 "
+    "hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:text-white "
+    "dark:hover:bg-gray-700 hover:cursor-pointer whitespace-nowrap"
+)
+
+_PLAIN_VARIANT_CLASS = (
+    "flex items-center justify-between w-full py-2 px-3 text-gray-900 rounded-sm "
+    "hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 "
+    "md:p-0 md:w-auto dark:text-white md:dark:hover:text-blue-500 "
+    "dark:focus:text-white dark:border-gray-700 dark:hover:bg-gray-700 "
+    "md:dark:hover:bg-transparent hover:cursor-pointer"
+)
+
+
 class ControlButton(BaseComponent):
     """The one polymorphic button/link builder — single home for button styling
     and the ``<a>``-vs-``<button>`` choice (issue #235).
@@ -410,6 +434,11 @@ class ControlButton(BaseComponent):
     ancestor at least 28rem wide (``@md``). There is no size parameter — the
     container decides. ``variant="segmented"`` is the ButtonGroup-member look
     (white background, hover hue, viewport-based sizing).
+
+    The dropdown-toggle variants are single-look and ignore ``color``:
+    ``variant="outline"`` is the bordered toggle (split-button carets, value
+    selectors — callers add rounding by shape, e.g. ``rounded-e-lg``);
+    ``variant="plain"`` is the borderless navbar nav-link trigger.
 
     Children go via the htpy ``[]`` slot — ``ControlButton(color="red")[label]``
     — which routes into the inner button in post mode. Extra attributes take the
@@ -431,16 +460,28 @@ class ControlButton(BaseComponent):
         _children: Children = None,
         **kwargs: object,
     ) -> None:
-        variant_class = (
-            _FILLED_VARIANT_CLASS if variant == "filled" else _SEGMENTED_VARIANT_CLASS
-        )
-        color_table = (
-            _FILLED_COLOR_CLASSES if variant == "filled" else _SEGMENTED_COLOR_CLASSES
-        )
+        if variant == "outline":
+            class_attrs: list[HTMLAttribute] = [("class", _OUTLINE_VARIANT_CLASS)]
+        elif variant == "plain":
+            class_attrs = [("class", _PLAIN_VARIANT_CLASS)]
+        else:
+            variant_class = (
+                _FILLED_VARIANT_CLASS
+                if variant == "filled"
+                else _SEGMENTED_VARIANT_CLASS
+            )
+            color_table = (
+                _FILLED_COLOR_CLASSES
+                if variant == "filled"
+                else _SEGMENTED_COLOR_CLASSES
+            )
+            class_attrs = [
+                ("class", _CONTROL_BASE_CLASS),
+                ("class", variant_class),
+                ("class", color_table[color]),
+            ]
         self._merged_attributes: list[HTMLAttribute] = [
-            ("class", _CONTROL_BASE_CLASS),
-            ("class", variant_class),
-            ("class", color_table[color]),
+            *class_attrs,
             *_coerce_attrs(attrs),
             *_attrs_from_kwargs(kwargs),
         ]

--- a/common/components/primitives.py
+++ b/common/components/primitives.py
@@ -1216,7 +1216,9 @@ def get_icon_node(name: str) -> Element:
 # buttons (bigger than the small inline platform icons). Tune sizes here.
 ICON_BASE_CLASS = "text-black dark:text-white"
 ICON_SIZE_CLASS = "w-2 h-2 lg:w-4 lg:h-4"
-ICON_BUTTON_SIZE_CLASS = "w-5 h-5"
+# Tracks _CONTROL_SIZE_CLASS's text line-height (text-xs → 1rem, @md:text-sm
+# → 1.25rem) so icon-only buttons stay exactly as tall as text ones.
+ICON_BUTTON_SIZE_CLASS = "w-4 h-4 @md:w-5 @md:h-5"
 
 
 def _with_title(children: Sequence[Child], title: str) -> list[Child]:

--- a/e2e/test_control_sizing_e2e.py
+++ b/e2e/test_control_sizing_e2e.py
@@ -1,0 +1,62 @@
+"""Same-row controls share one rendered height (issue #272 follow-up).
+
+The session-list row mixes a text control (the device-selector trigger, an
+outline ControlButton) with icon-only segmented buttons (finish/reset/edit/
+delete). Both follow ControlButton's container sizing scale, and button icons
+are sized to the text line-height — so an icon-only button must not out-grow
+a text one sitting on the same row.
+"""
+
+import datetime as dt
+
+import pytest
+from django.urls import reverse
+from playwright.sync_api import Page, expect
+
+from games.models import Device, Game, Platform, Session
+
+
+@pytest.fixture
+def authenticated_page(live_server, page: Page, django_user_model) -> Page:
+    django_user_model.objects.create_user(username="tester", password="secret123")
+    page.goto(f"{live_server.url}{reverse('login')}")
+    page.fill('input[name="username"]', "tester")
+    page.fill('input[name="password"]', "secret123")
+    page.click('button:has-text("Login")')
+    page.wait_for_url(f"{live_server.url}/tracker**")
+    return page
+
+
+def _make_session() -> Session:
+    platform = Platform.objects.create(name="PC", icon="pc", group="PC")
+    game = Game.objects.create(name="Sized Game", platform=platform)
+    Device.objects.create(name="Handheld", type=Device.HANDHELD)
+    # running (no end) so the row shows the finish/reset icon actions
+    return Session.objects.create(
+        game=game,
+        timestamp_start=dt.datetime(2020, 1, 1, 10, 0, tzinfo=dt.timezone.utc),
+    )
+
+
+def test_selector_trigger_and_icon_actions_share_height(
+    authenticated_page: Page, live_server
+):
+    page = authenticated_page
+    session = _make_session()
+
+    page.goto(f"{live_server.url}{reverse('games:list_sessions')}")
+    row = page.locator(f"#session-row-{session.id}")
+    expect(row).to_be_visible()
+
+    selector_trigger = row.locator("drop-down [data-toggle]").first
+    reset_button = row.locator("button[data-reset]")
+    expect(selector_trigger).to_be_visible()
+    expect(reset_button).to_be_visible()
+
+    trigger_box = selector_trigger.bounding_box()
+    action_box = reset_button.bounding_box()
+    assert trigger_box is not None and action_box is not None
+    assert abs(trigger_box["height"] - action_box["height"]) <= 1, (
+        f"device selector trigger is {trigger_box['height']}px tall but the "
+        f"icon action button is {action_box['height']}px"
+    )

--- a/games/views/game.py
+++ b/games/views/game.py
@@ -327,20 +327,20 @@ def _played_row(game: Game, request: HttpRequest) -> Node:
     """'Played N times' split button: a generic outlined Dropdown wrapped in
     <play-event-row>, which owns only the 'Played +1' action."""
     from common.components import (
+        ControlButton,
         DropdownActionItem,
         DropdownLinkItem,
         SplitButtonDropdown,
     )
-    from common.components.custom_elements import DROPDOWN_TOGGLE_OUTLINE, _PlayEventRow
-    from common.components.primitives import Button
+    from common.components.custom_elements import _PlayEventRow
 
     played = game.playevents.count()
 
-    count_button = A(href=reverse("games:add_playevent"))[
-        Button(class_=DROPDOWN_TOGGLE_OUTLINE + " rounded-s-lg")[
-            Span(data_count="")[str(played)], " times"
-        ]
-    ]
+    count_button = ControlButton(
+        [("class", "rounded-s-lg")],
+        variant="outline",
+        href=reverse("games:add_playevent"),
+    )[Span(data_count="")[str(played)], " times"]
     dropdown = SplitButtonDropdown(
         primary=count_button,
         id=f"played-{game.id}",

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -862,8 +862,9 @@ class ControlButtonTest(SimpleTestCase):
 
     def test_segmented_variant_classes(self):
         html = str(components.ControlButton(variant="segmented", color="gray")["Edit"])
-        self.assertIn("lg:px-4", html)  # viewport-based sizing, not container
-        self.assertNotIn("@md:", html)
+        # container-query sizing, same scale as filled — no viewport sizing
+        self.assertIn("@md:px-5", html)
+        self.assertNotIn("lg:px-4", html)
         self.assertIn("bg-white", html)
 
     def test_color_tables_have_matching_keys(self):
@@ -883,10 +884,21 @@ class ControlButtonTest(SimpleTestCase):
         self.assertTrue(html.startswith("<button"))
         self.assertIn("whitespace-nowrap", html)
         self.assertIn("border-gray-200", html)
-        # single-look variant: no color axis, no container sizing, no focus ring
+        # container-query sizing, same scale as every other button variant
+        self.assertIn("@md:px-5", html)
+        self.assertNotIn("lg:px-4", html)
+        # single-look variant: no color axis, no focus ring
         self.assertNotIn("bg-brand", html)
-        self.assertNotIn("@md:", html)
         self.assertNotIn("focus:ring", html)
+
+    def test_button_variants_share_one_sizing_scale(self):
+        # ALL button-shaped variants size via the container contract; only the
+        # nav-link plain variant keeps its navbar layout
+        for variant in ("filled", "segmented", "outline"):
+            with self.subTest(variant=variant):
+                html = str(components.ControlButton(variant=variant)["x"])
+                self.assertIn("px-3 py-2 text-xs", html)
+                self.assertIn("@md:px-5 @md:py-2.5 @md:text-sm", html)
 
     def test_plain_variant_is_the_navbar_nav_link_look(self):
         html = str(components.ControlButton(variant="plain")["x"])

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -878,6 +878,39 @@ class ControlButtonTest(SimpleTestCase):
         element = components.ControlButton()["Go"].as_element()
         self.assertEqual(element.tag_name, "button")
 
+    def test_outline_variant_is_the_dropdown_toggle_look(self):
+        html = str(components.ControlButton(variant="outline")["x"])
+        self.assertTrue(html.startswith("<button"))
+        self.assertIn("whitespace-nowrap", html)
+        self.assertIn("border-gray-200", html)
+        # single-look variant: no color axis, no container sizing, no focus ring
+        self.assertNotIn("bg-brand", html)
+        self.assertNotIn("@md:", html)
+        self.assertNotIn("focus:ring", html)
+
+    def test_plain_variant_is_the_navbar_nav_link_look(self):
+        html = str(components.ControlButton(variant="plain")["x"])
+        self.assertIn("md:hover:text-blue-700", html)
+        self.assertIn("justify-between", html)
+        # the nav-link layout survives untouched: no centering or inline-flex
+        # from the filled/segmented base, no color table
+        self.assertNotIn("justify-center", html)
+        self.assertNotIn("inline-flex", html)
+        self.assertNotIn("bg-brand", html)
+
+    def test_toggle_variants_ignore_color(self):
+        default = str(components.ControlButton(variant="outline")["x"])
+        red = str(components.ControlButton(variant="outline", color="red")["x"])
+        self.assertEqual(red, default)
+
+    def test_outline_variant_takes_extra_shape_classes(self):
+        html = str(
+            components.ControlButton([("class", "rounded-e-lg")], variant="outline")[
+                "x"
+            ]
+        )
+        self.assertIn("rounded-e-lg", html)
+
 
 class ModalContractTest(SimpleTestCase):
     """Modal injects [] children into the inner panel, not the outer backdrop."""

--- a/tests/test_rendered_pages.py
+++ b/tests/test_rendered_pages.py
@@ -236,6 +236,19 @@ class RenderedPagesTest(TestCase):
         self.assertNotIn("@@", html)  # token-replace hack gone
         self.assertNotIn("createPlayEvent", html)  # the old Alpine fn is gone
 
+    def test_played_row_count_link_is_a_single_anchor(self):
+        """The 'N times' count control is one styled <a> (ControlButton href
+        mode), not a <button> nested inside an <a> (invalid HTML)."""
+        game = Game.objects.create(name="Anchor Game", platform=self.platform)
+        html = self.get("games:view_game", game.id).content.decode()
+        row = html[html.index("<play-event-row") :]
+        count_at = row.index("data-count")
+        control = row[row.rindex("<a", 0, count_at) : row.index("</a>", count_at)]
+        self.assertNotIn("<button", control)
+        # the anchor itself carries the outline-toggle look and its shape class
+        self.assertIn("border-gray-200", control)
+        self.assertIn("rounded-s-lg", control)
+
     def test_view_game_empty_sections(self):
         """A game with no sessions/purchases/etc shows the empty messages."""
         lonely = Game.objects.create(name="Lonely Game", platform=self.platform)


### PR DESCRIPTION
Closes #272. Follow-up to #235 / #270.

## What

- `ControlButton` gains two single-look, colorless variants: `variant="outline"` (bordered dropdown-toggle) and `variant="plain"` (borderless navbar nav-link). Class strings are byte-identical to the `DROPDOWN_TOGGLE_OUTLINE` / `_DROPDOWN_TOGGLE_PLAIN` constants they replace, and the variants skip the filled/segmented base stack because the plain nav-link layout (`flex justify-between w-full`) contradicts it.
- The two constants are deleted from `custom_elements.py`. `MenuDropdown`, the `SplitButtonDropdown` caret, and the `SelectDropdown` trigger now build their toggles via `ControlButton(...).as_element()`, like `ButtonDropdown` already did. Shape rounding (`rounded-lg`, `rounded-e-lg`, `rounded-s-lg`) stays at the call sites.
- The played-row "N times" control in `games/views/game.py` becomes a single styled `<a>` (ControlButton href mode) instead of a `<button>` nested inside an `<a>` — the one deliberate DOM change, covered by a new rendered-page test.

## Verification

- A render snapshot taken before/after the migration shows `MenuDropdown`, `SplitButtonDropdown`, and `SelectDropdown` produce byte-identical HTML.
- New TDD-first unit tests cover both variants (look, color-axis ignored, extra shape classes) plus the played-row single-anchor shape.
- Full local gate green: ruff lint + format, mypy, ts-check, icon-codegen check, vitest (309), pytest unit suite (1280), full Playwright e2e (130).

Note: run locally outside the Nix shell (no pnpm on the host), so `node_modules` was refreshed via npm and Python deps resolved patch-level newer than `uv.lock`; CI's `make check` is the authoritative confirmation.

## Update: one sizing scale for all button variants

Second commit: the filled variant's container-query sizing is extracted into a shared `_CONTROL_SIZE_CLASS` and composed into **segmented** and **outline** (which also adopts the shared control base classes), replacing their viewport `lg:` scales. Only the `plain` nav-link variant keeps its own navbar layout.

Intentional visual change: segmented groups and outline toggles on table pages (no `@container` ancestor possible — table cells can't be size containers) now render compact at every viewport width, but consistently — previously selector triggers stayed `text-xs` while neighbouring Edit/Delete groups upsized at `lg:`, so same-page controls sat at different heights. Full gate re-run green (1297 unit / 130 e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
