### PR TITLE
refactor(filters): move chip and relation-select styling into server templates (#273)

### DIFF
--- a/common/components/custom_elements.py
+++ b/common/components/custom_elements.py
@@ -225,9 +225,11 @@ def FilterGroup(*, model: str, filter: str = "") -> Node:
 
     from common.components.filters import (
         FilterFieldPicker,
+        chip_templates,
         comparison_row_template,
         field_widget_templates,
         has_comparable_group,
+        relation_select_template,
     )
     from common.components.primitives import Template
     from common.criteria import comparable_columns
@@ -253,6 +255,11 @@ def FilterGroup(*, model: str, filter: str = "") -> Node:
     templates.append(
         Template(data_action_button_template="")[ControlButton(color="gray")[""]]
     )
+    # Likewise the connective/NOT chips (one template per visual state) and the
+    # relation rows' quantifier/relation-field <select> (#273) — the last
+    # TS-declared control styling in the builder moves server-side.
+    templates.extend(chip_templates())
+    templates.append(relation_select_template())
 
     return _FilterGroup(
         model=model,

--- a/common/components/filters.py
+++ b/common/components/filters.py
@@ -1,7 +1,7 @@
 """Stash-style filter bars, built from FilterSelect widgets."""
 
 import json
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 from django.db import models
 
@@ -932,6 +932,82 @@ def comparison_row_template(
 
     return Template(data_fc_row_template="", **_model_attr(model))[
         _field_comparison_row(columns, None, SELECT_CLASS)
+    ]
+
+
+# Connective + NOT chips (component 2, issue #190), shipped to the nested builder
+# as one ``<template data-chip-template="<state>">`` per visual state; the client
+# clones the matching state and only wires behavior (#273). Pill shape
+# (rounded-full) + saturated fill sets this cluster apart from the square, gray
+# restructuring buttons so it never reads as "just another button". The connective
+# is color-coded by value with a NON-semantic cool/warm pair — AND = teal, OR =
+# orange — kept out of the action palette (blue/red/green/gray) so it reads as
+# "logic type", not status. The NOT-on look uses an amber FILL + RING so a lit NOT
+# chip stays distinct from an adjacent OR chip (fill-only) — they never read as
+# one blob.
+_CHIP_BASE_CLASS = (
+    "rounded-full border px-2.5 py-0.5 text-xs font-semibold hover:cursor-pointer"
+)
+
+# A chip template's visual state, doubling as its data-chip-template tag; the
+# client's ChipState mirrors it.
+type ChipState = Literal["connective-and", "connective-or", "negate-off", "negate-on"]
+
+_CHIP_STATE_CLASSES: dict[ChipState, str] = {
+    "connective-and": (
+        "border-teal-300 bg-teal-100 text-teal-800 "
+        "dark:border-teal-500/60 dark:bg-teal-500/20 dark:text-teal-200"
+    ),
+    "connective-or": (
+        "border-orange-300 bg-orange-100 text-orange-800 "
+        "dark:border-orange-500/60 dark:bg-orange-500/20 dark:text-orange-200"
+    ),
+    "negate-off": (
+        "border-gray-200 text-gray-500 hover:bg-gray-100 "
+        "dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700"
+    ),
+    "negate-on": (
+        "border-amber-400 bg-amber-100 text-amber-900 ring-1 ring-amber-400 "
+        "dark:border-amber-500/70 dark:bg-amber-500/25 dark:text-amber-100 "
+        "dark:ring-amber-500/70"
+    ),
+}
+
+# No horizontal padding: @tailwindcss/forms styles bare <select> with
+# appearance:none, a right-anchored chevron, and the right padding (~2.5rem) that
+# clears it. A px-*/pr-* utility can't beat the plugin rule for the right side;
+# px-* only overrides it symmetrically, shrinking it so the label ("any") ends up
+# under the chevron. Set only vertical padding here.
+_RELATION_SELECT_CLASS = (
+    "rounded border border-gray-300 bg-white py-1 text-sm dark:border-gray-600 "
+    "dark:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+)
+
+
+def chip_templates() -> list[Node]:
+    """The nested builder's connective/NOT chip templates, one per state (#273).
+
+    Each holds a blank chip ``<button>`` wearing that state's full class set; the
+    client (``ts/elements/filter-group.ts``) clones the state it needs and sets
+    only wiring attributes (label, action, path, title, aria-pressed) — chip
+    styling is exclusively the server's concern. Model-agnostic, like the action
+    button template."""
+    return [
+        Template(data_chip_template=state)[
+            Button(type="button", class_=f"{_CHIP_BASE_CLASS} {state_class}")[""]
+        ]
+        for state, state_class in _CHIP_STATE_CLASSES.items()
+    ]
+
+
+def relation_select_template() -> Node:
+    """The nested builder's quantifier/relation-field ``<select>`` template (#273).
+
+    One blank styled ``<select>``; the client clones it for both the ANY/NONE/ALL
+    quantifier picker and the relation-field picker, then appends its own
+    ``<option>``s (they are data, not styling)."""
+    return Template(data_relation_select_template="")[
+        Select(class_=_RELATION_SELECT_CLASS)
     ]
 
 

--- a/e2e/test_filter_builder_e2e.py
+++ b/e2e/test_filter_builder_e2e.py
@@ -22,6 +22,7 @@ Prefill behavior note:
 """
 
 import json
+import re
 import urllib.parse
 from datetime import datetime, timezone
 
@@ -103,6 +104,25 @@ def test_builder_page_elements_load_and_initialize(
     count_badge = page.locator("filter-count")
     expect(count_badge).not_to_contain_text("Counting…")
     expect(count_badge).to_contain_text("≈ 1 game")
+
+    # Server-template cloning contract (#273/#274): the tree's controls carry the
+    # server-owned classes. A broken template selector would fall back to a
+    # CLASSLESS control (the jsdom fixture path) and everything above would still
+    # pass — so assert the styling actually arrived from the server templates.
+    connective_chip = page.locator(
+        'filter-group button[data-action="toggle-connective"]'
+    ).first
+    expect(connective_chip).to_have_class(re.compile(r"rounded-full"))
+    action_button = page.locator(
+        'filter-group button[data-action="add-condition"]'
+    ).first
+    expect(action_button).not_to_have_class("")
+    add_relation = page.locator('filter-group button[data-action="add-relation"]').first
+    add_relation.click()
+    relation_match_select = page.locator(
+        "filter-group select[data-relation-match]"
+    ).first
+    expect(relation_match_select).to_have_class(re.compile(r"rounded"))
 
 
 def test_apply_navigates_to_game_list(authenticated_page: Page, live_server) -> None:

--- a/tests/test_filter_bars.py
+++ b/tests/test_filter_bars.py
@@ -910,3 +910,14 @@ class FilterGroupComparisonTest(TestCase):
         html = str(FilterGroup(model="session"))
         for marker in _ESCAPED_TAG_MARKERS:
             self.assertNotIn(marker, html)
+
+    def test_emits_chip_and_relation_select_templates(self):
+        """Chip + relation-select styling is server-owned (#273): one chip
+        template per visual state and one styled <select> template, all
+        model-agnostic (emitted once, not per reachable model)."""
+        from common.components import FilterGroup
+
+        html = str(FilterGroup(model="game"))
+        for state in ("connective-and", "connective-or", "negate-on", "negate-off"):
+            self.assertEqual(html.count(f'data-chip-template="{state}"'), 1)
+        self.assertEqual(html.count("data-relation-select-template"), 1)

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -89,6 +89,63 @@ describe("<filter-group> action-button template cloning", () => {
   });
 });
 
+describe("<filter-group> chip and relation-select template cloning", () => {
+  function mountWithControlTemplates(): FilterGroupElement {
+    document.body.replaceChildren();
+    const host = document.createElement("filter-group") as FilterGroupElement;
+    host.setAttribute("model", "game");
+    host.setAttribute("models", JSON.stringify(MODELS_BASE));
+    for (const state of ["connective-and", "connective-or", "negate-on", "negate-off"]) {
+      const template = document.createElement("template");
+      template.setAttribute("data-chip-template", state);
+      template.innerHTML = `<button type="button" class="chip-${state}"></button>`;
+      host.appendChild(template);
+    }
+    const selectTemplate = document.createElement("template");
+    selectTemplate.setAttribute("data-relation-select-template", "");
+    selectTemplate.innerHTML = '<select class="select-from-server"></select>';
+    host.appendChild(selectTemplate);
+    document.body.appendChild(host);
+    return host;
+  }
+
+  it("clones the state-matching chip template, keeping wiring attributes", () => {
+    const host = mountWithControlTemplates();
+    const connective = button(host, "toggle-connective", []);
+    expect(connective?.className).toBe("chip-connective-and");
+    expect(connective?.textContent).toBe("AND");
+    const negate = button(host, "toggle-negate", []);
+    expect(negate?.className).toBe("chip-negate-off");
+    expect(negate?.getAttribute("aria-pressed")).toBe("false");
+
+    clickAction(host, "toggle-connective", []);
+    expect(button(host, "toggle-connective", [])?.className).toBe("chip-connective-or");
+    clickAction(host, "toggle-negate", []);
+    const negated = button(host, "toggle-negate", []);
+    expect(negated?.className).toBe("chip-negate-on");
+    expect(negated?.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("clones the relation-select template for both relation-row selects", () => {
+    const host = mountWithControlTemplates();
+    clickAction(host, "add-relation", []);
+    const match = host.querySelector<HTMLSelectElement>("[data-relation-match]");
+    const field = host.querySelector<HTMLSelectElement>("[data-relation-field]");
+    expect(match?.className).toBe("select-from-server");
+    expect(field?.className).toBe("select-from-server");
+    // Options are still the client's data: the quantifier choices arrive on the clone.
+    expect(match?.options.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to classless bare chips and selects without templates", () => {
+    const host = mount();
+    expect(button(host, "toggle-connective", [])?.className).toBe("");
+    expect(button(host, "toggle-negate", [])?.className).toBe("");
+    clickAction(host, "add-relation", []);
+    expect(host.querySelector<HTMLSelectElement>("[data-relation-match]")?.className).toBe("");
+  });
+});
+
 describe("<filter-group> initial render", () => {
   it("renders a root AND group with one criterion slot and a footer", () => {
     const host = mount();
@@ -402,14 +459,9 @@ describe("<filter-group> connective + negate (component 2, #190)", () => {
     expect(button(host, "toggle-connective", [])?.textContent).toBe("AND");
   });
 
-  it("color-codes the connective chip by value (teal AND / orange OR)", () => {
-    const host = mount();
-    expect(button(host, "toggle-connective", [])?.className).toContain("teal");
-    clickAction(host, "toggle-connective", []);
-    const orChip = button(host, "toggle-connective", []);
-    expect(orChip?.className).toContain("orange");
-    expect(orChip?.className).not.toContain("teal");
-  });
+  // Color-by-value (teal AND / orange OR) is asserted via state-template
+  // selection in the "chip and relation-select template cloning" suite —
+  // the classes themselves are server-owned now (#273).
 
   it("negate chip on a group wraps it in {NOT:[…]} and flips aria-pressed", () => {
     const host = mount();

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -120,21 +120,12 @@ const INCOMPLETE_ROW_CLASS = "bg-amber-50 dark:bg-amber-500/10 rounded";
 const BADGE_CLASS =
   "rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-medium " +
   "text-amber-700 dark:border-amber-500/50 dark:bg-amber-500/10 dark:text-amber-300";
-// Connective + NOT chips (component 2, issue #190). Pill shape (rounded-full) +
-// saturated fill sets this cluster apart from the square, gray restructuring
-// buttons so it never reads as "just another button". The connective is
-// color-coded by value with a NON-semantic cool/warm pair — AND = teal, OR =
-// orange — kept out of the action palette (blue/red/green/gray) so it reads as
-// "logic type", not status. The NOT-on look uses an amber FILL + RING so a lit
-// NOT chip stays distinct from an adjacent OR chip (fill-only) — they never read
-// as one blob.
-const CHIP_BASE = "rounded-full border px-2.5 py-0.5 text-xs font-semibold hover:cursor-pointer";
-const CONNECTIVE_AND_CLASS =
-  "border-teal-300 bg-teal-100 text-teal-800 " +
-  "dark:border-teal-500/60 dark:bg-teal-500/20 dark:text-teal-200";
-const CONNECTIVE_OR_CLASS =
-  "border-orange-300 bg-orange-100 text-orange-800 " +
-  "dark:border-orange-500/60 dark:bg-orange-500/20 dark:text-orange-200";
+// Chip and relation-select styling is server-owned (#273): the server ships one
+// <template data-chip-template="<state>"> per chip state and one
+// <template data-relation-select-template>; chip()/relationSelect() clone them.
+// The visual states a chip template can carry; mirrors the server's ChipState
+// (common/components/filters.py), where the class sets live.
+type ChipState = "connective-and" | "connective-or" | "negate-off" | "negate-on";
 // Group left-edge accent, colored by connective — reuses the chip hues (AND=teal,
 // OR=orange) so the card frame echoes the connective chip. Strong 400 edge matches
 // the relation descent's indigo-400 left edge; together `border-l-4` +
@@ -142,12 +133,6 @@ const CONNECTIVE_OR_CLASS =
 // box border into a colored accent.
 const GROUP_AND_EDGE_CLASS = "border-l-4 border-l-teal-400 dark:border-l-teal-500/70";
 const GROUP_OR_EDGE_CLASS = "border-l-4 border-l-orange-400 dark:border-l-orange-500/70";
-const NEGATE_OFF_CLASS =
-  "border-gray-200 text-gray-500 hover:bg-gray-100 " +
-  "dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700";
-const NEGATE_ON_CLASS =
-  "border-amber-400 bg-amber-100 text-amber-900 ring-1 ring-amber-400 " +
-  "dark:border-amber-500/70 dark:bg-amber-500/25 dark:text-amber-100 dark:ring-amber-500/70";
 // Relation-descent accent block (component 5, #193): a left-accented indigo card set
 // apart from the gray group chrome so the Game→Session model switch reads explicitly.
 // Header carries the `↳ [quantifier] of [relation] where` row.
@@ -157,14 +142,6 @@ const RELATION_CARD_CLASS =
 const RELATION_HEADER_CLASS = "flex items-center gap-2 flex-wrap";
 const RELATION_ARROW_CLASS = "text-indigo-500 dark:text-indigo-300 font-semibold";
 const RELATION_LABEL_CLASS = "text-sm text-gray-600 dark:text-gray-300";
-// No horizontal padding: @tailwindcss/forms styles bare <select> with
-// appearance:none, a right-anchored chevron, and the right padding (~2.5rem) that
-// clears it. A px-*/pr-* utility can't beat the plugin rule for the right side;
-// px-* only overrides it symmetrically, shrinking it so the label ("any") ends up
-// under the chevron (the old px-2 did this). Set only vertical padding here.
-const RELATION_SELECT_CLASS =
-  "rounded border border-gray-300 bg-white py-1 text-sm dark:border-gray-600 dark:bg-gray-800 " +
-  "disabled:opacity-50 disabled:cursor-not-allowed";
 
 // The closed set of restructuring actions a button can carry; producer
 // (actionButton) and consumer (applyAction's switch) share it so a typo on either
@@ -271,6 +248,11 @@ export class FilterGroupElement extends HTMLElement {
   // from (one model-agnostic template) — the client never declares button
   // classes itself.
   private actionButtonTemplate: HTMLTemplateElement | null = null;
+  // The server-rendered connective/NOT chips, one template per visual state,
+  // and the quantifier/relation <select> — like the action button, the client
+  // clones these and never declares their classes (#273).
+  private chipTemplates = new Map<ChipState, HTMLTemplateElement>();
+  private relationSelectTemplate: HTMLTemplateElement | null = null;
   // Monotonic suffix so cloned widget/picker element ids stay unique per leaf.
   private cloneSequence = 0;
 
@@ -348,6 +330,15 @@ export class FilterGroupElement extends HTMLElement {
   private captureTemplates(): void {
     this.actionButtonTemplate = this.querySelector<HTMLTemplateElement>(
       "template[data-action-button-template]",
+    );
+    this.querySelectorAll<HTMLTemplateElement>("template[data-chip-template]").forEach(
+      (template) => {
+        const state = template.getAttribute("data-chip-template") as ChipState;
+        this.chipTemplates.set(state, template);
+      },
+    );
+    this.relationSelectTemplate = this.querySelector<HTMLTemplateElement>(
+      "template[data-relation-select-template]",
     );
     this.querySelectorAll<HTMLTemplateElement>("template[data-model]").forEach((template) => {
       const bundle = this.models.get(template.getAttribute("data-model") ?? "");
@@ -788,9 +779,17 @@ export class FilterGroupElement extends HTMLElement {
     return span;
   }
 
+  // A relation-row <select>, cloned from the server template so its styling
+  // stays server-owned; the bare fallback keeps template-less fixtures (jsdom
+  // tests) functional. Options are appended by the caller — they are data.
+  private relationSelect(): HTMLSelectElement {
+    const cloned = this.relationSelectTemplate?.content.firstElementChild?.cloneNode(true);
+    return cloned instanceof HTMLSelectElement ? cloned : element("select");
+  }
+
   // The ANY/NONE/ALL quantifier picker; change dispatches setMatch.
   private relationMatchSelect(node: RelationNode): HTMLSelectElement {
-    const select = element("select", RELATION_SELECT_CLASS);
+    const select = this.relationSelect();
     select.dataset.relationMatch = "";
     for (const match of RELATION_MATCHES) {
       const option = element("option");
@@ -805,7 +804,7 @@ export class FilterGroupElement extends HTMLElement {
   // The relation-field picker: the current model's relation options; change
   // dispatches setRelationField (which resets the child group on a model change).
   private relationFieldSelect(node: RelationNode, model: string): HTMLSelectElement {
-    const select = element("select", RELATION_SELECT_CLASS);
+    const select = this.relationSelect();
     select.dataset.relationField = "";
     const placeholder = element("option");
     placeholder.value = "";
@@ -1136,17 +1135,19 @@ export class FilterGroupElement extends HTMLElement {
   }
 
   // A chip-style toggle button: a restructuring action (so it rides the existing
-  // data-action delegation + applyAction) wearing its own chip classes instead of
-  // the server action-button template. `pressed` reflects an on/off state via
-  // aria-pressed.
+  // data-action delegation + applyAction) cloned from the server template of its
+  // visual state — styling stays server-owned; the classless bare <button>
+  // fallback keeps template-less fixtures (jsdom tests) functional. `pressed`
+  // reflects an on/off state via aria-pressed.
   private chip(
     action: TreeAction,
     label: string,
     path: NodePath,
-    className: string,
+    state: ChipState,
     { title = "", pressed }: { title?: string; pressed?: boolean } = {},
   ): HTMLButtonElement {
-    const button = element("button", `${CHIP_BASE} ${className}`);
+    const cloned = this.chipTemplates.get(state)?.content.firstElementChild?.cloneNode(true);
+    const button = cloned instanceof HTMLButtonElement ? cloned : element("button");
     button.type = "button";
     button.textContent = label;
     button.dataset.action = action;
@@ -1159,8 +1160,8 @@ export class FilterGroupElement extends HTMLElement {
   // The connective chip: label is the value itself; clicking flips AND<->OR. Color
   // carries the value (no lit/pressed state — the label already shows it).
   private connectiveChip(connective: Connective, path: NodePath): HTMLButtonElement {
-    const colorClass = connective === "AND" ? CONNECTIVE_AND_CLASS : CONNECTIVE_OR_CLASS;
-    return this.chip("toggle-connective", connective, path, colorClass, {
+    const state: ChipState = connective === "AND" ? "connective-and" : "connective-or";
+    return this.chip("toggle-connective", connective, path, state, {
       title: "Toggle AND/OR for this group",
     });
   }
@@ -1168,7 +1169,7 @@ export class FilterGroupElement extends HTMLElement {
   // The NOT negate chip (groups and leaves): constant label, lit when the node's
   // negate flag is set. Clicking toggles it.
   private negateChip(node: FilterNode, path: NodePath): HTMLButtonElement {
-    return this.chip("toggle-negate", "NOT", path, node.negate ? NEGATE_ON_CLASS : NEGATE_OFF_CLASS, {
+    return this.chip("toggle-negate", "NOT", path, node.negate ? "negate-on" : "negate-off", {
       title: node.negate ? "Remove negation" : "Negate",
       pressed: node.negate,
     });


### PR DESCRIPTION
Closes #273. Follow-up to #271/#274 in the #235 server-owned-styling series.

## What

- `common/components/filters.py`: new `chip_templates()` — one `<template data-chip-template="<state>">` per chip visual state (`connective-and`, `connective-or`, `negate-off`, `negate-on`) with the full class set baked in — and `relation_select_template()` for the quantifier/relation-field `<select>`. Class strings moved verbatim from TS, along with their design-rationale comments (chip color semantics, the @tailwindcss/forms select-padding constraint).
- `common/components/custom_elements.py`: `FilterGroup` appends the new templates next to the existing action-button template (all model-agnostic, emitted once).
- `ts/elements/filter-group.ts`: `chip()` and the new `relationSelect()` clone from the captured templates and only wire behavior (label, action, path, title, aria-pressed); `CHIP_BASE`, `CONNECTIVE_AND/OR_CLASS`, `NEGATE_ON/OFF_CLASS`, `RELATION_SELECT_CLASS` deleted. A `ChipState` union mirrors the server's `Literal` and doubles as the template tag. Classless bare fallback keeps template-less jsdom fixtures working.

This ends TS-declared control styling in the filter builder.

## Tests

- vitest: template-cloning suite (state-matching chip selection incl. AND→OR / NOT on↔off flips, relation-select cloning for both row selects, classless fallback). The old "teal/orange className" test is superseded by state-template selection.
- pytest: `FilterGroup` emits each chip-state template and the select template exactly once.
- e2e: the builder page asserts cloned controls carry the server classes — the classless fallback would otherwise mask a broken template selector while every behavior test stays green.

Full `direnv exec . make check` green (1429 passed incl. e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)