### PR TITLE
feat(filters): scoped aggregates — AggregateCriterion over a sub-filtered relation (#151)

### DIFF
--- a/common/criteria.py
+++ b/common/criteria.py
@@ -703,6 +703,8 @@ class AggregateCriterion(_ScalarCriterion):
     # ``AggregateSpec``, which lives on the filter class), so only
     # ``OperatorFilter._aggregate_from_json`` may populate it. Re-adding this as
     # an init field would recreate the mis-typed dead field #139/#144 removed.
+    # Beware: ``dataclasses.replace()`` re-defaults ``init=False`` fields, so a
+    # replaced criterion silently loses its scope — mutate the attribute instead.
     scope: "OperatorFilter | None" = field(default=None, init=False)
     # Aggregates compare numerically; coerce so a wrong-typed bound is caught at
     # parse rather than surfacing as a query-execution 500 (the eager build can't
@@ -1174,6 +1176,19 @@ class AggregateSpec:
     source: AttrName | None = None  # summed/averaged related column; None for count
     unit: DurationUnit | None = None
 
+    def __post_init__(self) -> None:
+        # The reducer/source/unit dependencies are cross-field invariants the
+        # annotations can't say; specs are module-level constants, so validating
+        # here turns a mis-wired table into an import-time failure instead of a
+        # query-time 500 on first use.
+        if self.reducer == "count":
+            if self.source is not None:
+                raise TypeError("a count aggregate takes no source field")
+            if self.unit is not None:
+                raise TypeError("a count aggregate takes no unit")
+        elif self.source is None:
+            raise TypeError(f"a {self.reducer} aggregate requires a source field")
+
 
 @dataclass
 class OperatorFilter:
@@ -1225,9 +1240,10 @@ class OperatorFilter:
 
     # Declarative attr→lookup table consumed by the generic ``to_q``. Each concrete
     # filter overrides this with a ``FilterField`` per simple criterion field (the
-    # single source of truth for the ORM mapping); aggregates, M2M, ``search`` and
-    # relation sub-filters are absent — they live in ``_extra_q``. Declared as a
-    # ClassVar so the dataclass machinery does not treat it as a field.
+    # single source of truth for the ORM mapping); aggregates are absent (they live
+    # in the ``aggregates`` table below); M2M, ``search`` and relation sub-filters
+    # live in ``_extra_q``. Declared as a ClassVar so the dataclass machinery does
+    # not treat it as a field.
     fields: ClassVar[dict[AttrName, FilterField]] = {}
 
     # Declarative reducer/relation wiring per aggregate criterion field, consumed
@@ -1661,10 +1677,10 @@ def filter_to_json(f: OperatorFilter) -> str:
 
 
 # ── Relation & aggregate query helpers ──────────────────────────────────────
-# Self-contained Q builders for the two cross-entity node kinds. Filters pass the
-# related/parent model and the relation wiring (lookups, accessor, reducer); the
-# algebra lives here so every entity composes the same logic instead of repeating
-# bespoke subqueries in each to_q().
+# Self-contained Q builders for the two cross-entity node kinds. Callers pass the
+# related/parent model and the wiring (relation lookups, or the aggregate's
+# ``AggregateSpec``); the algebra lives here so every entity composes the same
+# logic instead of repeating bespoke subqueries in each to_q().
 
 Number = int | float
 
@@ -2364,6 +2380,15 @@ def aggregate_to_q(
 
     scope_condition: Q | None = None
     if criterion.scope is not None:
+        # A hand-assembled criterion could carry a wrong-typed scope; its Q would
+        # be built in the wrong model's namespace and produce a silently-wrong
+        # (or FieldError-ing) subquery, so guard the type loudly. Never user
+        # input — from_json always builds the scope from the spec's class.
+        if not isinstance(criterion.scope, spec.scope_filter):
+            raise RuntimeError(
+                f"aggregate scope must be a {spec.scope_filter.__name__},"
+                f" got {type(criterion.scope).__name__}"
+            )
         related_model: ModelClass = spec.scope_filter._comparison_model()
         if related_model is None:
             raise RuntimeError(

--- a/common/criteria.py
+++ b/common/criteria.py
@@ -8,7 +8,7 @@ filtering from *how* you're comparing, and makes filter serialization trivial.
 
 import json
 import types
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from datetime import date
 from dataclasses import dataclass, field, fields as dc_fields
 from enum import Enum
@@ -687,13 +687,23 @@ class AggregateCriterion(_ScalarCriterion):
     a game's purchase prices between X and Y".
 
     The reducer, relation accessor, source field, and unit are *static config*
-    supplied by the filter at query time (see ``aggregate_to_q``); the instance
-    carries only the user's comparison value(s)/modifier.
+    declared on the filter class (its ``aggregates`` table of ``AggregateSpec``,
+    read by ``aggregate_to_q``); the instance carries only the user's comparison
+    value(s)/modifier and an optional ``scope`` sub-filter narrowing which
+    related rows the reducer sees (issue #151) — e.g. "> 5 sessions *on the
+    Steam Deck*" counts only sessions matching ``scope``.
     """
 
     value: int | float = 0
     value2: int | float | None = None
     modifier: Modifier = Modifier.EQUALS
+    # Scope sub-filter over the related rows being reduced. ``init=False`` keeps
+    # it out of the base ``from_json`` field loop — the criterion alone cannot
+    # resolve the concrete filter class (that is fixed by the relation accessor's
+    # ``AggregateSpec``, which lives on the filter class), so only
+    # ``OperatorFilter._aggregate_from_json`` may populate it. Re-adding this as
+    # an init field would recreate the mis-typed dead field #139/#144 removed.
+    scope: "OperatorFilter | None" = field(default=None, init=False)
     # Aggregates compare numerically; coerce so a wrong-typed bound is caught at
     # parse rather than surfacing as a query-execution 500 (the eager build can't
     # catch it: ``aggregate_to_q`` feeds the value straight into Q). ``_coerce_number``
@@ -707,6 +717,18 @@ class AggregateCriterion(_ScalarCriterion):
         raise NotImplementedError(
             "AggregateCriterion is evaluated via aggregate_to_q(), not to_q()"
         )
+
+    def to_json(self) -> dict[str, Any]:
+        # The base loop would emit the raw ``scope`` OperatorFilter object;
+        # replace it with its JSON, omitting an empty scope — an empty sub-filter
+        # matches every related row, so "no scope" is the canonical form.
+        result = super().to_json()
+        result.pop("scope", None)
+        if self.scope is not None:
+            scope_json = self.scope.to_json()
+            if scope_json:
+                result["scope"] = scope_json
+        return result
 
 
 type ComparisonGranularity = Literal["raw", "date"]
@@ -1125,6 +1147,34 @@ _SUFFIX_MODIFIER: dict[str, Modifier] = {
 }
 
 
+type Reducer = Literal["count", "sum", "avg"]  # e.g. "count"
+type DurationUnit = Literal["duration_hours"]  # compare hours vs a DurationField
+type RelationAccessor = str  # a relation accessor on the parent model, e.g. "sessions"
+
+
+@dataclass(frozen=True)
+class AggregateSpec:
+    """Static wiring for one aggregate criterion field (issue #151): how to
+    reduce (``reducer``), over which relation (``accessor``), and which filter
+    type scopes the reduced rows (``scope_filter`` — e.g. ``SessionFilter`` for
+    a ``sessions`` aggregate).
+
+    The criterion instance carries only the user's comparison (and optional
+    ``scope`` sub-filter); this spec is the per-field static half, declared on
+    the filter class's ``aggregates`` table. ``scope_filter`` is what lets
+    ``from_json`` resolve the scope's concrete class — the criterion's own
+    annotation cannot name it (the abstract ``OperatorFilter`` says nothing
+    about *which* entity the accessor reaches). It doubles as the related-model
+    resolver for the scope subquery (via ``_comparison_model()``).
+    """
+
+    reducer: Reducer
+    accessor: RelationAccessor
+    scope_filter: "type[OperatorFilter]"
+    source: AttrName | None = None  # summed/averaged related column; None for count
+    unit: DurationUnit | None = None
+
+
 @dataclass
 class OperatorFilter:
     """Mixin providing AND/OR/NOT composition for entity filter types.
@@ -1179,6 +1229,14 @@ class OperatorFilter:
     # relation sub-filters are absent — they live in ``_extra_q``. Declared as a
     # ClassVar so the dataclass machinery does not treat it as a field.
     fields: ClassVar[dict[AttrName, FilterField]] = {}
+
+    # Declarative reducer/relation wiring per aggregate criterion field, consumed
+    # by the generic ``to_q`` walk and by ``from_json`` (an aggregate's ``scope``
+    # deserializes via its spec's ``scope_filter`` — issue #151). Empty on the
+    # base; a concrete filter with aggregate fields assigns its table *after* all
+    # filter classes exist (the specs reference sibling filter classes) — see
+    # ``GameFilter.aggregates`` in games/filters.py.
+    aggregates: ClassVar[Mapping[AttrName, AggregateSpec]] = {}
 
     # Criterion fields deliberately handled imperatively in ``_extra_q`` rather than
     # via ``fields`` (e.g. the M2M ``games``). ``search`` is here for every filter.
@@ -1308,9 +1366,10 @@ class OperatorFilter:
         """Build a Django Q object from this filter and its sub-filters.
 
         Generic for every concrete filter: walk the declarative ``fields`` table
-        (each set criterion mapped to its ORM lookup/handler), then fold in the
-        imperative tail (``_extra_q``: aggregates, M2M, free-text search, relation
-        sub-filters), then the AND/OR/NOT operators and field comparisons.
+        (each set criterion mapped to its ORM lookup/handler), then the
+        ``aggregates`` table, then fold in the imperative tail (``_extra_q``:
+        M2M, free-text search, relation sub-filters), then the AND/OR/NOT
+        operators and field comparisons.
         """
         q = Q()
         for attr_name, descriptor in self.fields.items():
@@ -1322,14 +1381,25 @@ class OperatorFilter:
             criterion = getattr(self, attr_name)
             if criterion is not None:
                 q &= descriptor.to_q(attr_name, criterion)
+        if self.aggregates:
+            model = self._comparison_model()
+            if model is None:
+                # Static mis-wiring, never user input — 500, don't FilterError.
+                raise RuntimeError(
+                    f"{type(self).__name__} declares aggregates but no comparison model"
+                )
+            for attr_name, spec in self.aggregates.items():
+                aggregate = getattr(self, attr_name)
+                if aggregate is not None:
+                    q &= aggregate_to_q(aggregate, model=model, spec=spec)
         q &= self._extra_q()
         return self._apply_operators(q)
 
     def _extra_q(self) -> Q:
         """Q for criterion fields handled imperatively rather than via ``fields``.
 
-        Default is empty; concrete filters override to add aggregates, the M2M
-        ``games`` handler, free-text ``search``, and relation sub-filters. Kept a
+        Default is empty; concrete filters override to add the M2M ``games``
+        handler, free-text ``search``, and relation sub-filters. Kept a
         separate hook so the generic ``to_q`` never needs overriding.
         """
         return Q()
@@ -1417,6 +1487,12 @@ class OperatorFilter:
             # whether the module stringizes its annotations.
             criterion_cls = _criterion_class_for(cls, f.name)
             if criterion_cls is not None:
+                # Aggregate fields carry an optional ``scope`` sub-filter whose
+                # concrete class only the field's AggregateSpec knows — split it
+                # off and parse it here rather than in the criterion (issue #151).
+                if f.name in cls.aggregates and isinstance(raw, dict):
+                    kwargs[f.name] = cls._aggregate_from_json(f.name, raw, _depth)
+                    continue
                 kwargs[f.name] = (
                     criterion_cls.from_json(raw) if isinstance(raw, dict) else None
                 )
@@ -1431,6 +1507,51 @@ class OperatorFilter:
                     else None
                 )
         return cls(**kwargs)
+
+    @classmethod
+    def _aggregate_from_json(
+        cls, name: AttrName, raw: dict[str, Any], _depth: int
+    ) -> AggregateCriterion | None:
+        """Parse one aggregate criterion dict, including its optional ``scope``.
+
+        ``scope`` is split off before the generic criterion parse (the field is
+        ``init=False``, so the base loop could never mis-assign the raw dict) and
+        deserialized via the field's ``AggregateSpec.scope_filter`` — only the
+        filter class knows which concrete filter type scopes the aggregate's
+        relation (issue #151). The scope descent consumes the same
+        ``MAX_FILTER_DEPTH`` budget as a relation descent, so a scope-nesting
+        bomb is bounded identically.
+        """
+        payload = dict(raw)
+        scope_raw = payload.pop("scope", None)
+        criterion_cls = _criterion_class_for(cls, name)
+        if criterion_cls is None or not issubclass(criterion_cls, AggregateCriterion):
+            # ``aggregates`` names a non-aggregate field: static mis-wiring the
+            # drift guard should have caught — 500, don't FilterError.
+            raise RuntimeError(
+                f"{cls.__name__}.aggregates[{name!r}] is not an AggregateCriterion field"
+            )
+        criterion = criterion_cls.from_json(payload)
+        if criterion is None or scope_raw is None:
+            return criterion
+        if not isinstance(scope_raw, dict):
+            raise FilterError(
+                f"aggregate scope must be an object, got {type(scope_raw).__name__}"
+            )
+        scope = cls.aggregates[name].scope_filter.from_json(
+            scope_raw, _depth=_depth + 1
+        )
+        if scope is not None and scope.match != RelationMatch.ANY:
+            # A scope is a row predicate over the reduced relation, not a
+            # relation test: a quantifier here would be silently meaningless
+            # (which rows would NONE/ALL count?), so reject rather than ignore.
+            raise FilterError("aggregate scope does not take a match quantifier")
+        if scope is not None and not scope.to_json():
+            # An empty scope matches every related row — normalize to unscoped so
+            # parse → serialize round-trips to the canonical omitted form.
+            scope = None
+        criterion.scope = scope
+        return criterion
 
     def to_json(self) -> dict[str, Any]:
         result: dict[str, Any] = {}
@@ -1546,8 +1667,6 @@ def filter_to_json(f: OperatorFilter) -> str:
 # bespoke subqueries in each to_q().
 
 Number = int | float
-type Reducer = Literal["count", "sum", "avg"]  # e.g. "count"
-type DurationUnit = Literal["duration_hours"]  # compare hours vs a DurationField
 
 
 def _numeric_to_q(
@@ -1778,7 +1897,8 @@ class FieldMeta(TypedDict):
     populated only for static-enum fields; ``relations`` is non-empty (a single
     entry) iff ``kind == "relation"``, and a relation entry always has empty
     ``choices``, empty ``modifiers``, and ``nullable=False``. A leaf entry always
-    has a non-empty ``modifiers``. These cross-field invariants are enforced by
+    has a non-empty ``modifiers``. ``scope_model`` is non-empty iff the field is
+    an aggregate (issue #151). These cross-field invariants are enforced by
     ``field_metadata`` (the sole producer), not by the type."""
 
     name: AttrName
@@ -1801,6 +1921,10 @@ class FieldMeta(TypedDict):
     # from the resolved model field, not stored on ``FilterField``.
     search_url: str
     is_m2m: bool
+    # The model key (``_meta.model_name``, e.g. "session") of the related rows an
+    # aggregate field reduces — the model whose fields build the aggregate's
+    # ``scope`` sub-filter (issue #151). ``""`` for every non-aggregate field.
+    scope_model: ModelKey
 
 
 class ModelFieldBundle(TypedDict):
@@ -1967,6 +2091,25 @@ def field_metadata(filter_cls: type[OperatorFilter]) -> list[FieldMeta]:
             # from the resolved model field, so a future FK set field needs no flag.
             is_m2m = bool(getattr(model_field, "many_to_many", False))
             search_url = field_spec.search_url if field_spec is not None else None
+            # An aggregate's scope target (issue #151): the model of the related
+            # rows it reduces, resolved from the field's AggregateSpec. Resolving
+            # loudly here matches the mis-typed-lookup contract above — a spec
+            # gap is a wiring bug, not a degraded picker.
+            scope_model: ModelKey = ""
+            if is_aggregate:
+                spec = filter_cls.aggregates.get(name)
+                if spec is None:
+                    raise ValueError(
+                        f"{filter_cls.__name__}.{name} is an aggregate field with "
+                        f"no AggregateSpec in {filter_cls.__name__}.aggregates"
+                    )
+                scope_target = spec.scope_filter._comparison_model()
+                if scope_target is None:
+                    raise ValueError(
+                        f"{filter_cls.__name__}.{name} scope filter "
+                        f"{spec.scope_filter.__name__} has no comparison model"
+                    )
+                scope_model = scope_target._meta.model_name or ""
             entries.append(
                 FieldMeta(
                     name=name,
@@ -1978,6 +2121,7 @@ def field_metadata(filter_cls: type[OperatorFilter]) -> list[FieldMeta]:
                     relations=[],
                     search_url=search_url or "",
                     is_m2m=is_m2m,
+                    scope_model=scope_model,
                 )
             )
             continue
@@ -2008,6 +2152,7 @@ def field_metadata(filter_cls: type[OperatorFilter]) -> list[FieldMeta]:
                     ],
                     search_url="",
                     is_m2m=False,
+                    scope_model="",
                 )
             )
     return entries
@@ -2196,10 +2341,7 @@ def aggregate_to_q(
     criterion: AggregateCriterion,
     *,
     model: ModelClass,
-    reducer: Reducer,
-    accessor: str,
-    source: str | None = None,
-    unit: DurationUnit | None = None,
+    spec: AggregateSpec,
 ) -> Q:
     """Filter ``model`` by a reducer (count / sum / avg) over a relation.
 
@@ -2208,24 +2350,48 @@ def aggregate_to_q(
     ``unit="duration_hours"`` compares an hours value against a DurationField
     aggregate; otherwise a plain numeric comparison is used. ``sum``/``avg``
     require a ``source`` field; ``count`` aggregates whole rows.
+
+    A criterion ``scope`` narrows the reducer to related rows matching the
+    sub-filter (issue #151), via the aggregate's ``filter=`` argument. The
+    condition is a subquery membership test — ``accessor IN (<related rows
+    matching scope>)`` — rather than a rewrite of the scope's Q into the parent
+    namespace: the scope Q is evaluated entirely by the related model's own
+    queryset, so ``F()`` expressions, transforms, and nested subqueries inside
+    it keep their meaning (a key-prefix rewriter would silently re-root them
+    against the wrong model).
     """
     from django.db.models import Avg, Count, Sum
 
-    # ``reducer``/``source`` are hard-coded by each filter's own to_q(), never
-    # user input — a failure here is a wiring bug. Raise RuntimeError (not
-    # ValueError) so filter_from_json's eager-validation catch does NOT reclassify
-    # it to FilterError: a real bug must still 500, not masquerade as bad input.
-    if reducer == "count":
-        aggregate_expression: Any = Count(accessor, distinct=True)
-    elif reducer in ("sum", "avg"):
-        if source is None:
-            raise RuntimeError(f"{reducer!r} aggregate requires a source field")
-        reduce = Sum if reducer == "sum" else Avg
-        aggregate_expression = reduce(f"{accessor}__{source}")
-    else:
-        raise RuntimeError(f"Unknown aggregate reducer {reducer!r}")
+    scope_condition: Q | None = None
+    if criterion.scope is not None:
+        related_model: ModelClass = spec.scope_filter._comparison_model()
+        if related_model is None:
+            raise RuntimeError(
+                f"{spec.scope_filter.__name__} has no comparison model"
+                f" to scope a {spec.accessor!r} aggregate"
+            )
+        matching = related_model.objects.filter(criterion.scope.to_q())
+        scope_condition = Q(**{f"{spec.accessor}__in": matching})
 
-    if unit == "duration_hours":
+    # The spec is static config declared on the filter class, never user input —
+    # a failure here is a wiring bug. Raise RuntimeError (not ValueError) so
+    # filter_from_json's eager-validation catch does NOT reclassify it to
+    # FilterError: a real bug must still 500, not masquerade as bad input.
+    if spec.reducer == "count":
+        aggregate_expression: Any = Count(
+            spec.accessor, distinct=True, filter=scope_condition
+        )
+    elif spec.reducer in ("sum", "avg"):
+        if spec.source is None:
+            raise RuntimeError(f"{spec.reducer!r} aggregate requires a source field")
+        reduce = Sum if spec.reducer == "sum" else Avg
+        aggregate_expression = reduce(
+            f"{spec.accessor}__{spec.source}", filter=scope_condition
+        )
+    else:
+        raise RuntimeError(f"Unknown aggregate reducer {spec.reducer!r}")
+
+    if spec.unit == "duration_hours":
         compare = duration_hours_to_q(
             criterion.value, criterion.value2, criterion.modifier, "_agg"
         )

--- a/e2e/test_filter_builder_e2e.py
+++ b/e2e/test_filter_builder_e2e.py
@@ -416,3 +416,125 @@ def test_nested_relation_prefill_renders_full_tree(
     count_badge = page.locator("filter-count")
     expect(count_badge).not_to_contain_text("Counting…")
     expect(count_badge).to_contain_text("≈ 1 purchase")
+
+
+def test_scoped_aggregate_prefill_hydrates_scope_and_counts(
+    authenticated_page: Page, live_server
+) -> None:
+    """A scoped aggregate in ?filter= (issue #151) hydrates the builder: the
+    aggregate leaf renders with its nested scope group (the device leaf shown as
+    a pill), the count reads the scoped query from the live widgets, and the
+    "− scope" action drops the scope — widening the count — proving the whole
+    add/remove wiring works against real server templates."""
+    from datetime import timedelta
+
+    from games.models import Device, Session
+
+    page = authenticated_page
+
+    platform = Platform.objects.create(name="PC")
+    deck = Device.objects.create(name="Steam Deck", type="Handheld")
+    desktop = Device.objects.create(name="Desktop", type="PC")
+    deck_game = Game.objects.create(name="DeckGame", platform=platform)
+    desktop_game = Game.objects.create(name="DeskGame", platform=platform)
+    first_start = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    for index, (game, device) in enumerate(
+        [
+            (deck_game, deck),
+            (deck_game, deck),
+            (desktop_game, desktop),
+            (desktop_game, desktop),
+        ]
+    ):
+        begin = first_start + timedelta(days=index)
+        Session.objects.create(
+            game=game,
+            device=device,
+            timestamp_start=begin,
+            timestamp_end=begin + timedelta(hours=1),
+        )
+
+    # Both games have 2 sessions; only DeckGame has >1 *on the deck*.
+    filter_json = {
+        "session_count": {
+            "value": 1,
+            "modifier": "GREATER_THAN",
+            "scope": {
+                "device": {
+                    "value": [{"id": str(deck.pk), "label": deck.name}],
+                    "modifier": "INCLUDES",
+                }
+            },
+        }
+    }
+    page.goto(
+        f"{live_server.url}{reverse('games:filter_builder', args=['game'])}"
+        f"?filter={_encode_filter(filter_json)}"
+    )
+
+    group = page.locator("filter-group")
+    expect(group).to_be_attached()
+
+    # The scope group hydrated: addressed through the "scope" path sentinel, with
+    # the device leaf's include pill rendered from the {id, label} value.
+    scope_group = group.locator('[data-kind="group"][data-path*="scope"]')
+    expect(scope_group).to_be_attached()
+    scope_pill = scope_group.locator("[data-search-select-pills] [data-pill]")
+    expect(scope_pill).to_contain_text("Steam Deck")
+
+    # The count reads the scoped query via serializeForQuery(): only DeckGame.
+    count_badge = page.locator("filter-count")
+    expect(count_badge).not_to_contain_text("Counting…")
+    expect(count_badge).to_contain_text("≈ 1 game")
+
+    # "− scope" drops the scope: unscoped, both games have >1 session.
+    page.locator('filter-group button[data-action="remove-scope"]').click()
+    expect(scope_group).not_to_be_attached()
+    expect(count_badge).to_contain_text("≈ 2 games")
+
+
+def test_scoped_aggregate_narrows_game_list(
+    authenticated_page: Page, live_server
+) -> None:
+    """The list round-trip for a scoped aggregate: ?filter= JSON → GameFilter
+    (scope resolved via the aggregates spec) → filtered aggregate queryset."""
+    from datetime import timedelta
+
+    from games.models import Device, Session
+
+    page = authenticated_page
+
+    platform = Platform.objects.create(name="PC")
+    deck = Device.objects.create(name="Steam Deck", type="Handheld")
+    desktop = Device.objects.create(name="Desktop", type="PC")
+    deck_game = Game.objects.create(name="DeckGame", platform=platform)
+    desktop_game = Game.objects.create(name="DeskGame", platform=platform)
+    first_start = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    for index, (game, device) in enumerate(
+        [
+            (deck_game, deck),
+            (deck_game, deck),
+            (desktop_game, desktop),
+            (desktop_game, desktop),
+        ]
+    ):
+        begin = first_start + timedelta(days=index)
+        Session.objects.create(
+            game=game,
+            device=device,
+            timestamp_start=begin,
+            timestamp_end=begin + timedelta(hours=1),
+        )
+
+    filter_json = {
+        "session_count": {
+            "value": 1,
+            "modifier": "GREATER_THAN",
+            "scope": {"device": {"value": [deck.pk], "modifier": "INCLUDES"}},
+        }
+    }
+    page.goto(
+        f"{live_server.url}{reverse('games:list_games')}?filter={_encode_filter(filter_json)}"
+    )
+    expect(page.get_by_text("DeckGame")).to_be_visible()
+    expect(page.get_by_text("DeskGame")).not_to_be_visible()

--- a/games/filters.py
+++ b/games/filters.py
@@ -28,6 +28,7 @@ from django.utils.http import urlencode
 
 from common.criteria import (
     AggregateCriterion,
+    AggregateSpec,
     BoolCriterion,
     ChoiceCriterion,
     DateCriterion,
@@ -41,7 +42,6 @@ from common.criteria import (
     MultiCriterion,
     OperatorFilter,
     StringCriterion,
-    aggregate_to_q,
     bool_isnull_handler,
     bool_nonzero_duration_handler,
     comparable_columns,
@@ -96,8 +96,9 @@ class GameFilter(OperatorFilter):
     updated_at: DateCriterion | None = None  # compared via __date
 
     # Aggregates over the game's relations (count / sum / avg). The reducer +
-    # relation accessor + source + unit are supplied at query time via
-    # aggregate_to_q; the criterion carries only the numeric comparison.
+    # relation accessor + source + unit live in ``GameFilter.aggregates`` (the
+    # AggregateSpec table assigned below all filter classes); the criterion
+    # carries only the numeric comparison and an optional scope sub-filter.
     session_count: AggregateCriterion | None = None
     session_average: AggregateCriterion | None = None  # average in hours
     purchase_count: AggregateCriterion | None = None  # distinct purchases per game
@@ -151,75 +152,6 @@ class GameFilter(OperatorFilter):
 
     def _extra_q(self) -> Q:
         q = Q()
-
-        # ── aggregates over the game's relations ──
-        if self.session_count is not None:
-            from games.models import Game
-
-            q &= aggregate_to_q(
-                self.session_count, model=Game, reducer="count", accessor="sessions"
-            )
-
-        if self.session_average is not None:
-            from games.models import Game
-
-            q &= aggregate_to_q(
-                self.session_average,
-                model=Game,
-                reducer="avg",
-                accessor="sessions",
-                source="duration_total",
-                unit="duration_hours",
-            )
-
-        if self.purchase_count is not None:
-            from games.models import Game
-
-            q &= aggregate_to_q(
-                self.purchase_count, model=Game, reducer="count", accessor="purchases"
-            )
-
-        if self.playevent_count is not None:
-            from games.models import Game
-
-            q &= aggregate_to_q(
-                self.playevent_count, model=Game, reducer="count", accessor="playevents"
-            )
-
-        if self.manual_playtime_hours is not None:
-            from games.models import Game
-
-            q &= aggregate_to_q(
-                self.manual_playtime_hours,
-                model=Game,
-                reducer="sum",
-                accessor="sessions",
-                source="duration_manual",
-                unit="duration_hours",
-            )
-
-        if self.calculated_playtime_hours is not None:
-            from games.models import Game
-
-            q &= aggregate_to_q(
-                self.calculated_playtime_hours,
-                model=Game,
-                reducer="sum",
-                accessor="sessions",
-                source="duration_calculated",
-                unit="duration_hours",
-            )
-
-        if self.purchase_price_total is not None:
-            from games.models import Game
-
-            q &= aggregate_to_q(
-                self.purchase_price_total,
-                model=Game,
-                reducer="sum",
-                accessor="purchases",
-                source="converted_price",
-            )
 
         # ── free-text search (OR across multiple fields) ──
         if self.search is not None:
@@ -727,6 +659,42 @@ class PlayEventFilter(OperatorFilter):
         return q
 
 
+# ── Aggregate wiring ───────────────────────────────────────────────────────
+
+# Assigned after the class definitions (not in GameFilter's body) because the
+# specs reference filter classes defined below GameFilter — a class-body dict
+# would NameError on SessionFilter/PurchaseFilter/PlayEventFilter. The generic
+# ``OperatorFilter.to_q`` walks this table; ``from_json`` reads each spec's
+# ``scope_filter`` to deserialize an aggregate's scope. The drift guard in
+# tests/test_filters.py asserts the table covers exactly the
+# AggregateCriterion-annotated fields.
+GameFilter.aggregates = {
+    "session_count": AggregateSpec("count", "sessions", SessionFilter),
+    "session_average": AggregateSpec(
+        "avg", "sessions", SessionFilter, source="duration_total", unit="duration_hours"
+    ),
+    "purchase_count": AggregateSpec("count", "purchases", PurchaseFilter),
+    "playevent_count": AggregateSpec("count", "playevents", PlayEventFilter),
+    "manual_playtime_hours": AggregateSpec(
+        "sum",
+        "sessions",
+        SessionFilter,
+        source="duration_manual",
+        unit="duration_hours",
+    ),
+    "calculated_playtime_hours": AggregateSpec(
+        "sum",
+        "sessions",
+        SessionFilter,
+        source="duration_calculated",
+        unit="duration_hours",
+    ),
+    "purchase_price_total": AggregateSpec(
+        "sum", "purchases", PurchaseFilter, source="converted_price"
+    ),
+}
+
+
 # ── Convenience helpers ────────────────────────────────────────────────────
 
 
@@ -773,11 +741,14 @@ def filter_for_model(model_name: ModelKey) -> type[OperatorFilter]:
 
 
 def reachable_models(root_model: ModelKey) -> dict[ModelKey, type[OperatorFilter]]:
-    """The closed set of models reachable from ``root_model`` via relation descents,
-    each mapped to its ``OperatorFilter`` subclass (BFS over ``field_metadata``'s
-    relation entries). Relation fields cycle (game↔session, game↔purchase, …), so the
-    result covers every model the nested builder can descend into from the root — the
-    metadata the client needs to render any child group offline (#193)."""
+    """The closed set of models reachable from ``root_model`` via relation descents
+    or aggregate-scope descents, each mapped to its ``OperatorFilter`` subclass (BFS
+    over ``field_metadata``'s relation entries and ``scope_model``s). Relation fields
+    cycle (game↔session, game↔purchase, …), so the result covers every model the
+    nested builder can descend into from the root — the metadata the client needs to
+    render any child group offline (#193). Aggregate scope targets (#151) are
+    enqueued too so a scope group's field bundle always ships, even for a model
+    reachable only through a scope."""
     from collections import deque
 
     result: dict[ModelKey, type[OperatorFilter]] = {}
@@ -793,6 +764,8 @@ def reachable_models(root_model: ModelKey) -> dict[ModelKey, type[OperatorFilter
                 target_key = relation["model"].lower()
                 if target_key not in result:
                     queue.append(target_key)
+            if meta["scope_model"] and meta["scope_model"] not in result:
+                queue.append(meta["scope_model"])
     return result
 
 

--- a/tests/test_filter_tree_contract.py
+++ b/tests/test_filter_tree_contract.py
@@ -48,7 +48,25 @@ def test_canonical_artifact_present_under_ci():
 
 def _q_str(filter_object) -> str:
     # str(Q) is a stable structural rendering; equal structures compare equal.
-    return str(filter_object.to_q())
+    # QuerySet values (relation/aggregate subqueries) must be expanded to their
+    # compiled SQL: repr() would *evaluate* them, and on the empty test DB every
+    # subquery prints "<QuerySet []>" — making structurally different scoped
+    # aggregates compare equal and the contract vacuous for them (issue #151).
+    return _render_q(filter_object.to_q())
+
+
+def _render_q(node) -> str:
+    from django.db.models import Q, QuerySet
+
+    if isinstance(node, Q):
+        children = ", ".join(_render_q(child) for child in node.children)
+        return f"{'NOT ' if node.negated else ''}{node.connector}({children})"
+    if isinstance(node, tuple):
+        key, value = node
+        if isinstance(value, QuerySet):
+            return f"({key!r}, SQL[{value.query}])"
+        return repr(node)
+    return repr(node)
 
 
 @pytest.mark.django_db

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3713,7 +3713,8 @@ class TestFilterFieldDescriptors:
     """Guard the declarative ``fields`` table against drift from the dataclass.
 
     Each concrete filter's generic ``to_q`` walks ``fields`` for its simple
-    criteria and delegates the rest to ``_extra_q``. These tests assert that
+    criteria and the ``aggregates`` table for aggregates, delegating the rest
+    to ``_extra_q``. These tests assert that
     every declared criterion field is accounted for exactly once — in ``fields``,
     as an aggregate, or in ``_IMPERATIVE_CRITERIA`` — so a newly added field can't
     silently fall through (and thus be ignored by ``to_q``).
@@ -3779,7 +3780,15 @@ class TestFilterFieldDescriptors:
         assert set(filter_cls.aggregates) == self._aggregate_fields(filter_cls)
 
     @pytest.mark.parametrize("filter_cls", ALL_FILTERS)
-    def test_descriptor_keys_are_real_criterion_fields(self, filter_cls):
+    def test_aggregate_accessor_reaches_the_scope_filter_model(self, filter_cls):
+        """Each spec's ``accessor`` must reach exactly ``scope_filter``'s model —
+        ``aggregate_to_q`` builds ``Q(accessor__in=<scope_filter's queryset>)``,
+        so a mismatched pair produces a wrong-model pk subquery that returns
+        silently wrong results rather than raising (issue #151)."""
+        parent_model = filter_cls._comparison_model()
+        for name, spec in filter_cls.aggregates.items():
+            related_model = parent_model._meta.get_field(spec.accessor).related_model
+            assert related_model is spec.scope_filter._comparison_model(), name
         declared = self._declared_criterion_fields(filter_cls)
         for key in filter_cls.fields:
             assert key in declared, (
@@ -4774,3 +4783,176 @@ class TestScopedAggregateJSON:
         )
         with pytest.raises(FilterError):
             filter_from_json(GameFilter, blob)
+
+
+@pytest.mark.django_db
+class TestScopedAggregateReducers:
+    """Reducer-specific scoped-aggregate semantics the base class doesn't cover:
+    the distinct M2M count, the avg reducer, a nested relation inside the scope,
+    and the NULL sum for parents whose related rows all fail the scope."""
+
+    def test_scoped_purchase_count_is_distinct_over_the_m2m(self):
+        """A bundle purchase linked to two games must count once per game under
+        a scope — distinct + FILTER + M2M join is the shape most prone to
+        alias/duplication bugs."""
+        import datetime
+
+        from games.filters import GameFilter
+        from games.models import Game, Platform, Purchase
+
+        platform = Platform.objects.create(name="PC")
+        first_game = Game.objects.create(name="First", platform=platform)
+        second_game = Game.objects.create(name="Second", platform=platform)
+
+        def make_purchase(games, ownership_type):
+            purchase = Purchase.objects.create(
+                platform=platform,
+                date_purchased=datetime.date(2026, 1, 1),
+                ownership_type=ownership_type,
+            )
+            purchase.games.set(games)
+            return purchase
+
+        make_purchase([first_game, second_game], Purchase.PHYSICAL)  # the bundle
+        make_purchase([first_game], Purchase.PHYSICAL)
+        make_purchase([first_game], Purchase.DIGITAL)  # fails the scope
+
+        game_filter = GameFilter.from_json(
+            {
+                "purchase_count": {
+                    "value": 2,
+                    "modifier": "EQUALS",
+                    "scope": {
+                        "ownership_type": {
+                            "value": [Purchase.PHYSICAL],
+                            "modifier": "INCLUDES",
+                        }
+                    },
+                }
+            }
+        )
+        assert set(Game.objects.filter(game_filter.to_q())) == {first_game}
+        one_physical = GameFilter.from_json(
+            {
+                "purchase_count": {
+                    "value": 1,
+                    "modifier": "EQUALS",
+                    "scope": {
+                        "ownership_type": {
+                            "value": [Purchase.PHYSICAL],
+                            "modifier": "INCLUDES",
+                        }
+                    },
+                }
+            }
+        )
+        assert set(Game.objects.filter(one_physical.to_q())) == {second_game}
+
+    def _seed_two_device_games(self):
+        import datetime
+        from datetime import timedelta
+
+        from games.models import Device, Game, Platform, Session
+
+        platform = Platform.objects.create(name="PC")
+        deck = Device.objects.create(name="Steam Deck", type="Handheld")
+        desktop = Device.objects.create(name="Desktop", type="PC")
+        mixed = Game.objects.create(name="Mixed", platform=platform)
+        desktop_only = Game.objects.create(name="Desktop Only", platform=platform)
+        first_start = datetime.datetime(2026, 6, 1, 12, 0, tzinfo=datetime.UTC)
+
+        def make_session(game, device, index, hours):
+            begin = first_start + timedelta(days=index)
+            return Session.objects.create(
+                game=game,
+                device=device,
+                timestamp_start=begin,
+                timestamp_end=begin + timedelta(hours=hours),
+            )
+
+        # mixed: two 1h sessions on the deck + one 5h on the desktop → the
+        # unscoped average (7/3 ≈ 2.3h) differs from the deck-scoped one (1h).
+        make_session(mixed, deck, 0, hours=1)
+        make_session(mixed, deck, 1, hours=1)
+        make_session(mixed, desktop, 2, hours=5)
+        # desktop_only: one 1h session, never on the deck.
+        make_session(desktop_only, desktop, 3, hours=1)
+        return {
+            "deck": deck,
+            "mixed": mixed,
+            "desktop_only": desktop_only,
+        }
+
+    def _games_matching(self, filter_json: dict) -> set:
+        from games.filters import GameFilter
+        from games.models import Game
+
+        game_filter = GameFilter.from_json(filter_json)
+        assert game_filter is not None
+        return set(Game.objects.filter(game_filter.to_q()))
+
+    def test_scoped_average_executes_against_the_db(self):
+        """The avg reducer with a scope: only the deck sessions feed the mean.
+        This also pins the spec table's avg wiring (source/unit), which the
+        name-coverage drift guard can't."""
+        data = self._seed_two_device_games()
+        deck_scope = {"device": {"value": [data["deck"].id], "modifier": "INCLUDES"}}
+        scoped_hour_average = {
+            "session_average": {"value": 1, "modifier": "EQUALS", "scope": deck_scope}
+        }
+        unscoped_hour_average = {"session_average": {"value": 1, "modifier": "EQUALS"}}
+        # Scoped to the deck, mixed averages exactly 1h; unscoped its 5h desktop
+        # session pulls the mean into the [2, 3) bucket, leaving only desktop_only.
+        assert self._games_matching(scoped_hour_average) == {data["mixed"]}
+        assert self._games_matching(unscoped_hour_average) == {data["desktop_only"]}
+
+    def test_nested_relation_inside_scope_executes_against_the_db(self):
+        """A scope carrying a relation descent with its own quantifier: count
+        sessions whose device does NOT match. This executes the subquery-
+        membership design claim — a key-prefix Q rewrite would break exactly
+        here and nowhere else in the suite."""
+        data = self._seed_two_device_games()
+        off_deck_scope = {
+            "device_filter": {
+                "match": "NONE",
+                "name": {"value": "Steam Deck", "modifier": "EQUALS"},
+            }
+        }
+        one_session_off_deck = {
+            "session_count": {"value": 1, "modifier": "EQUALS", "scope": off_deck_scope}
+        }
+        # mixed has exactly one non-deck session; desktop_only has one too.
+        assert self._games_matching(one_session_off_deck) == {
+            data["mixed"],
+            data["desktop_only"],
+        }
+        two_sessions_off_deck = {
+            "session_count": {"value": 2, "modifier": "EQUALS", "scope": off_deck_scope}
+        }
+        assert self._games_matching(two_sessions_off_deck) == set()
+
+    def test_scoped_sum_is_null_when_no_row_matches_the_scope(self):
+        """SUM with a filter= that matches no rows yields SQL NULL (unlike the
+        count's 0): a game whose sessions all fail the scope matches neither
+        EQUALS 0 (NULL != 0) nor the duration IS_NULL (defined as *zero
+        duration*, see duration_hours_to_q) — identical to the pre-existing
+        unscoped no-session case. Pin it so a future 'coalesce to 0' change is
+        a deliberate decision, with a positive contrast proving the scoped sum
+        itself computes."""
+        data = self._seed_two_device_games()
+        deck_scope = {"device": {"value": [data["deck"].id], "modifier": "INCLUDES"}}
+
+        def scoped(modifier, value=0):
+            return {
+                "calculated_playtime_hours": {
+                    "value": value,
+                    "modifier": modifier,
+                    "scope": deck_scope,
+                }
+            }
+
+        # desktop_only's NULL deck-sum is invisible to both zero tests…
+        assert self._games_matching(scoped("EQUALS", 0)) == set()
+        assert self._games_matching(scoped("IS_NULL")) == set()
+        # …while mixed's deck sessions (1h + 1h calculated) sum normally.
+        assert self._games_matching(scoped("EQUALS", 2)) == {data["mixed"]}

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -30,6 +30,7 @@ from common.criteria import (
     Modifier,
     MultiCriterion,
     OperatorFilter,
+    RelationMatch,
     StringCriterion,
     _ScalarCriterion,
     _allowed_comparison_modifiers,
@@ -3770,6 +3771,14 @@ class TestFilterFieldDescriptors:
         assert aggregates.isdisjoint(imperative)
 
     @pytest.mark.parametrize("filter_cls", ALL_FILTERS)
+    def test_aggregates_table_matches_aggregate_fields(self, filter_cls):
+        """The ``aggregates`` spec table must cover exactly the
+        AggregateCriterion-annotated fields — a new aggregate field without a
+        spec would silently drop out of ``to_q``; a spec for a non-aggregate
+        field is dead wiring (issue #151)."""
+        assert set(filter_cls.aggregates) == self._aggregate_fields(filter_cls)
+
+    @pytest.mark.parametrize("filter_cls", ALL_FILTERS)
     def test_descriptor_keys_are_real_criterion_fields(self, filter_cls):
         declared = self._declared_criterion_fields(filter_cls)
         for key in filter_cls.fields:
@@ -4108,6 +4117,35 @@ class TestFieldMetadata:
         assert entry["choices"] == []
         assert entry["relations"] == []
 
+    def test_aggregate_scope_model_names_the_reduced_relation(self):
+        by_name = self._by_name(GameFilter)
+        assert by_name["session_count"]["scope_model"] == "session"
+        assert by_name["purchase_price_total"]["scope_model"] == "purchase"
+        assert by_name["playevent_count"]["scope_model"] == "playevent"
+
+    @pytest.mark.parametrize("filter_cls", _ALL_FILTERS)
+    def test_scope_model_nonempty_iff_aggregate(self, filter_cls):
+        """The FieldMeta invariant (issue #151): ``scope_model`` is populated
+        exactly on aggregate fields."""
+        from common.criteria import AggregateCriterion
+
+        for entry in field_metadata(filter_cls):
+            criterion_cls = _criterion_class_for(filter_cls, entry["name"])
+            is_aggregate = criterion_cls is not None and issubclass(
+                criterion_cls, AggregateCriterion
+            )
+            assert bool(entry["scope_model"]) == is_aggregate, entry["name"]
+
+    def test_reachable_models_include_scope_targets(self):
+        from games.filters import reachable_models
+
+        for root_model in ("game", "session", "purchase", "device", "platform"):
+            reachable = reachable_models(root_model)
+            for filter_cls in reachable.values():
+                for entry in field_metadata(filter_cls):
+                    if entry["scope_model"]:
+                        assert entry["scope_model"] in reachable
+
     def test_relation_entry_targets_subfilter(self):
         entry = self._by_name(GameFilter)["session_filter"]
         assert entry["kind"] == "relation"
@@ -4439,3 +4477,300 @@ class TestStringFieldNullConvention:
             "whether null=False with default='' would work instead.\n"
             f"Unexpected nullable fields found: {', '.join(unexpected_nullable_fields)}"
         )
+
+
+# ── Scoped aggregates (issue #151) ───────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestScopedAggregatesAgainstDB:
+    """``AggregateCriterion.scope`` narrows the reducer to related rows matching
+    the sub-filter — "games with > 2 sessions *on the Steam Deck*", "sum of
+    *physical* purchase prices > 100".
+
+    The session fixture is deliberately shaped to expose join-duplication bugs:
+    ``deck_heavy`` has sessions on two devices, so a cross-join in the filtered
+    aggregate would inflate its per-device counts past the assertions.
+    """
+
+    def _seed_sessions(self):
+        import datetime
+        from datetime import timedelta
+
+        from games.models import Device, Game, Platform, Session
+
+        platform = Platform.objects.create(name="PC")
+        deck = Device.objects.create(name="Steam Deck", type="Handheld")
+        desktop = Device.objects.create(name="Desktop", type="PC")
+        deck_heavy = Game.objects.create(name="Deck Heavy", platform=platform)
+        desktop_only = Game.objects.create(name="Desktop Only", platform=platform)
+        unplayed = Game.objects.create(name="Unplayed", platform=platform)
+
+        first_start = datetime.datetime(2026, 6, 1, 12, 0, tzinfo=datetime.UTC)
+
+        def make_session(game, device, index, manual_hours=0):
+            begin = first_start + timedelta(days=index)
+            return Session.objects.create(
+                game=game,
+                device=device,
+                timestamp_start=begin,
+                timestamp_end=begin + timedelta(hours=1),
+                duration_manual=timedelta(hours=manual_hours),
+            )
+
+        # deck_heavy: 3 sessions on the deck (1h manual each) + 1 on the desktop
+        # (4h manual) — mixed devices, the join-duplication canary.
+        for index in range(3):
+            make_session(deck_heavy, deck, index, manual_hours=1)
+        make_session(deck_heavy, desktop, 3, manual_hours=4)
+        # desktop_only: 3 sessions, none on the deck.
+        for index in range(4, 7):
+            make_session(desktop_only, desktop, index)
+
+        return {
+            "deck": deck,
+            "desktop": desktop,
+            "deck_heavy": deck_heavy,
+            "desktop_only": desktop_only,
+            "unplayed": unplayed,
+        }
+
+    def _games_matching(self, filter_json: dict) -> set:
+        from games.filters import GameFilter
+        from games.models import Game
+
+        game_filter = GameFilter.from_json(filter_json)
+        assert game_filter is not None
+        return set(Game.objects.filter(game_filter.to_q()))
+
+    def test_session_count_scoped_to_device(self):
+        data = self._seed_sessions()
+        scoped = {
+            "session_count": {
+                "value": 2,
+                "modifier": "GREATER_THAN",
+                "scope": {
+                    "device": {"value": [data["deck"].id], "modifier": "INCLUDES"}
+                },
+            }
+        }
+        # Unscoped, both played games have 3+ sessions — the scope is what
+        # excludes desktop_only, so this proves it was applied.
+        unscoped = {"session_count": {"value": 2, "modifier": "GREATER_THAN"}}
+        assert self._games_matching(unscoped) == {
+            data["deck_heavy"],
+            data["desktop_only"],
+        }
+        assert self._games_matching(scoped) == {data["deck_heavy"]}
+
+    def test_scoped_count_ignores_other_device_rows(self):
+        """Join-duplication canary: deck_heavy's desktop session must neither
+        count toward its deck total nor multiply it."""
+        data = self._seed_sessions()
+        exactly_three_on_deck = {
+            "session_count": {
+                "value": 3,
+                "modifier": "EQUALS",
+                "scope": {
+                    "device": {"value": [data["deck"].id], "modifier": "INCLUDES"}
+                },
+            }
+        }
+        assert self._games_matching(exactly_three_on_deck) == {data["deck_heavy"]}
+        exactly_one_on_desktop = {
+            "session_count": {
+                "value": 1,
+                "modifier": "EQUALS",
+                "scope": {
+                    "device": {"value": [data["desktop"].id], "modifier": "INCLUDES"}
+                },
+            }
+        }
+        assert self._games_matching(exactly_one_on_desktop) == {data["deck_heavy"]}
+
+    def test_scoped_count_equals_zero(self):
+        """Zero-row parity (#223): games with no matching related rows still
+        compare as count 0 — both the unplayed game and the game whose sessions
+        all fail the scope."""
+        data = self._seed_sessions()
+        zero_on_deck = {
+            "session_count": {
+                "value": 0,
+                "modifier": "EQUALS",
+                "scope": {
+                    "device": {"value": [data["deck"].id], "modifier": "INCLUDES"}
+                },
+            }
+        }
+        assert self._games_matching(zero_on_deck) == {
+            data["desktop_only"],
+            data["unplayed"],
+        }
+
+    def test_scoped_duration_sum(self):
+        """A duration-unit aggregate (manual playtime hours) scoped to a device:
+        deck_heavy has 3h manual on the deck but 7h in total, so EQUALS 3 only
+        matches with the scope applied."""
+        data = self._seed_sessions()
+        scope = {"device": {"value": [data["deck"].id], "modifier": "INCLUDES"}}
+        scoped = {
+            "manual_playtime_hours": {"value": 3, "modifier": "EQUALS", "scope": scope}
+        }
+        unscoped = {"manual_playtime_hours": {"value": 3, "modifier": "EQUALS"}}
+        assert self._games_matching(scoped) == {data["deck_heavy"]}
+        assert self._games_matching(unscoped) == set()
+
+    def test_purchase_price_total_scoped_to_physical(self):
+        """Issue use case: "sum of physical purchase prices > 100". The mixed
+        game's digital purchase pushes its unscoped total past 100, so it only
+        drops out when the scope filters the summed rows."""
+        import datetime
+
+        from games.models import Game, Platform, Purchase
+
+        platform = Platform.objects.create(name="PC")
+        physical_expensive = Game.objects.create(name="Boxed", platform=platform)
+        mixed = Game.objects.create(name="Mixed", platform=platform)
+
+        def make_purchase(game, price, ownership_type):
+            purchase = Purchase.objects.create(
+                platform=platform,
+                date_purchased=datetime.date(2026, 1, 1),
+                price=price,
+                price_currency="CZK",
+                converted_price=price,
+                converted_currency="CZK",
+                ownership_type=ownership_type,
+            )
+            purchase.games.add(game)
+            return purchase
+
+        make_purchase(physical_expensive, 150, Purchase.PHYSICAL)
+        make_purchase(mixed, 50, Purchase.PHYSICAL)
+        make_purchase(mixed, 200, Purchase.DIGITAL)
+
+        scoped = {
+            "purchase_price_total": {
+                "value": 100,
+                "modifier": "GREATER_THAN",
+                "scope": {
+                    "ownership_type": {
+                        "value": [Purchase.PHYSICAL],
+                        "modifier": "INCLUDES",
+                    }
+                },
+            }
+        }
+        unscoped = {"purchase_price_total": {"value": 100, "modifier": "GREATER_THAN"}}
+        assert self._games_matching(unscoped) == {physical_expensive, mixed}
+        assert self._games_matching(scoped) == {physical_expensive}
+
+
+class TestScopedAggregateJSON:
+    """Serialization contract for the aggregate ``scope`` (issue #151)."""
+
+    def _scoped_filter_json(self) -> dict:
+        return {
+            "session_count": {
+                "value": 5,
+                "modifier": "GREATER_THAN",
+                "scope": {"device": {"value": [1], "modifier": "INCLUDES"}},
+            }
+        }
+
+    def test_scope_deserializes_to_the_accessor_filter_class(self):
+        from games.filters import GameFilter, SessionFilter
+
+        game_filter = GameFilter.from_json(self._scoped_filter_json())
+        assert game_filter is not None
+        assert game_filter.session_count is not None
+        assert isinstance(game_filter.session_count.scope, SessionFilter)
+        assert game_filter.session_count.scope.device is not None
+
+    def test_scoped_aggregate_round_trips(self):
+        from games.filters import GameFilter
+
+        original = GameFilter.from_json(self._scoped_filter_json())
+        assert original is not None
+        reparsed = GameFilter.from_json(original.to_json())
+        assert reparsed == original
+        assert "scope" in original.to_json()["session_count"]
+
+    def test_empty_scope_normalizes_to_unscoped(self):
+        from games.filters import GameFilter
+
+        game_filter = GameFilter.from_json({"session_count": {"value": 5, "scope": {}}})
+        assert game_filter is not None
+        assert game_filter.session_count is not None
+        assert game_filter.session_count.scope is None
+        assert "scope" not in game_filter.to_json()["session_count"]
+
+    def test_criterion_alone_ignores_scope_key(self):
+        """AggregateCriterion.from_json can't resolve a scope class — the raw
+        ``scope`` key must not leak onto the instance (the #139/#144 bug)."""
+        criterion = AggregateCriterion.from_json(
+            {"value": 5, "scope": {"device": {"value": [1]}}}
+        )
+        assert criterion is not None
+        assert criterion.scope is None
+
+    def test_scope_must_be_an_object(self):
+        from games.filters import GameFilter
+
+        with pytest.raises(FilterError, match="must be an object"):
+            GameFilter.from_json({"session_count": {"value": 5, "scope": [1, 2]}})
+
+    def test_scope_rejects_match_quantifier(self):
+        from games.filters import GameFilter
+
+        with pytest.raises(FilterError, match="match quantifier"):
+            GameFilter.from_json(
+                {
+                    "session_count": {
+                        "value": 5,
+                        "scope": {"match": "NONE", "emulated": {"value": True}},
+                    }
+                }
+            )
+
+    def test_nested_relation_inside_scope_keeps_its_match(self):
+        from games.filters import GameFilter
+
+        game_filter = GameFilter.from_json(
+            {
+                "session_count": {
+                    "value": 1,
+                    "scope": {"device_filter": {"match": "NONE"}},
+                }
+            }
+        )
+        assert game_filter is not None
+        scope = game_filter.session_count.scope
+        assert scope is not None
+        assert scope.device_filter is not None
+        assert scope.device_filter.match == RelationMatch.NONE
+
+    def test_scope_depth_bomb_rejected(self):
+        from games.filters import GameFilter
+
+        deep: dict = {"emulated": {"value": True}}
+        for _ in range(MAX_FILTER_DEPTH + 1):
+            deep = {"AND": [deep]}
+        with pytest.raises(FilterError, match="too deep"):
+            GameFilter.from_json({"session_count": {"value": 1, "scope": deep}})
+
+    def test_bad_scope_value_is_a_filter_error(self):
+        """Eager validation: a wrong-typed value inside the scope surfaces as
+        FilterError at the filter_from_json boundary, not a 500."""
+        from games.filters import GameFilter
+
+        blob = json.dumps(
+            {
+                "session_count": {
+                    "value": 1,
+                    "scope": {"device": {"value": ["x"], "modifier": "INCLUDES"}},
+                }
+            }
+        )
+        with pytest.raises(FilterError):
+            filter_from_json(GameFilter, blob)

--- a/ts/elements/filter-group.test.ts
+++ b/ts/elements/filter-group.test.ts
@@ -1527,3 +1527,195 @@ describe("<filter-group> prefill hydrates relation subtrees", () => {
     expect(host.serializeForQuery()).toEqual({}); // incomplete → pruned
   });
 });
+
+// ── Aggregate scope (#151) ──
+// game has one aggregate field (session_count, scope over session) plus a plain
+// string field to prove non-scopable fields never offer "+ scope"; session brings
+// its own picker + one string widget so the scope group's rows can be driven live.
+const SESSION_COUNT_META = {
+  name: "session_count",
+  label: "Session Count",
+  kind: "number",
+  nullable: false,
+  choices: [],
+  modifiers: ["EQUALS", "GREATER_THAN"],
+  relations: [],
+  search_url: "",
+  is_m2m: false,
+  scope_model: "session",
+};
+
+const SCOPE_NOTE_META = { ...NAME_META, name: "note", label: "Note" };
+
+function mountScope(): FilterGroupElement {
+  document.body.replaceChildren();
+  const host = document.createElement("filter-group") as FilterGroupElement;
+  host.setAttribute("model", "game");
+  host.setAttribute(
+    "models",
+    JSON.stringify({
+      game: { fields: [SESSION_COUNT_META, NAME_META], columns: [] },
+      session: { fields: [SCOPE_NOTE_META], columns: [] },
+    }),
+  );
+  host.innerHTML = `
+    <template data-model="game" data-field-picker-template>
+      <div data-field-picker><search-select name="field-picker"><input data-search-select-search /></search-select></div>
+    </template>
+    <template data-model="session" data-field-picker-template>
+      <div data-field-picker><search-select name="field-picker"><input data-search-select-search /></search-select></div>
+    </template>
+    <template data-model="game" data-field="session_count">
+      <div class="flex-col">
+        <select data-number-modifier-select>
+          <option value="EQUALS" selected>=</option>
+          <option value="GREATER_THAN">&gt;</option>
+        </select>
+        <div>
+          <input type="number" />
+          <input type="number" data-number-value2 class="hidden" />
+        </div>
+      </div>
+    </template>
+    <template data-model="game" data-field="name">
+      <div class="flex-col">
+        <select data-string-modifier-select><option value="EQUALS" selected>is</option></select>
+        <input type="text" />
+      </div>
+    </template>
+    <template data-model="session" data-field="note">
+      <div class="flex-col">
+        <select data-string-modifier-select><option value="EQUALS" selected>is</option></select>
+        <input type="text" />
+      </div>
+    </template>`;
+  document.body.appendChild(host);
+  return host;
+}
+
+function typeNumber(host: HTMLElement, path: Path, value: string): void {
+  const input = row(host, path).querySelector<HTMLInputElement>(
+    '[data-value-cell] input[type="number"]:not([data-number-value2])',
+  )!;
+  input.value = value;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("<filter-group> aggregate scope (#151)", () => {
+  it("offers + scope only on a scopable (aggregate) field", () => {
+    const host = mountScope();
+    expect(button(host, "add-scope", [0])).toBeNull(); // no field picked yet
+    pickField(host, [0], NAME_META);
+    expect(button(host, "add-scope", [0])).toBeNull(); // plain string field
+    pickField(host, [0], SESSION_COUNT_META);
+    expect(button(host, "add-scope", [0])).not.toBeNull();
+  });
+
+  it("+ scope opens a scope group over the scope model, with a seeded row", () => {
+    const host = mountScope();
+    pickField(host, [0], SESSION_COUNT_META);
+    clickAction(host, "add-scope", [0]);
+    const scopeGroup = host.querySelector(
+      `[data-kind="group"][data-path='${JSON.stringify([0, "scope"])}']`,
+    );
+    expect(scopeGroup).not.toBeNull();
+    // Seeded with one empty criterion row, addressed through SCOPE_CHILD.
+    expect(row(host, [0, "scope", 0])).not.toBeNull();
+    // The affordance flips: + scope is replaced by − scope on the leaf row.
+    expect(button(host, "add-scope", [0])).toBeNull();
+    expect(button(host, "remove-scope", [0])).not.toBeNull();
+  });
+
+  it("scope rows resolve field pickers/widgets against the scope model", () => {
+    const host = mountScope();
+    pickField(host, [0], SESSION_COUNT_META);
+    typeNumber(host, [0], "5");
+    clickAction(host, "add-scope", [0]);
+    pickField(host, [0, "scope", 0], SCOPE_NOTE_META);
+    typeValue(host, [0, "scope", 0], "docked");
+    expect(host.serializeForQuery()).toEqual({
+      AND: [
+        {
+          session_count: {
+            value: 5,
+            modifier: "EQUALS",
+            scope: { AND: [{ note: { value: "docked", modifier: "EQUALS" } }] },
+          },
+        },
+      ],
+    });
+  });
+
+  it("an empty scope serializes away (unscoped) but keeps its UI", () => {
+    const host = mountScope();
+    pickField(host, [0], SESSION_COUNT_META);
+    typeNumber(host, [0], "3");
+    clickAction(host, "add-scope", [0]); // seeded row left unfilled → pruned
+    expect(host.serializeForQuery()).toEqual({
+      AND: [{ session_count: { value: 3, modifier: "EQUALS" } }],
+    });
+    expect(
+      host.querySelector(`[data-kind="group"][data-path='${JSON.stringify([0, "scope"])}']`),
+    ).not.toBeNull();
+  });
+
+  it("− scope drops the scope subtree from tree and query", () => {
+    const host = mountScope();
+    pickField(host, [0], SESSION_COUNT_META);
+    typeNumber(host, [0], "5");
+    clickAction(host, "add-scope", [0]);
+    pickField(host, [0, "scope", 0], SCOPE_NOTE_META);
+    typeValue(host, [0, "scope", 0], "docked");
+    clickAction(host, "remove-scope", [0]);
+    expect(
+      host.querySelector(`[data-kind="group"][data-path='${JSON.stringify([0, "scope"])}']`),
+    ).toBeNull();
+    expect(host.serializeForQuery()).toEqual({
+      AND: [{ session_count: { value: 5, modifier: "EQUALS" } }],
+    });
+  });
+
+  it("counts an unfilled scope row as incomplete under the scope model", () => {
+    const host = mountScope();
+    let last = -1;
+    host.addEventListener("filter-tree-change", (event) => {
+      last = (event as CustomEvent).detail.incompleteCount;
+    });
+    pickField(host, [0], SESSION_COUNT_META);
+    typeNumber(host, [0], "5");
+    expect(last).toBe(0);
+    clickAction(host, "add-scope", [0]); // seeded empty scope row
+    expect(last).toBe(1);
+    pickField(host, [0, "scope", 0], SCOPE_NOTE_META);
+    typeValue(host, [0, "scope", 0], "docked");
+    expect(last).toBe(0);
+  });
+
+  it("prefill hydrates a scoped aggregate into the scope UI and round-trips", () => {
+    const host = mountScope();
+    host.loadFilter({
+      session_count: {
+        value: 5,
+        modifier: "GREATER_THAN",
+        scope: { note: { value: "docked", modifier: "EQUALS" } },
+      },
+    });
+    // The scope group renders with its hydrated row.
+    expect(row(host, [0, "scope", 0])).not.toBeNull();
+    expect(
+      row(host, [0, "scope", 0]).querySelector<HTMLInputElement>('[data-value-cell] input[type="text"]')!
+        .value,
+    ).toBe("docked");
+    expect(host.serializeForQuery()).toEqual({
+      AND: [
+        {
+          session_count: {
+            value: 5,
+            modifier: "GREATER_THAN",
+            scope: { AND: [{ note: { value: "docked", modifier: "EQUALS" } }] },
+          },
+        },
+      ],
+    });
+  });
+});

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -35,6 +35,8 @@ import type {
 import {
   type NodePath,
   RELATION_CHILD,
+  SCOPE_CHILD,
+  addScope,
   canAddGroup,
   canAddRelation,
   canUnwrap,
@@ -53,6 +55,7 @@ import {
   parseFieldMeta,
   pruneIncomplete,
   removeAt,
+  removeScope,
   setLeafField,
   setMatch,
   setRelationField,
@@ -104,6 +107,9 @@ function relationEmptyText(match: RelationMatch): string {
   const unreachable: never = match; // exhaustive over RelationMatch; a new member fails tsc here
   return unreachable;
 }
+// An empty scope group is meaningful too (issue #151): it serializes away, so the
+// aggregate reduces over ALL related rows until a condition lands. Spell that out.
+const SCOPE_EMPTY_TEXT = "Counting all related items. Add a condition to narrow them.";
 const SLOT_ROW_CLASS = "flex items-center gap-2 flex-wrap";
 const FIELD_CELL_CLASS = "min-w-[12rem]";
 const VALUE_CELL_CLASS = "flex-1 min-w-[12rem]";
@@ -142,6 +148,12 @@ const RELATION_CARD_CLASS =
 const RELATION_HEADER_CLASS = "flex items-center gap-2 flex-wrap";
 const RELATION_ARROW_CLASS = "text-indigo-500 dark:text-indigo-300 font-semibold";
 const RELATION_LABEL_CLASS = "text-sm text-gray-600 dark:text-gray-300";
+// The aggregate-scope accent block (issue #151): the leaf row plus its nested scope
+// group, teal-accented to read as "narrows this row" rather than a relation descent.
+const SCOPE_CARD_CLASS =
+  "flex flex-col gap-2 rounded-lg border border-l-4 border-teal-200 border-l-teal-400 " +
+  "bg-teal-50/50 p-2 dark:border-teal-500/40 dark:border-l-teal-500/70 dark:bg-teal-500/10";
+const SCOPE_LABEL_CLASS = "text-sm text-teal-700 dark:text-teal-300";
 
 // The closed set of restructuring actions a button can carry; producer
 // (actionButton) and consumer (applyAction's switch) share it so a typo on either
@@ -151,6 +163,8 @@ type TreeAction =
   | "add-comparison"
   | "add-group"
   | "add-relation"
+  | "add-scope"
+  | "remove-scope"
   | "remove"
   | "duplicate"
   | "wrap"
@@ -382,6 +396,17 @@ export class FilterGroupElement extends HTMLElement {
     return meta?.relations[0]?.model?.toLowerCase() ?? model;
   }
 
+  // The model an aggregate field's scope group filters (FieldMeta.scope_model,
+  // issue #151) — the scope-descent analogue of targetModel, with the same
+  // warn-and-fall-back on a metadata gap.
+  private scopeModel(model: string, field: string): string {
+    const scopeModel = this.bundle(model)?.fields.get(field)?.scope_model;
+    if (field && !scopeModel) {
+      console.warn(`filter-group: field "${field}" on model "${model}" has no scope model`);
+    }
+    return scopeModel || model;
+  }
+
   /** The current node tree — for 2d serialize/count. Do not mutate it: every edit
    *  must go through the pure ops (the change-event dispatch depends on it). The
    *  `Readonly` is shallow — it flags top-level rebinds only; deep mutation of
@@ -446,12 +471,19 @@ export class FilterGroupElement extends HTMLElement {
     for (const [key, bundle] of this.models) {
       const fields = new Set<string>();
       const relations: Record<string, string> = {};
+      const scopes: Record<string, string> = {};
       for (const [name, meta] of bundle.fields) {
         const target = meta.relations[0]?.model;
-        if (meta.kind === "relation" && target) relations[name] = target.toLowerCase();
-        else fields.add(name);
+        if (meta.kind === "relation" && target) {
+          relations[name] = target.toLowerCase();
+        } else {
+          fields.add(name);
+          // Aggregate fields advertise the model their scope sub-filter targets
+          // (FieldMeta.scope_model, non-empty iff aggregate — issue #151).
+          if (meta.scope_model) scopes[name] = meta.scope_model;
+        }
       }
-      registry[key] = { fields, relations };
+      registry[key] = { fields, relations, scopes };
     }
     return registry;
   }
@@ -466,7 +498,18 @@ export class FilterGroupElement extends HTMLElement {
 
   private fillNode(node: FilterNode, model: string): FilterNode {
     if (node.kind === "group") return this.fillCriteria(node, model);
-    if (node.kind === "criterion") return { ...node, criterion: this.readLeaf(node, model) ?? {} };
+    if (node.kind === "criterion") {
+      // An aggregate leaf's scope group holds live leaves too (issue #151) —
+      // fill them under the scope's target model.
+      const scope = node.scope
+        ? this.fillCriteria(node.scope, this.scopeModel(model, node.field))
+        : undefined;
+      return {
+        ...node,
+        criterion: this.readLeaf(node, model) ?? {},
+        ...(scope ? { scope } : {}),
+      };
+    }
     if (node.kind === "comparison") return { ...node, comparison: this.readComparison(node) ?? {} };
     // relation: its child group's leaves are live too — fill them under the target model.
     return { ...node, child: this.fillCriteria(node.child, this.targetModel(model, node.field)) };
@@ -508,8 +551,14 @@ export class FilterGroupElement extends HTMLElement {
     let count = 0;
     for (const child of node.children) {
       if (child.kind === "group") count += this.incompleteCount(child, model);
-      else if (child.kind === "criterion" && !this.leafComplete(child, model)) count += 1;
-      else if (child.kind === "comparison" && !this.comparisonComplete(child)) count += 1;
+      else if (child.kind === "criterion") {
+        if (!this.leafComplete(child, model)) count += 1;
+        // An aggregate leaf's scope group has leaves of its own (issue #151),
+        // counted under the scope's target model.
+        if (child.scope) {
+          count += this.incompleteCount(child.scope, this.scopeModel(model, child.field));
+        }
+      } else if (child.kind === "comparison" && !this.comparisonComplete(child)) count += 1;
       else if (child.kind === "relation") {
         // A field-unset relation is incomplete (would serialize to `{"": …}`); its
         // child group's leaves count under the target model.
@@ -541,6 +590,12 @@ export class FilterGroupElement extends HTMLElement {
         break;
       case "add-relation":
         if (canAddRelation(this.tree, path)) this.tree = insertChild(this.tree, path, emptyRelation());
+        break;
+      case "add-scope":
+        this.tree = addScope(this.tree, path);
+        break;
+      case "remove-scope":
+        this.tree = removeScope(this.tree, path);
         break;
       case "remove":
         this.tree = removeAt(this.tree, path);
@@ -619,9 +674,15 @@ export class FilterGroupElement extends HTMLElement {
     for (const child of node.children) {
       if (child.kind === "group") {
         this.reflectFieldSelections(child, model);
-      } else if (child.kind === "criterion" && child.field) {
-        const cells = this.rowCache.get(child.id);
-        if (cells) this.showFieldSelection(cells.fieldCell, child.field, model);
+      } else if (child.kind === "criterion") {
+        if (child.field) {
+          const cells = this.rowCache.get(child.id);
+          if (cells) this.showFieldSelection(cells.fieldCell, child.field, model);
+        }
+        // The scope group's own leaves have field-pickers too (issue #151).
+        if (child.scope) {
+          this.reflectFieldSelections(child.scope, this.scopeModel(model, child.field));
+        }
       } else if (child.kind === "relation") {
         this.reflectFieldSelections(child.child, this.targetModel(model, child.field));
       }
@@ -636,7 +697,11 @@ export class FilterGroupElement extends HTMLElement {
     const walk = (node: FilterNode): void => {
       if (node.kind === "group") node.children.forEach(walk);
       else if (node.kind === "relation") walk(node.child); // its child group's leaves stay live
-      else live.add(node.id);
+      else {
+        live.add(node.id);
+        // An aggregate leaf's scope group holds live leaf cells too (issue #151).
+        if (node.kind === "criterion" && node.scope) walk(node.scope);
+      }
     };
     walk(this.tree);
     for (const id of [...this.rowCache.keys()]) {
@@ -658,23 +723,27 @@ export class FilterGroupElement extends HTMLElement {
     siblingCount: number,
     model: string,
     depth: number,
-    relationEmptyLabel?: string,
+    ownedEmptyLabel?: string,
   ): HTMLElement {
-    const isRelationChild = path[path.length - 1] === RELATION_CHILD;
+    // A group owned by another node — a relation's child group or an aggregate
+    // leaf's scope group (issue #151) — is not a positional sibling: it carries no
+    // move/remove controls and may sit empty.
+    const lastStep = path[path.length - 1];
+    const isOwnedChild = lastStep === RELATION_CHILD || lastStep === SCOPE_CHILD;
     const edgeClass = node.connective === "AND" ? GROUP_AND_EDGE_CLASS : GROUP_OR_EDGE_CLASS;
     const card = element("div", `${CARD_CLASS} ${depthBackground(depth)} ${edgeClass}`);
     card.dataset.kind = "group";
     card.dataset.path = JSON.stringify(path);
 
-    // The root and every relation child group may sit empty — the root serializes to
-    // {} (matches all), a relation's empty child is the ANY/NONE presence test. A
-    // header-less state keeps an empty group off the NOT/connective chips it has
-    // nothing to apply to (issue #236).
-    if ((path.length === 0 || isRelationChild) && node.children.length === 0) {
+    // The root and every owned child group may sit empty — the root serializes to
+    // {} (matches all), a relation's empty child is the ANY/NONE presence test, an
+    // empty scope serializes away (unscoped). A header-less state keeps an empty
+    // group off the NOT/connective chips it has nothing to apply to (issue #236).
+    if ((path.length === 0 || isOwnedChild) && node.children.length === 0) {
       const emptyState = element("div", EMPTY_STATE_CLASS);
-      // Only a relation child supplies a label (its per-quantifier presence-test copy);
+      // Only an owned child supplies a label (its presence-test / all-rows copy);
       // the root empty group falls through to the generic "matches all" text.
-      emptyState.textContent = relationEmptyLabel ?? EMPTY_STATE_TEXT;
+      emptyState.textContent = ownedEmptyLabel ?? EMPTY_STATE_TEXT;
       card.appendChild(emptyState);
       card.appendChild(this.footer(path, model));
       return card;
@@ -687,9 +756,9 @@ export class FilterGroupElement extends HTMLElement {
     connectiveCluster.appendChild(this.negateChip(node, path));
     connectiveCluster.appendChild(this.connectiveChip(node.connective, path));
     header.appendChild(connectiveCluster);
-    // A relation child group is owned by its relation (not a list sibling), so it
-    // carries no up/down/wrap/unwrap/duplicate/remove — only the relation node does.
-    if (path.length > 0 && !isRelationChild) {
+    // An owned child group (relation child / scope group) carries no
+    // up/down/wrap/unwrap/duplicate/remove — only its owning node does.
+    if (path.length > 0 && !isOwnedChild) {
       header.appendChild(this.controls(path, true, index, siblingCount));
     }
     card.appendChild(header);
@@ -717,7 +786,9 @@ export class FilterGroupElement extends HTMLElement {
     if (child.kind === "group") {
       return this.renderGroup(child, path, index, siblingCount, model, depth + 1);
     }
-    if (child.kind === "criterion") return this.renderCriterionRow(child, path, index, siblingCount, model);
+    if (child.kind === "criterion") {
+      return this.renderCriterionRow(child, path, index, siblingCount, model, depth);
+    }
     if (child.kind === "comparison") {
       return this.renderComparisonRow(child, path, index, siblingCount, model);
     }
@@ -823,14 +894,18 @@ export class FilterGroupElement extends HTMLElement {
   }
 
   // The live criterion leaf row: [NOT] [field combobox] [value widget] [badge?]
-  // [controls]. The two stateful cells are reused across renders via rowCache so a
-  // structural edit never wipes an in-progress widget.
+  // [+ scope?] [controls]. The two stateful cells are reused across renders via
+  // rowCache so a structural edit never wipes an in-progress widget. A scopable
+  // (aggregate) field offers "+ scope" (issue #151); with a scope attached, the row
+  // and its nested scope group render inside a teal accent card, mirroring the
+  // relation-card pattern.
   private renderCriterionRow(
     node: CriterionLeaf,
     path: NodePath,
     index: number,
     siblingCount: number,
     model: string,
+    depth: number,
   ): HTMLElement {
     const cells = this.leafCells(node, model);
     const row = element("div", SLOT_ROW_CLASS);
@@ -841,10 +916,46 @@ export class FilterGroupElement extends HTMLElement {
     row.appendChild(this.negateChip(node, path));
     row.appendChild(cells.fieldCell);
     row.appendChild(cells.valueCell);
+    const scopeModel = node.field ? this.bundle(model)?.fields.get(node.field)?.scope_model : "";
+    if (scopeModel && !node.scope) {
+      row.appendChild(
+        this.actionButton("add-scope", "+ scope", path, {
+          title: "Only count related items matching extra conditions",
+        }),
+      );
+    }
+    if (node.scope) {
+      row.appendChild(
+        this.actionButton("remove-scope", "− scope", path, {
+          title: "Remove the scope (count all related items again)",
+        }),
+      );
+    }
     row.appendChild(this.controls(path, false, index, siblingCount));
     // Controls are the row's last child; the badge (if any) is inserted before them.
     this.applyIncompleteState(row, Boolean(node.field) && !this.leafComplete(node, model));
-    return row;
+    if (!node.scope) return row;
+
+    // Scoped: the row plus its scope group in one accent card. Structural data
+    // attributes stay on the ROW (value events resolve their leaf via
+    // closest("[data-node-slot]")); the card is pure layout.
+    const card = element("div", SCOPE_CARD_CLASS);
+    card.appendChild(row);
+    const scopeLabel = element("div", SCOPE_LABEL_CLASS);
+    scopeLabel.textContent = "only counting items where";
+    card.appendChild(scopeLabel);
+    card.appendChild(
+      this.renderGroup(
+        node.scope,
+        [...path, SCOPE_CHILD],
+        0,
+        1,
+        scopeModel || this.scopeModel(model, node.field),
+        depth + 1,
+        SCOPE_EMPTY_TEXT,
+      ),
+    );
+    return card;
   }
 
   // Build or reuse a leaf's field + value cells, rebuilding the value cell only when
@@ -1124,6 +1235,11 @@ export class FilterGroupElement extends HTMLElement {
       if (step === RELATION_CHILD) {
         if (node.kind !== "relation") return null;
         node = node.child;
+        continue;
+      }
+      if (step === SCOPE_CHILD) {
+        if (node.kind !== "criterion" || !node.scope) return null;
+        node = node.scope;
         continue;
       }
       if (node.kind !== "group") return null;

--- a/ts/elements/filter-group.ts
+++ b/ts/elements/filter-group.ts
@@ -39,6 +39,7 @@ import {
   addScope,
   canAddGroup,
   canAddRelation,
+  canAddScope,
   canUnwrap,
   canWrap,
   criterionForField,
@@ -592,7 +593,7 @@ export class FilterGroupElement extends HTMLElement {
         if (canAddRelation(this.tree, path)) this.tree = insertChild(this.tree, path, emptyRelation());
         break;
       case "add-scope":
-        this.tree = addScope(this.tree, path);
+        if (canAddScope(this.tree, path)) this.tree = addScope(this.tree, path);
         break;
       case "remove-scope":
         this.tree = removeScope(this.tree, path);
@@ -918,9 +919,15 @@ export class FilterGroupElement extends HTMLElement {
     row.appendChild(cells.valueCell);
     const scopeModel = node.field ? this.bundle(model)?.fields.get(node.field)?.scope_model : "";
     if (scopeModel && !node.scope) {
+      // Depth-gated like + group/+ relation: the scope group sits one level
+      // below this leaf's containing group.
+      const scopeAllowed = canAddScope(this.tree, path);
       row.appendChild(
         this.actionButton("add-scope", "+ scope", path, {
-          title: "Only count related items matching extra conditions",
+          disabled: !scopeAllowed,
+          title: scopeAllowed
+            ? "Only count related items matching extra conditions"
+            : "Max nesting reached",
         }),
       );
     }

--- a/ts/elements/filter-tree/fixtures.json
+++ b/ts/elements/filter-tree/fixtures.json
@@ -1,12 +1,14 @@
 {
   "registry": {
     "game": {
-      "fields": ["name", "status", "year_released", "search"],
-      "relations": { "session_filter": "session" }
+      "fields": ["name", "status", "year_released", "search", "session_count"],
+      "relations": { "session_filter": "session" },
+      "scopes": { "session_count": "session" }
     },
     "session": {
       "fields": ["device", "note"],
-      "relations": { "game_filter": "game" }
+      "relations": { "game_filter": "game" },
+      "scopes": {}
     }
   },
   "cases": [
@@ -109,6 +111,53 @@
           "game_filter": { "name": { "value": "zelda", "modifier": "INCLUDES" } }
         }
       }
+    },
+    {
+      "description": "scoped aggregate: session_count over deck sessions",
+      "model": "game",
+      "filter": {
+        "session_count": {
+          "value": 5,
+          "modifier": "GREATER_THAN",
+          "scope": { "device": { "value": [1], "modifier": "INCLUDES" } }
+        }
+      }
+    },
+    {
+      "description": "negated scoped aggregate",
+      "model": "game",
+      "filter": {
+        "NOT": [
+          {
+            "session_count": {
+              "value": 0,
+              "modifier": "EQUALS",
+              "scope": { "device": { "value": [1], "modifier": "INCLUDES" } }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "description": "scoped aggregate with inner OR scope",
+      "model": "game",
+      "filter": {
+        "session_count": {
+          "value": 2,
+          "modifier": "GREATER_THAN",
+          "scope": {
+            "OR": [
+              { "device": { "value": [1], "modifier": "INCLUDES" } },
+              { "note": { "value": "docked", "modifier": "INCLUDES" } }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "description": "scoped aggregate with empty scope normalizes to unscoped",
+      "model": "game",
+      "filter": { "session_count": { "value": 1, "modifier": "EQUALS", "scope": {} } }
     }
   ]
 }

--- a/ts/elements/filter-tree/operations.test.ts
+++ b/ts/elements/filter-tree/operations.test.ts
@@ -8,7 +8,9 @@ import type { FilterFieldMeta } from "./types.js";
 ignoreNodeIds();
 import {
   RELATION_CHILD,
+  SCOPE_CHILD,
   SOFT_DEPTH_CAP,
+  addScope,
   canAddGroup,
   canAddRelation,
   canUnwrap,
@@ -30,6 +32,7 @@ import {
   parseFieldMeta,
   pruneIncomplete,
   removeAt,
+  removeScope,
   setConnective,
   setLeafCriterion,
   setLeafField,
@@ -52,6 +55,7 @@ function fieldMeta(overrides: Partial<FilterFieldMeta> = {}): FilterFieldMeta {
     relations: [],
     search_url: "",
     is_m2m: false,
+    scope_model: "",
     ...overrides,
   };
 }
@@ -713,5 +717,126 @@ describe("setRelationField (#193)", () => {
 
   it("throws on a non-relation node", () => {
     expect(() => setRelationField(group("AND", [criterion("a")]), [0], "x")).toThrow();
+  });
+});
+
+describe("aggregate scope (#151)", () => {
+  function scopedLeaf(): CriterionLeaf {
+    return {
+      kind: "criterion",
+      id: nextNodeId(),
+      field: "session_count",
+      criterion: { value: 5, modifier: "GREATER_THAN" },
+      scope: group("AND", [criterion("device")]),
+      negate: false,
+    };
+  }
+
+  it("addScope seeds an AND group with one empty criterion row", () => {
+    const root = group("AND", [criterion("session_count")]);
+    const next = addScope(root, [0]);
+    const leaf = nodeAt(next, [0]) as CriterionLeaf;
+    expect(leaf.scope).toEqual(group("AND", [emptyCriterion()]));
+  });
+
+  it("addScope is a no-op when a scope already exists", () => {
+    const root = group("AND", [scopedLeaf()]);
+    const next = addScope(root, [0]);
+    expect((nodeAt(next, [0]) as CriterionLeaf).scope).toEqual(
+      (nodeAt(root, [0]) as CriterionLeaf).scope,
+    );
+  });
+
+  it("addScope throws on a non-criterion node", () => {
+    const root = group("AND", [relation("session_filter", group("AND", []))]);
+    expect(() => addScope(root, [0])).toThrow(/not a criterion leaf/);
+  });
+
+  it("removeScope drops the whole scope subtree", () => {
+    const root = group("AND", [scopedLeaf()]);
+    const next = removeScope(root, [0]);
+    const leaf = nodeAt(next, [0]) as CriterionLeaf;
+    expect(leaf.scope).toBeUndefined();
+    expect(leaf.criterion).toEqual({ value: 5, modifier: "GREATER_THAN" });
+  });
+
+  it("nodeAt descends through SCOPE_CHILD", () => {
+    const root = group("AND", [scopedLeaf()]);
+    const scopeGroup = nodeAt(root, [0, SCOPE_CHILD]);
+    expect(scopeGroup.kind).toBe("group");
+    const scopeRow = nodeAt(root, [0, SCOPE_CHILD, 0]);
+    expect(scopeRow).toEqual(criterion("device"));
+  });
+
+  it("nodeAt throws for SCOPE_CHILD on a scope-less leaf", () => {
+    const root = group("AND", [criterion("session_count")]);
+    expect(() => nodeAt(root, [0, SCOPE_CHILD])).toThrow(/without a scope group/);
+  });
+
+  it("edits inside the scope rewrite the spine immutably", () => {
+    const root = group("AND", [scopedLeaf()]);
+    const next = setLeafCriterion(root, [0, SCOPE_CHILD, 0], { value: [2], modifier: "INCLUDES" });
+    expect((nodeAt(next, [0, SCOPE_CHILD, 0]) as CriterionLeaf).criterion).toEqual({
+      value: [2],
+      modifier: "INCLUDES",
+    });
+    // The input tree is untouched.
+    expect((nodeAt(root, [0, SCOPE_CHILD, 0]) as CriterionLeaf).criterion).toEqual({
+      value: "device",
+      modifier: "INCLUDES",
+    });
+  });
+
+  it("removing the scope group's last row keeps the emptied scope attached", () => {
+    const root = group("AND", [scopedLeaf()]);
+    const next = removeAt(root, [0, SCOPE_CHILD, 0]);
+    const leaf = nodeAt(next, [0]) as CriterionLeaf;
+    expect(leaf.scope).toEqual(group("AND", []));
+  });
+
+  it("setLeafField drops the scope with the rest of the old leaf", () => {
+    const root = group("AND", [scopedLeaf()]);
+    const next = setLeafField(root, [0], fieldMeta({ name: "name", kind: "string" }));
+    expect((nodeAt(next, [0]) as CriterionLeaf).scope).toBeUndefined();
+  });
+
+  it("duplicateAt reassigns ids inside the scope subtree", () => {
+    const root = group("AND", [scopedLeaf()]);
+    const next = duplicateAt(root, [0]);
+    const original = nodeAt(next, [0]) as CriterionLeaf;
+    const clone = nodeAt(next, [1]) as CriterionLeaf;
+    expect(clone.scope).toBeDefined();
+    expect(clone.id).not.toBe(original.id);
+    expect(clone.scope!.id).not.toBe(original.scope!.id);
+    expect(clone.scope!.children[0].id).not.toBe(original.scope!.children[0].id);
+  });
+
+  it("pruneIncomplete prunes the scope's incomplete rows but keeps the group", () => {
+    const withIncompleteScopeRow: CriterionLeaf = {
+      ...scopedLeaf(),
+      scope: group("AND", [criterion("device"), emptyCriterion()]),
+    };
+    const pruned = pruneIncomplete(group("AND", [withIncompleteScopeRow]));
+    const leaf = pruned.children[0] as CriterionLeaf;
+    expect(leaf.scope).toEqual(group("AND", [criterion("device")]));
+
+    const withOnlyIncomplete: CriterionLeaf = {
+      ...scopedLeaf(),
+      scope: group("AND", [emptyCriterion()]),
+    };
+    const emptied = pruneIncomplete(group("AND", [withOnlyIncomplete]));
+    expect((emptied.children[0] as CriterionLeaf).scope).toEqual(group("AND", []));
+  });
+
+  it("pruneIncomplete drops an incomplete aggregate leaf, scope and all", () => {
+    const incomplete: CriterionLeaf = { ...scopedLeaf(), criterion: {} };
+    const pruned = pruneIncomplete(group("AND", [incomplete]));
+    expect(pruned.children).toEqual([]);
+  });
+
+  it("a scope group counts one group level for depth", () => {
+    const root = group("AND", [scopedLeaf()]);
+    expect(groupDepthAt(root, [0, SCOPE_CHILD])).toBe(1);
+    expect(deepestGroupDepth(root, 0)).toBe(1);
   });
 });

--- a/ts/elements/filter-tree/operations.test.ts
+++ b/ts/elements/filter-tree/operations.test.ts
@@ -13,6 +13,7 @@ import {
   addScope,
   canAddGroup,
   canAddRelation,
+  canAddScope,
   canUnwrap,
   canWrap,
   criterionForField,
@@ -838,5 +839,23 @@ describe("aggregate scope (#151)", () => {
     const root = group("AND", [scopedLeaf()]);
     expect(groupDepthAt(root, [0, SCOPE_CHILD])).toBe(1);
     expect(deepestGroupDepth(root, 0)).toBe(1);
+  });
+});
+
+describe("canAddScope depth gating (#151 review)", () => {
+  it("allows a scope on a shallow leaf and forbids one at the soft cap", () => {
+    const shallow = group("AND", [criterion("session_count")]);
+    expect(canAddScope(shallow, [0])).toBe(true);
+    expect(canAddScope(shallow, [])).toBe(false); // the root is not a leaf
+
+    // Nest groups down to the soft cap; the leaf inside the deepest group sits
+    // one level past it, so its scope group would exceed the cap.
+    let tree = group("AND", [criterion("session_count")]);
+    let path: (number | typeof SCOPE_CHILD | typeof RELATION_CHILD)[] = [0];
+    for (let level = 0; level < SOFT_DEPTH_CAP; level += 1) {
+      tree = group("AND", [tree]);
+      path = [0, ...path];
+    }
+    expect(canAddScope(tree, path)).toBe(false);
   });
 });

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -550,6 +550,15 @@ export function canAddRelation(root: GroupNode, groupPath: NodePath): boolean {
   return canAddGroup(root, groupPath);
 }
 
+// `+ scope` attaches a group one level below the leaf's containing group — the
+// same depth arithmetic as `+ group`, addressed from the leaf's path (issue
+// #151). Without this gate, deep relation/scope alternation could build a tree
+// serializeNode hard-rejects, leaving Apply dead with console-only feedback.
+export function canAddScope(root: GroupNode, leafPath: NodePath): boolean {
+  if (leafPath.length === 0) return false; // the root is a group, never a leaf
+  return groupDepthAt(root, leafPath.slice(0, -1)) < SOFT_DEPTH_CAP;
+}
+
 // Wrapping pushes the node's whole subtree one level deeper (under a fresh wrapper
 // group at the node's current slot depth). Allowed only when the deepest resulting
 // group stays within the soft cap. Works for every node kind because the wrapper is

--- a/ts/elements/filter-tree/operations.ts
+++ b/ts/elements/filter-tree/operations.ts
@@ -30,12 +30,15 @@ import { group } from "./serializer.js";
 import { nextNodeId } from "./node-id.js";
 import { isPresenceModifier, isRangeModifier } from "../filter-tokens.js";
 
-// A path step is either a positional index into a group's children, or the
-// `RELATION_CHILD` sentinel meaning "descend into the relation node's child group".
-// The string sentinel survives `JSON.stringify`/`JSON.parse` (paths are stored in the
-// DOM as `data-path` JSON), so no custom (de)serialization is needed.
+// A path step is either a positional index into a group's children, or a string
+// sentinel: `RELATION_CHILD` descends from a relation node into its one child
+// group; `SCOPE_CHILD` descends from a criterion leaf into its aggregate scope
+// group (issue #151). The string sentinels survive `JSON.stringify`/`JSON.parse`
+// (paths are stored in the DOM as `data-path` JSON), so no custom
+// (de)serialization is needed.
 export const RELATION_CHILD = "child";
-export type PathStep = number | typeof RELATION_CHILD;
+export const SCOPE_CHILD = "scope";
+export type PathStep = number | typeof RELATION_CHILD | typeof SCOPE_CHILD;
 export type NodePath = readonly PathStep[];
 
 // Soft UI cap on group nesting (design spec): the root group is depth 0; a new
@@ -157,6 +160,13 @@ export function nodeAt(root: GroupNode, path: NodePath): FilterNode {
       node = node.child;
       continue;
     }
+    if (step === SCOPE_CHILD) {
+      if (node.kind !== "criterion" || !node.scope) {
+        throw new Error(`SCOPE_CHILD step on a node without a scope group`);
+      }
+      node = node.scope;
+      continue;
+    }
     if (node.kind !== "group") throw new Error(`Path descends into a non-group node`);
     const child: FilterNode | undefined = node.children[step];
     if (child === undefined) throw new Error(`Path index ${step} out of range`);
@@ -196,6 +206,12 @@ function replaceNode(
     if (node.kind !== "relation") throw new Error(`RELATION_CHILD step on a non-relation node`);
     return { ...node, child: replaceNode(node.child, rest, transform) as GroupNode };
   }
+  if (step === SCOPE_CHILD) {
+    if (node.kind !== "criterion" || !node.scope) {
+      throw new Error(`SCOPE_CHILD step on a node without a scope group`);
+    }
+    return { ...node, scope: replaceNode(node.scope, rest, transform) as GroupNode };
+  }
   if (node.kind !== "group") throw new Error(`Path descends into a non-group node`);
   const child = node.children[step];
   if (child === undefined) throw new Error(`Path index ${step} out of range`);
@@ -217,8 +233,9 @@ function updateChildren(
 
 // Split a *positional* node path into its containing group + index. The last step
 // must be a numeric index: only a group's positional children are removed / moved /
-// duplicated / wrapped. A `RELATION_CHILD`-terminated path addresses a relation's
-// child group, which is owned by its relation (never a list slot), so it is rejected.
+// duplicated / wrapped. A `RELATION_CHILD`- or `SCOPE_CHILD`-terminated path
+// addresses a group owned by its relation / criterion leaf (never a list slot),
+// so it is rejected.
 function splitPath(path: NodePath): { parentPath: NodePath; index: number } {
   if (path.length === 0) throw new Error(`Path addresses the root, which has no parent`);
   const last = path[path.length - 1];
@@ -254,6 +271,8 @@ export function removeAt(root: GroupNode, path: NodePath): GroupNode {
   // children (numeric last step). A relation's child group (RELATION_CHILD-terminated)
   // is a boundary like the root: ANY over an empty child group is the meaningful
   // "has ≥1 related row" presence test, so it may sit empty and the relation stays.
+  // A criterion leaf's scope group (SCOPE_CHILD-terminated) is a boundary too: an
+  // emptied scope simply serializes away as unscoped (issue #151).
   while (
     groupPath.length > 0 &&
     typeof groupPath[groupPath.length - 1] === "number" &&
@@ -278,10 +297,13 @@ export function duplicateAt(root: GroupNode, path: NodePath): GroupNode {
 
 // A duplicated subtree must get fresh ids on every node — a structuredClone copies
 // the source ids, which would collide with the originals in the shell's id→DOM map.
+// Every child-bearing kind descends: group children, a relation's child group, and
+// a criterion leaf's aggregate scope group (issue #151).
 function reassignIds(node: FilterNode): FilterNode {
   node.id = nextNodeId();
   if (node.kind === "group") node.children.forEach(reassignIds);
   else if (node.kind === "relation") reassignIds(node.child);
+  else if (node.kind === "criterion" && node.scope) reassignIds(node.scope);
   return node;
 }
 
@@ -339,6 +361,32 @@ export function setRelationField(root: GroupNode, path: NodePath, field: string)
   });
 }
 
+// ── Aggregate scope (issue #151) ─────────────────────────────────────────────
+
+// Attach an empty scope group to the aggregate criterion leaf at `path`, seeded
+// with one empty criterion row (like `emptyGroup`) so the user lands on a
+// fillable row rather than a bare shell. A no-op when a scope already exists.
+// Only the UI knows whether the leaf's field is scopable (ModelMeta.scopes) —
+// the op just requires a criterion leaf.
+export function addScope(root: GroupNode, path: NodePath): GroupNode {
+  return replaceNodeAt(root, path, (node) => {
+    if (node.kind !== "criterion") throw new Error(`Node at path is not a criterion leaf`);
+    if (node.scope) return node;
+    return { ...node, scope: group("AND", [emptyCriterion()]) };
+  });
+}
+
+// Detach the scope group (back to reducing over all related rows). The subtree is
+// dropped wholesale, mirroring how `setRelationField` resets a relation's child.
+export function removeScope(root: GroupNode, path: NodePath): GroupNode {
+  return replaceNodeAt(root, path, (node) => {
+    if (node.kind !== "criterion") throw new Error(`Node at path is not a criterion leaf`);
+    if (!node.scope) return node;
+    const { scope: _dropped, ...rest } = node;
+    return rest;
+  });
+}
+
 // ── Leaf payload edits (issue #192) ──────────────────────────────────────────
 
 // Pick (or change) a criterion leaf's field: replace it with a FRESH leaf for the
@@ -392,8 +440,13 @@ function pruneGroup(node: GroupNode): GroupNode {
 
 function pruneNode(node: FilterNode): FilterNode | null {
   switch (node.kind) {
-    case "criterion":
-      return isCriterionComplete(node) ? node : null;
+    case "criterion": {
+      if (!isCriterionComplete(node)) return null;
+      // A complete aggregate leaf keeps its scope group with the group's own
+      // incomplete leaves pruned; an emptied scope group stays attached (it
+      // serializes away — unscoped — while the UI keeps showing it).
+      return node.scope ? { ...node, scope: pruneGroup(node.scope) } : node;
+    }
     case "comparison":
       return isComparisonComplete(node) ? node : null;
     case "relation":
@@ -440,7 +493,8 @@ export function unwrapGroup(root: GroupNode, path: NodePath): GroupNode {
 
 // The deepest group-nesting depth anywhere in `group`'s subtree, given the group
 // itself sits at `groupDepth`. A child group is +1; a relation's child group is +1
-// (the relation node is not itself a group); leaves contribute nothing. This is the
+// (the relation node is not itself a group); a criterion leaf's aggregate scope
+// group is +1 likewise (issue #151); other leaves contribute nothing. This is the
 // single primitive every cap check is derived from.
 export function deepestGroupDepth(node: GroupNode, groupDepth: number): number {
   let deepest = groupDepth;
@@ -449,6 +503,8 @@ export function deepestGroupDepth(node: GroupNode, groupDepth: number): number {
       deepest = Math.max(deepest, deepestGroupDepth(child, groupDepth + 1));
     } else if (child.kind === "relation") {
       deepest = Math.max(deepest, deepestGroupDepth(child.child, groupDepth + 1));
+    } else if (child.kind === "criterion" && child.scope) {
+      deepest = Math.max(deepest, deepestGroupDepth(child.scope, groupDepth + 1));
     }
   }
   return deepest;
@@ -467,6 +523,14 @@ export function groupDepthAt(root: GroupNode, groupPath: NodePath): number {
       if (node.kind !== "relation") throw new Error(`RELATION_CHILD step on a non-relation node`);
       node = node.child;
       depth += 1; // a relation's child group is one level below the relation's group
+      continue;
+    }
+    if (step === SCOPE_CHILD) {
+      if (node.kind !== "criterion" || !node.scope) {
+        throw new Error(`SCOPE_CHILD step on a node without a scope group`);
+      }
+      node = node.scope;
+      depth += 1; // a leaf's scope group is one level below the leaf's group
       continue;
     }
     if (node.kind !== "group") throw new Error(`Path descends into a non-group node`);

--- a/ts/elements/filter-tree/serializer.test.ts
+++ b/ts/elements/filter-tree/serializer.test.ts
@@ -103,10 +103,15 @@ describe("serialize", () => {
   });
 });
 
-// Fixture registry: game has a session relation; session has none used here.
+// Fixture registry: game has a session relation and a session-scoped aggregate
+// (session_count, issue #151); session has neither used here.
 const registry: MetadataRegistry = {
-  game: { fields: new Set(["name", "status", "year_released", "search"]), relations: { session_filter: "session" } },
-  session: { fields: new Set(["device", "note"]), relations: {} },
+  game: {
+    fields: new Set(["name", "status", "year_released", "search", "session_count"]),
+    relations: { session_filter: "session" },
+    scopes: { session_count: "session" },
+  },
+  session: { fields: new Set(["device", "note"]), relations: {}, scopes: {} },
 };
 
 type Json = Record<string, unknown>;
@@ -351,7 +356,11 @@ type CanonicalCase = { description: string; model: string; filter: Record<string
 function buildRegistry(raw: typeof fixtures.registry): MetadataRegistry {
   const registry: Record<string, ModelMeta> = {};
   for (const [model, meta] of Object.entries(raw)) {
-    registry[model] = { fields: new Set(meta.fields), relations: meta.relations } as ModelMeta;
+    registry[model] = {
+      fields: new Set(meta.fields),
+      relations: meta.relations,
+      scopes: "scopes" in meta ? meta.scopes : {},
+    } as ModelMeta;
   }
   return registry;
 }
@@ -373,5 +382,146 @@ describe("round-trip over fixtures + canonical artifact", () => {
     const canonicalPath = fileURLToPath(new URL("./fixtures.canonical.json", import.meta.url));
     writeFileSync(canonicalPath, JSON.stringify({ cases: canonical }, null, 2));
     expect(canonical.length).toBe(fixtures.cases.length);
+  });
+});
+
+describe("aggregate scope (#151)", () => {
+  function deckScope(): GroupNode {
+    return {
+      kind: "group",
+      id: "sg",
+      connective: "AND",
+      negate: false,
+      children: [
+        { kind: "criterion", id: "sc", field: "device", criterion: { value: [1], modifier: "INCLUDES" }, negate: false },
+      ],
+    };
+  }
+
+  it("serializes the scope group inside the criterion payload", () => {
+    const leaf: FilterNode = {
+      kind: "criterion",
+      id: "c",
+      field: "session_count",
+      criterion: { value: 5, modifier: "GREATER_THAN" },
+      scope: deckScope(),
+      negate: false,
+    };
+    expect(serialize(root(leaf))).toEqual({
+      AND: [
+        {
+          session_count: {
+            value: 5,
+            modifier: "GREATER_THAN",
+            scope: { AND: [{ device: { value: [1], modifier: "INCLUDES" } }] },
+          },
+        },
+      ],
+    });
+  });
+
+  it("omits an empty scope group entirely (canonical unscoped)", () => {
+    const leaf: FilterNode = {
+      kind: "criterion",
+      id: "c",
+      field: "session_count",
+      criterion: { value: 5, modifier: "GREATER_THAN" },
+      scope: { kind: "group", id: "sg", connective: "AND", negate: false, children: [] },
+      negate: false,
+    };
+    expect(serialize(root(leaf))).toEqual({
+      AND: [{ session_count: { value: 5, modifier: "GREATER_THAN" } }],
+    });
+  });
+
+  it("deserializes a scoped aggregate into a leaf with a scope group", () => {
+    const tree = deserialize(
+      {
+        session_count: {
+          value: 5,
+          modifier: "GREATER_THAN",
+          scope: { device: { value: [1], modifier: "INCLUDES" } },
+        },
+      },
+      "game",
+      registry,
+    );
+    const leaf = tree.children[0];
+    if (leaf.kind !== "criterion") throw new Error("expected a criterion leaf");
+    // The scope key is split out of the opaque payload…
+    expect(leaf.criterion).toEqual({ value: 5, modifier: "GREATER_THAN" });
+    // …into a child group over the scope's target model.
+    expect(leaf.scope).toBeDefined();
+    expect(leaf.scope!.children).toEqual([
+      expect.objectContaining({
+        kind: "criterion",
+        field: "device",
+        criterion: { value: [1], modifier: "INCLUDES" },
+        negate: false,
+      }),
+    ]);
+  });
+
+  it("deserializes an empty scope as unscoped (backend parity)", () => {
+    const tree = deserialize(
+      { session_count: { value: 1, modifier: "EQUALS", scope: {} } },
+      "game",
+      registry,
+    );
+    const leaf = tree.children[0];
+    if (leaf.kind !== "criterion") throw new Error("expected a criterion leaf");
+    expect(leaf.scope).toBeUndefined();
+    expect(leaf.criterion).toEqual({ value: 1, modifier: "EQUALS" });
+  });
+
+  it("keeps a stray scope key verbatim on a non-scopable field", () => {
+    const tree = deserialize(
+      { year_released: { value: 2000, modifier: "EQUALS", scope: { device: { value: [1] } } } },
+      "game",
+      registry,
+    );
+    const leaf = tree.children[0];
+    if (leaf.kind !== "criterion") throw new Error("expected a criterion leaf");
+    expect(leaf.scope).toBeUndefined();
+    expect(leaf.criterion).toEqual({
+      value: 2000,
+      modifier: "EQUALS",
+      scope: { device: { value: [1] } },
+    });
+  });
+
+  it("scoped aggregate round-trip is a fixed point", () => {
+    const input = {
+      session_count: {
+        value: 5,
+        modifier: "GREATER_THAN",
+        scope: { OR: [{ device: { value: [1], modifier: "INCLUDES" } }, { note: { value: "docked", modifier: "INCLUDES" } }] },
+      },
+    };
+    const once = serialize(deserialize(input, "game", registry));
+    const twice = serialize(deserialize(once, "game", registry));
+    expect(twice).toEqual(once);
+    expect(JSON.stringify(once)).toContain('"scope"');
+  });
+
+  it("a scope descent consumes depth budget like a relation descent", () => {
+    // A registry with the game<->session relation cycle (the file-level fixture
+    // registry deliberately leaves session without relations).
+    const cyclicRegistry: MetadataRegistry = {
+      ...registry,
+      session: { ...registry.session, relations: { game_filter: "game" } },
+    };
+    // Build a scope whose inner filter nests past MAX_FILTER_DEPTH via
+    // game_filter/session_filter alternation. The scope is a *session* filter, so
+    // the outermost relation must be session's `game_filter` (even final level),
+    // then alternate — a wrong-model relation key would be silently dropped and
+    // the depth guard never reached.
+    let inner: Record<string, unknown> = { device: { value: [1], modifier: "INCLUDES" } };
+    for (let level = 0; level < 11; level += 1) {
+      inner = level % 2 === 0 ? { game_filter: inner } : { session_filter: inner };
+    }
+    expect(() =>
+      deserialize({ session_count: { value: 1, scope: inner } }, "game", cyclicRegistry),
+    ).toThrow(FilterTreeError);
   });
 });

--- a/ts/elements/filter-tree/serializer.test.ts
+++ b/ts/elements/filter-tree/serializer.test.ts
@@ -525,3 +525,39 @@ describe("aggregate scope (#151)", () => {
     ).toThrow(FilterTreeError);
   });
 });
+
+describe("aggregate scope malformations — backend parity (#151 review)", () => {
+  it("rejects a match quantifier inside a scope instead of stripping it", () => {
+    expect(() =>
+      deserialize(
+        { session_count: { value: 1, scope: { match: "NONE", device: { value: [1] } } } },
+        "game",
+        registry,
+      ),
+    ).toThrow(/match quantifier/);
+  });
+
+  it("accepts an explicit ANY match inside a scope (backend parity)", () => {
+    const tree = deserialize(
+      { session_count: { value: 1, scope: { match: "ANY", device: { value: [1], modifier: "INCLUDES" } } } },
+      "game",
+      registry,
+    );
+    const leaf = tree.children[0];
+    if (leaf.kind !== "criterion") throw new Error("expected a criterion leaf");
+    expect(leaf.scope).toBeDefined();
+  });
+
+  it("rejects a non-object scope on a scopable field", () => {
+    expect(() =>
+      deserialize({ session_count: { value: 1, scope: [1, 2] } }, "game", registry),
+    ).toThrow(/must be an object/);
+  });
+
+  it("treats an explicit null scope as no scope (backend pop default)", () => {
+    const tree = deserialize({ session_count: { value: 1, scope: null } }, "game", registry);
+    const leaf = tree.children[0];
+    if (leaf.kind !== "criterion") throw new Error("expected a criterion leaf");
+    expect(leaf.scope).toBeUndefined();
+  });
+});

--- a/ts/elements/filter-tree/serializer.ts
+++ b/ts/elements/filter-tree/serializer.ts
@@ -164,6 +164,9 @@ function deserializeNode(json: Json, modelKey: string, registry: MetadataRegistr
 // empty scope deserializes to no scope at all — backend parity (it normalizes an
 // empty scope to unscoped). On a non-scopable field the payload stays verbatim
 // (opaque-payload principle; the backend equally ignores a stray `scope` key).
+// The backend's two loud rejections are mirrored, not repaired: silently
+// stripping them here would turn a hand-edited/legacy URL into a *different*
+// valid filter with no feedback, while the list view rejects the same URL.
 function criterionNode(
   field: string,
   raw: Json,
@@ -172,8 +175,19 @@ function criterionNode(
   depth: number,
 ): CriterionLeaf {
   const scopeModel = meta.scopes[field];
-  if (scopeModel === undefined || !isObject(raw.scope)) {
+  if (scopeModel === undefined) {
     return { kind: "criterion", id: nextNodeId(), field, criterion: raw, negate: false };
+  }
+  // null mirrors the backend's pop-with-None-default: an explicit null scope is
+  // "no scope", not malformed.
+  if (raw.scope != null && !isObject(raw.scope)) {
+    throw new FilterTreeError(`aggregate scope on ${field} must be an object`, "INVALID_SCOPE");
+  }
+  if (!isObject(raw.scope)) {
+    return { kind: "criterion", id: nextNodeId(), field, criterion: raw, negate: false };
+  }
+  if (raw.scope.match != null && raw.scope.match !== "ANY") {
+    throw new FilterTreeError("aggregate scope does not take a match quantifier", "INVALID_SCOPE");
   }
   const { scope: scopeJson, ...criterion } = raw;
   const child = asGroup(deserializeNode(scopeJson as Json, scopeModel, registry, depth + 1));

--- a/ts/elements/filter-tree/serializer.ts
+++ b/ts/elements/filter-tree/serializer.ts
@@ -7,9 +7,11 @@
  */
 import {
   type Connective,
+  type CriterionLeaf,
   type FilterNode,
   type GroupNode,
   type MetadataRegistry,
+  type ModelMeta,
   type RelationMatch,
   FilterTreeError,
   MAX_FIELD_COMPARISONS,
@@ -49,8 +51,16 @@ function serializeNode(node: FilterNode, depth: number): Json {
       const inner: Json = children.length ? { [node.connective]: children } : {};
       return wrapNegate(inner, node.negate);
     }
-    case "criterion":
-      return wrapNegate({ [node.field]: node.criterion }, node.negate);
+    case "criterion": {
+      // An aggregate's scope group (issue #151) rides inside the criterion payload
+      // as a `scope` key; an empty scope group serializes away entirely (matching
+      // the backend, which normalizes an empty scope to unscoped).
+      const scopeJson = node.scope ? serializeNode(node.scope, depth + 1) : {};
+      const criterion = Object.keys(scopeJson).length
+        ? { ...node.criterion, scope: scopeJson }
+        : node.criterion;
+      return wrapNegate({ [node.field]: criterion }, node.negate);
+    }
     case "comparison":
       return wrapNegate({ field_comparisons: [node.comparison] }, node.negate);
     case "relation": {
@@ -93,7 +103,7 @@ function deserializeNode(json: Json, modelKey: string, registry: MetadataRegistr
     // for well-formed metadata, so order only matters if a key ever appears in both.
     if (meta.fields.has(key)) {
       if (isObject(value)) {
-        baseChildren.push({ kind: "criterion", id: nextNodeId(), field: key, criterion: value, negate: false });
+        baseChildren.push(criterionNode(key, value, meta, registry, depth));
       }
     } else if (key in meta.relations) {
       if (isObject(value)) {
@@ -147,6 +157,34 @@ function deserializeNode(json: Json, modelKey: string, registry: MetadataRegistr
   if (!isEmptyGroup(core)) andChildren.push(core);
   andChildren.push(...tail);
   return collapse(group("AND", andChildren));
+}
+
+// A criterion leaf; on a scopable (aggregate) field, a `scope` key in the payload
+// is split off into a child group over the scope's target model (issue #151). An
+// empty scope deserializes to no scope at all — backend parity (it normalizes an
+// empty scope to unscoped). On a non-scopable field the payload stays verbatim
+// (opaque-payload principle; the backend equally ignores a stray `scope` key).
+function criterionNode(
+  field: string,
+  raw: Json,
+  meta: ModelMeta,
+  registry: MetadataRegistry,
+  depth: number,
+): CriterionLeaf {
+  const scopeModel = meta.scopes[field];
+  if (scopeModel === undefined || !isObject(raw.scope)) {
+    return { kind: "criterion", id: nextNodeId(), field, criterion: raw, negate: false };
+  }
+  const { scope: scopeJson, ...criterion } = raw;
+  const child = asGroup(deserializeNode(scopeJson as Json, scopeModel, registry, depth + 1));
+  return {
+    kind: "criterion",
+    id: nextNodeId(),
+    field,
+    criterion,
+    ...(isEmptyGroup(child) ? {} : { scope: child }),
+    negate: false,
+  };
 }
 
 function relationNode(

--- a/ts/elements/filter-tree/summary.test.ts
+++ b/ts/elements/filter-tree/summary.test.ts
@@ -16,6 +16,7 @@ function field(partial: Partial<FieldMeta> & { name: string }): FieldMeta {
     relations: partial.relations ?? [],
     search_url: partial.search_url ?? "",
     is_m2m: partial.is_m2m ?? false,
+    scope_model: partial.scope_model ?? "",
   };
 }
 
@@ -465,5 +466,76 @@ describe("summary modifier contract artifact", () => {
     );
     writeFileSync(canonicalPath, JSON.stringify(keys, null, 2));
     expect(keys.length).toBeGreaterThan(0);
+  });
+});
+
+describe("summarize — aggregate scope (#151)", () => {
+  const SCOPED: SummaryContext = {
+    modelKey: "game",
+    modelLabel: "Games",
+    models: {
+      game: {
+        fields: new Map([
+          [
+            "session_count",
+            field({
+              name: "session_count",
+              label: "Session Count",
+              kind: "number",
+              scope_model: "session",
+            }),
+          ],
+        ]),
+      },
+      session: {
+        fields: new Map([
+          [
+            "device",
+            field({
+              name: "device",
+              label: "Device",
+              kind: "set",
+              choices: [{ value: "1", label: "Steam Deck" }],
+            }),
+          ],
+        ]),
+      },
+    },
+  };
+
+  function scopedLeaf(scopeChildren: GroupNode["children"]): GroupNode["children"][number] {
+    return {
+      kind: "criterion",
+      id: "c",
+      field: "session_count",
+      criterion: { value: 5, modifier: "GREATER_THAN" },
+      scope: { kind: "group", id: "sg", connective: "AND", negate: false, children: scopeChildren },
+      negate: false,
+    };
+  }
+
+  it("appends the scope as an 'over … matching' suffix", () => {
+    const tree = root(
+      scopedLeaf([
+        { kind: "criterion", id: "sc", field: "device", criterion: { value: ["1"], modifier: "INCLUDES" }, negate: false },
+      ]),
+    );
+    expect(summarize(tree, SCOPED)).toBe(
+      "Games where Session Count is more than 5, over sessions matching (Device is Steam Deck).",
+    );
+  });
+
+  it("an empty scope group contributes no suffix", () => {
+    const tree = root(scopedLeaf([]));
+    expect(summarize(tree, SCOPED)).toBe("Games where Session Count is more than 5.");
+  });
+
+  it("a scope whose only row is incomplete keeps the placeholder inside the suffix", () => {
+    const tree = root(
+      scopedLeaf([{ kind: "criterion", id: "sc", field: "", criterion: {}, negate: false }]),
+    );
+    expect(summarize(tree, SCOPED)).toBe(
+      "Games where Session Count is more than 5, over sessions matching (…).",
+    );
   });
 });

--- a/ts/elements/filter-tree/summary.ts
+++ b/ts/elements/filter-tree/summary.ts
@@ -209,7 +209,14 @@ function renderScopeSuffix(
 ): string {
   if (!leaf.scope || leaf.scope.children.length === 0) return "";
   const scopeKey = model?.fields.get(leaf.field)?.scope_model;
-  if (!scopeKey) return "";
+  if (!scopeKey) {
+    // Metadata gap (same warn-and-degrade contract as targetModelKey): the scope
+    // still serializes and applies, so dropping the suffix entirely would make
+    // the sentence understate the filter. Phrase it generically instead.
+    console.warn(`filter summary: no scope model for aggregate field "${leaf.field}"`);
+    const fallbackBody = joinChildren(leaf.scope, undefined, context);
+    return fallbackBody ? `, over related items matching (${fallbackBody})` : "";
+  }
   const scopeModel = context.models[scopeKey];
   if (!scopeModel) {
     // Same gap-warning contract as targetModelKey: a missing scope model would

--- a/ts/elements/filter-tree/summary.ts
+++ b/ts/elements/filter-tree/summary.ts
@@ -116,7 +116,7 @@ function renderInner(node: FilterNode, model: SummaryModel | undefined, context:
     case "group":
       return joinChildren(node, model, context);
     case "criterion":
-      return renderCriterion(node, model);
+      return renderCriterion(node, model, context);
     case "relation":
       return renderRelation(node, model, context);
     case "comparison":
@@ -188,7 +188,42 @@ function emptyRelationPhrase(match: RelationMatch, noun: string): string {
   return unreachable;
 }
 
-function renderCriterion(leaf: CriterionLeaf, model: SummaryModel | undefined): string {
+function renderCriterion(
+  leaf: CriterionLeaf,
+  model: SummaryModel | undefined,
+  context: SummaryContext,
+): string {
+  const clause = renderCriterionClause(leaf, model);
+  if (!clause || clause === PLACEHOLDER) return clause;
+  return `${clause}${renderScopeSuffix(leaf, model, context)}`;
+}
+
+// The aggregate-scope suffix (issue #151): ", over <rows> matching (…)" appended to
+// the aggregate's own clause — "Session Count is more than 5, over sessions matching
+// (Device is Steam Deck)". "over" is reducer-neutral (count / sum / avg all read).
+// An empty or absent scope contributes nothing (unscoped is canonical).
+function renderScopeSuffix(
+  leaf: CriterionLeaf,
+  model: SummaryModel | undefined,
+  context: SummaryContext,
+): string {
+  if (!leaf.scope || leaf.scope.children.length === 0) return "";
+  const scopeKey = model?.fields.get(leaf.field)?.scope_model;
+  if (!scopeKey) return "";
+  const scopeModel = context.models[scopeKey];
+  if (!scopeModel) {
+    // Same gap-warning contract as targetModelKey: a missing scope model would
+    // silently phrase the body with the wrong labels.
+    console.warn(`filter summary: no metadata for scope model "${scopeKey}"`);
+  }
+  const body = joinChildren(leaf.scope, scopeModel, context);
+  if (!body) return "";
+  // Naive plural (+s) is exact for every current model key (session, purchase,
+  // playevent, …); revisit if a model with irregular plural ever gets aggregates.
+  return `, over ${scopeKey}s matching (${body})`;
+}
+
+function renderCriterionClause(leaf: CriterionLeaf, model: SummaryModel | undefined): string {
   if (!leaf.field) return PLACEHOLDER;
   const meta = model?.fields.get(leaf.field);
   const label = meta?.label ?? leaf.field;

--- a/ts/elements/filter-tree/types.ts
+++ b/ts/elements/filter-tree/types.ts
@@ -78,6 +78,12 @@ export interface CriterionLeaf {
   id: string;
   field: string;
   criterion: CriterionPayload;
+  // Aggregate scope (issue #151): a sub-filter over the related rows the
+  // aggregate reduces, e.g. session_count counting only Steam Deck sessions.
+  // Present only on aggregate fields (ModelMeta.scopes says which, and names the
+  // model the group's rows filter). Serializes as a `scope` key inside the
+  // criterion payload; an empty group serializes away (unscoped is canonical).
+  scope?: GroupNode;
   negate: boolean;
 }
 
@@ -117,6 +123,9 @@ export interface FilterTreeChangeDetail {
 export interface ModelMeta {
   fields: ReadonlySet<string>; // valid criterion field names (includes "search")
   relations: Readonly<Record<string, string>>; // relationField -> targetModelKey
+  // aggregateField -> the model its scope sub-filter targets (issue #151); keys
+  // are a subset of `fields` (an aggregate is still a criterion field).
+  scopes: Readonly<Record<string, string>>;
 }
 
 export type MetadataRegistry = Readonly<Record<string, ModelMeta>>; // modelKey -> meta

--- a/ts/elements/filter-tree/types.ts
+++ b/ts/elements/filter-tree/types.ts
@@ -151,6 +151,7 @@ export type FilterTreeErrorCode =
   | "INVALID_FIELD_COMPARISON"
   | "UNKNOWN_MODEL"
   | "INVALID_MATCH"
+  | "INVALID_SCOPE"
   | "SERIALIZE_DEPTH_EXCEEDED";
 
 export class FilterTreeError extends Error {


### PR DESCRIPTION
Closes #151.

An aggregate criterion can now carry a **scope** sub-filter narrowing which related rows the reducer sees — "games with > 5 sessions **on the Steam Deck**", "games where the sum of **physical** purchase prices > 100" — via Django's `filter=` argument on `Count`/`Sum`/`Avg`.

## The three design problems from #151

1. **Concrete-type resolution** — a declarative `AggregateSpec` table (`OperatorFilter.aggregates`, assigned post-class in `games/filters.py` because the specs reference sibling filter classes) maps each aggregate field to its reducer/accessor/scope filter class. `from_json` resolves the scope's class from the spec, never from the criterion annotation: `AggregateCriterion.scope` is `init=False`, so the generic parse loop can never mis-assign a raw dict (the exact bug #139/#144 removed). The seven inline aggregate blocks in `GameFilter._extra_q` collapse into a generic `to_q` walk over the table, guarded by a drift test (`aggregates` keys == aggregate-annotated fields).
2. **Q re-rooting** — avoided entirely via subquery membership: `filter=Q(accessor__in=RelatedModel.objects.filter(scope.to_q()))`. The scope Q is evaluated by the related model's own queryset, so `F()` expressions, transforms, and nested subqueries inside it keep their meaning (a key-prefix rewriter would silently re-root them). Same mechanism as the proven `stats_data.py` filtered count.
3. **UI surface** — the nested filter-group builder: a scopable aggregate row (driven by new `FieldMeta.scope_model`, non-empty iff aggregate) offers "+ scope", opening a teal accent card whose scope group reuses the owned-child group rendering via a new `SCOPE_CHILD` path sentinel beside `RELATION_CHILD`. The summary phrases it as "Session Count is more than 5, over sessions matching (Device is Steam Deck)".

## Contract details

- JSON shape: the scope rides inside the criterion — `{"session_count": {"value": 5, "modifier": "GREATER_THAN", "scope": {…SessionFilter JSON…}}}`.
- An empty scope normalizes to unscoped at parse on both sides (canonical omission).
- A scope with a `match` quantifier raises `FilterError` (a scope is a row predicate, not a relation test); nested relations *inside* the scope keep their own `match`.
- Scope descents consume the same `MAX_FILTER_DEPTH` budget as relation descents in both Python and TS.
- Four new shared fixtures flow through the TS↔Python contract test (`tests/test_filter_tree_contract.py`).

## Tests

- DB tests for both issue use cases, with canaries shaped to expose join duplication (a game with sessions on two devices; a game with mixed-ownership purchases) and zero-count parity (#223).
- JSON round-trip + error paths (scope-as-list, `match: NONE`, depth bomb, bad scope values → `FilterError` at the boundary).
- vitest: serializer emit/parse/round-trip, operations (`addScope`/`removeScope`, `SCOPE_CHILD` descent, prune keeps an emptied scope, duplicate reassigns scope ids, field change drops the scope, depth counting), summary wording, and jsdom builder interaction (gating, live serialization, incomplete counting, prefill hydration).
- e2e: builder hydration of a scoped `?filter=` (scope pill rendered, live count reflects the scope, "− scope" widens it) and backend list narrowing.

`make check` green: 1463 pytest (incl. e2e) + 345 vitest + lint/format/mypy/ts-check.

## Known limitation (accepted in planning)

The flat filter bar's number widgets don't carry a scope, so loading a scoped filter into a flat list bar and re-applying drops the scope (`_parse_number` reads only value/value2/modifier). Scoped aggregates are built and edited in the advanced builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)